### PR TITLE
WIP: Validate Transactions by using read only call

### DIFF
--- a/packages/wallet/src/redux/sagas/transaction-tester.ts
+++ b/packages/wallet/src/redux/sagas/transaction-tester.ts
@@ -1,0 +1,12 @@
+import { call } from "redux-saga/effects";
+import { ethers } from "ethers";
+import { getProvider } from "../../utils/contract-utils";
+
+
+export function* transactionTester(transaction) {
+  // TODO: We'd put appropriate actions here 
+  const provider: ethers.providers.JsonRpcProvider = yield call(getProvider);
+  yield provider.call(transaction);
+
+
+}

--- a/packages/wallet/src/utils/transaction-generator.ts
+++ b/packages/wallet/src/utils/transaction-generator.ts
@@ -110,3 +110,12 @@ export function createDepositTransaction(contractAddress: string, depositAmount:
     value: depositAmount,
   };
 }
+
+export function createValidTransitionTransaction(contractAddress: string, fromState: string, toState: string): TransactionRequest {
+  const adjudicatorInterface = getSimpleAdjudicatorInterface();
+  const data = adjudicatorInterface.functions.validTransition.encode([fromState, toState]);
+  return {
+    to: contractAddress,
+    data,
+  };
+} 


### PR DESCRIPTION
This is related to https://zube.io/magmo/apps/c/449.

This is a quick POC of validating transitions by doing a read-only call to the `validTransition` function on the Adjudicator.

I tried this against the `ropsten` network and it seemed to perform reasonably well, I didn't really notice any huge delay making transitions.

