### PR TITLE
Remove unused open/close channel and throw errors in opening stage

### DIFF
--- a/packages/rps/src/redux/message-service/saga.ts
+++ b/packages/rps/src/redux/message-service/saga.ts
@@ -179,8 +179,7 @@ function* handleWalletMessage(walletMessage: WalletMessage, state: gameStates.Pl
       }
       break;
     case "FUNDING_REQUESTED":
-      // TODO: We need to close the channel at some point
-      Wallet.openChannel(WALLET_IFRAME_ID, channel);
+
       const myIndex = player === Player.PlayerA ? 0 : 1;
 
       const opponentAddress = participants[1 - myIndex];

--- a/packages/wallet-client/src/messages-to-wallet.ts
+++ b/packages/wallet-client/src/messages-to-wallet.ts
@@ -37,36 +37,6 @@ export const fundingRequest = (
 });
 export type FundingRequest = ReturnType<typeof fundingRequest>;
 
-
-// CHANNELS
-// ========
-
-// Currently triggered in the app's messaging-service, immediately before funding is requested
-// Responsible for loading channel and kicking off the monitoring sagas.
-// TODO: remove - we shouldn't need this after the wallet refactor
-export const OPEN_CHANNEL_REQUEST = 'WALLET.CHANNEL.REQUEST.OPEN';
-export const openChannelRequest = (channel: Channel) => ({
-  type: OPEN_CHANNEL_REQUEST as typeof OPEN_CHANNEL_REQUEST,
-  channel,
-});
-export type OpenChannelRequest = ReturnType<typeof openChannelRequest>;
-
-export const CONCLUDE_CHANNEL_REQUEST = 'WALLET.CHANNEL.REQUEST.CONCLUDE';
-export const concludeChannelRequest = () => ({
-  type: CONCLUDE_CHANNEL_REQUEST as typeof CONCLUDE_CHANNEL_REQUEST,
-});
-export type ConcludeChannelRequest = ReturnType<typeof concludeChannelRequest>;
-
-// Currently called by the app's messaging-service, after withdrawal is requested.
-// Responsible for shutting down the sagas that openChannelRequest started.
-// TODO: remove - don't need after the refactor
-export const CLOSE_CHANNEL_REQUEST = 'WALLET.CHANNEL.REQUEST.CLOSE';
-export const closeChannelRequest = () => ({
-  type: CLOSE_CHANNEL_REQUEST as typeof CLOSE_CHANNEL_REQUEST,
-});
-export type CloseChannelRequest = ReturnType<typeof closeChannelRequest>;
-
-
 // VALIDATION
 // ==========
 

--- a/packages/wallet-client/src/messages-to-wallet.ts
+++ b/packages/wallet-client/src/messages-to-wallet.ts
@@ -88,7 +88,11 @@ export const respondToChallenge = (position: string) => ({
 });
 export type RespondToChallenge = ReturnType<typeof respondToChallenge>;
 
-
+export const CONCLUDE_CHANNEL_REQUEST = 'WALLET.CHANNEL.REQUEST.CONCLUDE';
+export const concludeChannelRequest = () => ({
+  type: CONCLUDE_CHANNEL_REQUEST as typeof CONCLUDE_CHANNEL_REQUEST,
+});
+export type ConcludeChannelRequest = ReturnType<typeof concludeChannelRequest>;
 // MESSAGING
 // =========
 
@@ -108,11 +112,9 @@ export type ReceiveMessage = ReturnType<typeof receiveMessage>;
 // Requests
 // ========
 export type RequestAction =
-  OpenChannelRequest |
-  CloseChannelRequest |
+  ConcludeChannelRequest |
   FundingRequest |
   SignatureRequest |
   ValidationRequest |
   WithdrawalRequest |
-  CreateChallengeRequest |
-  ConcludeChannelRequest;
+  CreateChallengeRequest;

--- a/packages/wallet-client/src/wallet-events.ts
+++ b/packages/wallet-client/src/wallet-events.ts
@@ -52,10 +52,13 @@ export type FundingResponse = FundingSuccess | FundingFailure;
 // ========
 
 /**
- * @ignore
- * Is this actually used?
+ * The type of event thrown when a channel is successfully opened.
  */
 export const CHANNEL_OPENED = 'WALLET.CHANNEL.OPENED';
+/**
+ * The type of event thrown when an error occurs trying to open a channel.
+ */
+export const CHANNEL_OPEN_FAILURE = 'WALLET.CHANNEL.OPEN_FAILURE';
 
 /**
  * @ignore
@@ -70,6 +73,12 @@ export const channelOpened = (channelId: string) => ({
   type: CHANNEL_OPENED as typeof CHANNEL_OPENED,
   channelId,
 });
+/**
+ * @ignore
+ */
+export const channelOpenFailure = () => ({
+  type: CHANNEL_OPEN_FAILURE as typeof CHANNEL_OPEN_FAILURE,
+});
 
 /**
  * @ignore
@@ -80,10 +89,14 @@ export const channelClosed = (walletId: string) => ({
 });
 
 /**
- * @ignore
- * Is this actually used?
+ * The event thrown when a channel is successfully opened 
  */
 export type ChannelOpened = ReturnType<typeof channelOpened>;
