### PR TITLE
Checksum address for signature verification

### DIFF
--- a/packages/rps-poc/src/wallet/utils/signing-utils.ts
+++ b/packages/rps-poc/src/wallet/utils/signing-utils.ts
@@ -1,4 +1,4 @@
-import { splitSignature } from 'ethers/utils';
+import { splitSignature, getAddress } from 'ethers/utils';
 import { recover, sign, SolidityType } from 'fmg-core';
 
 
@@ -9,7 +9,7 @@ export const validSignature = (data: string, signature: string, address: string)
 
     const recovered = recover(data, v, r, s);
 
-    return recovered === address;
+    return recovered === getAddress(address);
   } catch (err) {
 
     return false;


### PR DESCRIPTION
At the moment, bot addresses used for communication through Firebase are not checksummed. This small PR converts the opponent address to a checksummed format before comparing the address to the recovered address from a signature.

This PR (along with a few changes in the bot code base) fixes https://zube.io/magmo/client-wallet/c/364.