### PR TITLE
Get CircleCI working

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ jobs:
   build:
     docker:
       # specify the version you desire here
-      - image: circleci/node:10.15.0
+      - image: circleci/node:9.11.2
       
       # Specify service dependencies here if necessary
       # CircleCI maintains a library of pre-built images
@@ -34,7 +34,7 @@ jobs:
           key: v1-dependencies-{{ checksum "package.json" }}
         
       # run tests!
-      - run: npx lerna run test:ci --stream --concurrency 1
+      - run: npx lerna run test:ci --stream --concurrency 2
 
 
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,7 +34,7 @@ jobs:
           key: v1-dependencies-{{ checksum "package.json" }}
         
       # run tests!
-      - run: npx lerna run test:ci --stream
+      - run: npx lerna run test:ci --stream --concurrency 1
 
 
 

--- a/packages/rps-poc/package.json
+++ b/packages/rps-poc/package.json
@@ -74,7 +74,7 @@
     "start": "node scripts/start.js",
     "build": "node scripts/build.js",
     "test": "run-s test:truffle 'test:app --all'",
-    "test:ci": "DEV_GANACHE_PORT=8502 run-s 'test:contracts --all --ci' 'test:app --all --ci' build",
+    "test:ci": "DEV_GANACHE_PORT=8502 run-s 'test:contracts --all --ci' 'test:app --all --ci --runInBand' build",
     "test:app": "npx run-jest -c ./config/jest/jest.config.js",
     "test:contracts": "npx ganache-then-jest -c ./config/jest/jest.integration.config.js --runInBand",
     "deployContracts": "npx deploy-contracts",

--- a/packages/wallet/package.json
+++ b/packages/wallet/package.json
@@ -74,7 +74,7 @@
     "start": "node scripts/start.js",
     "build": "node scripts/build.js",
     "test": "run-s 'test:app --all'",
-    "test:ci": "DEV_GANACHE_PORT=8503 run-s 'test:integration --all --ci' 'test:app --all --ci' build",
+    "test:ci": "DEV_GANACHE_PORT=8503 run-s 'test:integration --all --ci' 'test:app --all --ci --runInBand' build",
     "test:app": "npx run-jest -c ./config/jest/jest.config.js",
     "deployContracts": "npx deploy-contracts",
     "ganache:start": "npx start-ganache",


### PR DESCRIPTION
Addresses #32 

It looks like running with `runInBand` and limiting the `concurrency` to 2 can address memory errors/ processes being killed.