+
+/**
+ * The event thrown when a channel fails to open successfully.
+ */
+export type ChannelOpenFailure = ReturnType<typeof channelOpenFailure>;
 
 /**
  * @ignore
@@ -378,6 +391,7 @@ export type WalletEventType =
   typeof FUNDING_FAILURE |
   typeof FUNDING_SUCCESS |
   typeof CHANNEL_OPENED |
+  typeof CHANNEL_OPEN_FAILURE |
   typeof CHANNEL_CLOSED;
 
 /**
@@ -401,4 +415,5 @@ export type WalletEvent =
   ChallengeRejected |
   ChallengeResponseRequested |
   ChallengeComplete |
+  ChannelOpenFailure |
   MessageRequest;

--- a/packages/wallet-client/src/wallet-events.ts
+++ b/packages/wallet-client/src/wallet-events.ts
@@ -48,62 +48,6 @@ export type FundingFailure = ReturnType<typeof fundingFailure>;
  */
 export type FundingResponse = FundingSuccess | FundingFailure;
 
-// CHANNELS
-// ========
-
-/**
- * The type of event thrown when a channel is successfully opened.
- */
-export const CHANNEL_OPENED = 'WALLET.CHANNEL.OPENED';
-/**
- * The type of event thrown when an error occurs trying to open a channel.
- */
-export const CHANNEL_OPEN_FAILURE = 'WALLET.CHANNEL.OPEN_FAILURE';
-
-/**
- * @ignore
- * Is this actually used?
- */
-export const CHANNEL_CLOSED = 'WALLET.CHANNEL.CLOSED';
-
-/**
- * @ignore
- */
-export const channelOpened = (channelId: string) => ({
-  type: CHANNEL_OPENED as typeof CHANNEL_OPENED,
-  channelId,
-});
-/**
- * @ignore
- */
-export const channelOpenFailure = () => ({
-  type: CHANNEL_OPEN_FAILURE as typeof CHANNEL_OPEN_FAILURE,
-});
-
-/**
- * @ignore
- */
-export const channelClosed = (walletId: string) => ({
-  type: CHANNEL_CLOSED as typeof CHANNEL_CLOSED,
-  walletId,
-});
-
-/**
- * The event thrown when a channel is successfully opened 
- */
-export type ChannelOpened = ReturnType<typeof channelOpened>;
-
-/**
- * The event thrown when a channel fails to open successfully.
- */
-export type ChannelOpenFailure = ReturnType<typeof channelOpenFailure>;
-
-/**
- * @ignore
- * Is this actually used?
- */
-export type ChannelClosed = ReturnType<typeof channelClosed>;
-
 // VALIDATION
 // ==========
 /**
@@ -415,5 +359,4 @@ export type WalletEvent =
   ChallengeRejected |
   ChallengeResponseRequested |
   ChallengeComplete |
-  ChannelOpenFailure |
   MessageRequest;

--- a/packages/wallet-client/src/wallet-events.ts
+++ b/packages/wallet-client/src/wallet-events.ts
@@ -333,10 +333,7 @@ export type WalletEventType =
   typeof VALIDATION_FAILURE |
   typeof VALIDATION_SUCCESS |
   typeof FUNDING_FAILURE |
-  typeof FUNDING_SUCCESS |
-  typeof CHANNEL_OPENED |
-  typeof CHANNEL_OPEN_FAILURE |
-  typeof CHANNEL_CLOSED;
+  typeof FUNDING_SUCCESS;
 
 /**
  * @ignore

--- a/packages/wallet-client/src/wallet-functions.ts
+++ b/packages/wallet-client/src/wallet-functions.ts
@@ -1,6 +1,5 @@
-import { Channel } from 'fmg-core';
-import { INITIALIZATION_SUCCESS, INITIALIZATION_FAILURE, CHANNEL_OPENED, ChannelOpened, FUNDING_FAILURE, FUNDING_SUCCESS, FundingResponse, SIGNATURE_FAILURE, SIGNATURE_SUCCESS, SignatureResponse, VALIDATION_SUCCESS, VALIDATION_FAILURE, ValidationResponse, messageRequest, MESSAGE_REQUEST, SHOW_WALLET, HIDE_WALLET, CONCLUDE_FAILURE, CONCLUDE_SUCCESS } from './wallet-events';
-import { openChannelRequest, initializeRequest, fundingRequest, signatureRequest, validationRequest, receiveMessage, concludeChannelRequest, createChallenge, respondToChallenge } from './messages-to-wallet';
+import { INITIALIZATION_SUCCESS, INITIALIZATION_FAILURE, SIGNATURE_FAILURE, SIGNATURE_SUCCESS, SignatureResponse, VALIDATION_SUCCESS, VALIDATION_FAILURE, ValidationResponse, SHOW_WALLET, HIDE_WALLET } from './wallet-events';
+import { concludeChannelRequest, initializeRequest, fundingRequest, signatureRequest, validationRequest, receiveMessage, createChallenge, respondToChallenge } from './messages-to-wallet';
 import BN from 'bn.js';
 
 

--- a/packages/wallet-client/src/wallet-functions.ts
+++ b/packages/wallet-client/src/wallet-functions.ts
@@ -75,19 +75,6 @@ export async function initializeWallet(iFrameId: string, userId: string): Promis
   return initPromise;
 }
 
-// TODO: Should this be part of funding? If not we should return a channelId
-/**
- * Opens a channel in the wallet so a game can be funded. This should be called before funding is started.
- * @param iFrameId The id of the embedded wallet iframe.
- * @param channel The channel to open in the wallet.
- */
-export function openChannel(iFrameId: string, channel: Channel): void {
-  const iFrame = document.getElementById(iFrameId) as HTMLIFrameElement;
-  const message = openChannelRequest(channel);
-  iFrame.contentWindow.postMessage(message, "*");
-
-}
-
 /**
  * Validates that data was signed by the opponent's wallet.
  * @param iFrameId The id of the embedded wallet iframe.

--- a/packages/wallet/src/redux/reducers/__tests__/opening.test.ts
+++ b/packages/wallet/src/redux/reducers/__tests__/opening.test.ts
@@ -5,6 +5,7 @@ import * as actions from '../../actions';
 
 import { itTransitionsToStateType, itDoesntTransition } from './helpers';
 import * as scenarios from './test-scenarios';
+import { validationFailure, SIGNATURE_FAILURE } from 'wallet-client';
 
 const {
   preFundSetupAHex,
@@ -38,6 +39,7 @@ describe('when in WaitForChannel', () => {
     itTransitionsToStateType(states.WAIT_FOR_PRE_FUND_SETUP, updatedState);
   });
 
+
   describe('when an opponent sends a PreFundSetupA', () => {
     // preFundSetupA is A's move, so in this case we need to be player B
     const state = states.waitForChannel({ ...defaults, address: bsAddress, privateKey: bsPrivateKey });
@@ -48,12 +50,16 @@ describe('when in WaitForChannel', () => {
 
   });
 
-  describe('when an oppoent sends a PreFundSetupA but the signature is bad', () => {
+  describe('when an opponent sends a PreFundSetupA but the signature is bad', () => {
     const state = states.waitForChannel({ ...defaults, address: bsAddress, privateKey: bsPrivateKey });
     const action = actions.opponentPositionReceived(preFundSetupAHex, 'not-a-signature');
     const updatedState = walletReducer(state, action);
 
     itDoesntTransition(state, updatedState);
+    it(`sends a validation failed message`, () => {
+      expect(updatedState.messageOutbox).toEqual(validationFailure('InvalidSignature'));
+    });
+
   });
 
   describe('when we send in a a non-PreFundSetupA', () => {
@@ -62,6 +68,9 @@ describe('when in WaitForChannel', () => {
     const updatedState = walletReducer(state, action);
 
     itDoesntTransition(state, updatedState);
+    it(`sends a signature failed message`, () => {
+      expect(updatedState.messageOutbox!.type).toEqual(SIGNATURE_FAILURE);
+    });
   });
 });
 
@@ -95,10 +104,12 @@ describe('when in WaitForPreFundSetup', () => {
 
   describe('when an opponent sends a PreFundSetupB but the signature is bad', () => {
     const state = states.waitForPreFundSetup({ ...defaults2, ourIndex: 0 });
-    const action = actions.opponentPositionReceived(preFundSetupAHex, 'not-a-signature');
+    const action = actions.opponentPositionReceived(preFundSetupBHex, 'not-a-signature');
     const updatedState = walletReducer(state, action);
-
     itDoesntTransition(state, updatedState);
+    it(`sends a validation failed message`, () => {
+      expect(updatedState.messageOutbox).toEqual(validationFailure('InvalidSignature'));
+    });
   });
 
   describe('when we send in a a non-PreFundSetupB', () => {
@@ -107,6 +118,9 @@ describe('when in WaitForPreFundSetup', () => {
     const updatedState = walletReducer(state, action);
 
     itDoesntTransition(state, updatedState);
+    it(`sends a signature failed message`, () => {
+      expect(updatedState.messageOutbox!.type).toEqual(SIGNATURE_FAILURE);
+    });
   });
 
 });


### PR DESCRIPTION
Addresses #63.

Instead of returning failure/success messages for opening a channel I removed the Channel Events and the `openChannel` function since they're not actually used in the wallet at all.

I've also modified the opening reducer so we throw errors instead of failing silently.