### PR TITLE
App is responsible for toggling wallet visibility

### DIFF
--- a/packages/rps/src/containers/NavigationBarContainer.tsx
+++ b/packages/rps/src/containers/NavigationBarContainer.tsx
@@ -9,14 +9,14 @@ import { SiteState } from '../redux/reducer';
 const mapStateToProps = (state: SiteState) => {
   const name = ('myName' in state.game.gameState) ? state.game.gameState.myName : "";
   return {
-    showRules: state.rules.visible,
+    showRules: state.overlay.rulesVisible,
     loginDisplayName: name,
   };
 };
 
 const mapDispatchToProps = {
   logoutRequest: loginActions.logoutRequest,
-  rulesRequest: globalActions.toggleVisibility,
+  rulesRequest: globalActions.toggleRulesVisibility,
 };
 
 export default connect(

--- a/packages/rps/src/containers/SiteContainer.tsx
+++ b/packages/rps/src/containers/SiteContainer.tsx
@@ -14,6 +14,7 @@ interface SiteProps {
   isAuthenticated: boolean;
   metamaskError: MetamaskError | null;
   loading: boolean;
+  walletVisible: boolean;
 }
 
 class Site extends React.PureComponent<SiteProps>{
@@ -36,6 +37,19 @@ class Site extends React.PureComponent<SiteProps>{
       component = <MetamaskErrorPage error={this.props.metamaskError} />;
     } else if (this.props.isAuthenticated) {
       component = <ApplicationContainer />;
+      const iFrame = document.getElementById(WALLET_IFRAME_ID) as HTMLIFrameElement;
+      if (this.props.walletVisible) {
+        iFrame.style.display = 'initial';
+        document.body.style.overflow = 'hidden';
+        iFrame.width = '100%';
+        iFrame.height = '100%';
+      }
+      else {
+        iFrame.style.display = 'none';
+        document.body.style.overflow = 'initial';
+        iFrame.width = '0';
+        iFrame.height = '0';
+      }
     } else {
       component = <HomePageContainer />;
     }
@@ -50,6 +64,7 @@ const mapStateToProps = (state: SiteState): SiteProps => {
     isAuthenticated: state.login && state.login.loggedIn,
     loading: state.metamask.loading,
     metamaskError: state.metamask.error,
+    walletVisible: state.overlay.walletVisible,
   };
 };
 

--- a/packages/rps/src/redux/global/actions.ts
+++ b/packages/rps/src/redux/global/actions.ts
@@ -1,7 +1,17 @@
-export const TOGGLE_VISIBILITY = 'RULES.TOGGLE_VISIBILITY';
-
-export const toggleVisibility = () => ({
-  type: TOGGLE_VISIBILITY as typeof TOGGLE_VISIBILITY,
+export const TOGGLE_RULES_VISIBILITY = 'APP.TOGGLE_RULES_VISIBILITY';
+export const toggleRulesVisibility = () => ({
+  type: TOGGLE_RULES_VISIBILITY as typeof TOGGLE_RULES_VISIBILITY,
 });
+export type ToggleRulesVisibility = ReturnType<typeof toggleRulesVisibility>;
 
-export type ToggleVisibility = ReturnType<typeof toggleVisibility>;
+export const SHOW_WALLET = 'APP.SHOW_WALLET';
+export const showWallet = () => ({
+  type: SHOW_WALLET as typeof SHOW_WALLET,
+});
+export type showWallet = ReturnType<typeof showWallet>;
+
+export const HIDE_WALLET = 'APP.HIDE_WALLET';
+export const hideWallet = () => ({
+  type: HIDE_WALLET as typeof HIDE_WALLET,
+});
+export type hideWallet = ReturnType<typeof hideWallet>;

--- a/packages/rps/src/redux/global/reducer.ts
+++ b/packages/rps/src/redux/global/reducer.ts
@@ -1,16 +1,21 @@
 import { Reducer } from "redux";
 
 import * as actions from "./actions";
-import { RulesState } from "./state";
+import { OverlayState } from "./state";
 
-const initialState : RulesState = {
-    visible: false,
+const initialState: OverlayState = {
+  rulesVisible: false,
+  walletVisible: false,
 };
 
-export const rulesReducer: Reducer<RulesState> = (state = initialState, action: actions.ToggleVisibility) => {
+export const overlayReducer: Reducer<OverlayState> = (state = initialState, action: any) => {
   switch (action.type) {
-    case actions.TOGGLE_VISIBILITY:
-      return {visible: !state.visible};
+    case actions.TOGGLE_RULES_VISIBILITY:
+      return { ...state, rulesVisible: !state.rulesVisible };
+    case actions.SHOW_WALLET:
+      return { ...state, walletVisible: true };
+    case actions.HIDE_WALLET:
+      return { ...state, walletVisible: false };
     default:
       // unreachable
       return state;

--- a/packages/rps/src/redux/global/state.ts
+++ b/packages/rps/src/redux/global/state.ts
@@ -1,5 +1,6 @@
-export interface Rules {
-  visible: boolean;
+export interface Overlay {
+  rulesVisible: boolean;
+  walletVisible: boolean;
 }
 
-export type RulesState = Rules;
+export type OverlayState = Overlay;

--- a/packages/rps/src/redux/message-service/saga.ts
+++ b/packages/rps/src/redux/message-service/saga.ts
@@ -5,6 +5,7 @@ import { reduxSagaFirebase } from '../../gateways/firebase';
 
 import { encode, decode, Player, positions } from '../../core';
 import * as gameActions from '../game/actions';
+import * as appActions from '../global/actions';
 import { MessageState, WalletMessage } from './state';
 import * as gameStates from '../game/state';
 import { Channel } from 'fmg-core';
@@ -27,7 +28,7 @@ export default function* messageSaga() {
   yield fork(exitGameSaga);
   yield fork(receiveChallengePositionFromWalletSaga);
   yield fork(receiveChallengeFromWalletSaga);
-
+  yield fork(recieveDisplayEventFromWalletSaga);
 }
 
 export function* sendWalletMessageSaga() {
@@ -236,6 +237,26 @@ function* receiveChallengeFromWalletSaga() {
 
   }
 }
+
+function* recieveDisplayEventFromWalletSaga() {
+  const displayChannel = createWalletEventChannel([Wallet.SHOW_WALLET, Wallet.HIDE_WALLET]);
+  while (true) {
+    const event = yield take(displayChannel);
+    switch (event.type) {
+      case Wallet.SHOW_WALLET:
+        yield put(appActions.showWallet());
+        break;
+      case Wallet.HIDE_WALLET:
+        yield put(appActions.hideWallet());
+        break;
+      default:
+        throw new Error(
+          'recieveDisplayFromWalletSaga: unexpected event'
+        );
+    }
+  }
+}
+
 function* receiveChallengePositionFromWalletSaga() {
   const challengeChannel = createWalletEventChannel([Wallet.CHALLENGE_POSITION_RECEIVED]);
   while (true) {

--- a/packages/rps/src/redux/reducer.ts
+++ b/packages/rps/src/redux/reducer.ts
@@ -5,15 +5,15 @@ import { MetamaskState, metamaskReducer } from './metamask/reducer';
 import { gameReducer, JointState } from './game/reducer';
 import { OpenGameState } from './open-games/state';
 import { openGamesReducer } from './open-games/reducer';
-import { rulesReducer } from './global/reducer';
-import { RulesState } from './global/state';
+import { overlayReducer } from './global/reducer';
+import { OverlayState } from './global/state';
 
 export interface SiteState {
   login: LoginState;
   metamask: MetamaskState;
   openGames: OpenGameState;
   game: JointState;
-  rules: RulesState;
+  overlay: OverlayState;
 }
 
 export default combineReducers<SiteState>({
@@ -21,5 +21,5 @@ export default combineReducers<SiteState>({
   metamask: metamaskReducer,
   openGames: openGamesReducer,
   game: gameReducer,
-  rules: rulesReducer,
+  overlay: overlayReducer,
 });

--- a/packages/wallet-client/src/wallet-events.ts
+++ b/packages/wallet-client/src/wallet-events.ts
@@ -333,7 +333,9 @@ export type WalletEventType =
   typeof VALIDATION_FAILURE |
   typeof VALIDATION_SUCCESS |
   typeof FUNDING_FAILURE |
-  typeof FUNDING_SUCCESS;
+  typeof FUNDING_SUCCESS |
+  typeof SHOW_WALLET |
+  typeof HIDE_WALLET;
 
 /**
  * @ignore

--- a/packages/wallet-client/src/wallet-functions.ts
+++ b/packages/wallet-client/src/wallet-functions.ts
@@ -26,21 +26,6 @@ export function createWalletIFrame(iframeId: string, walletUrl?: string): HTMLIF
 
   iFrame.setAttribute('allowtransparency', 'true');
 
-  window.addEventListener('message', (event => {
-    if (event.data && event.data.type && event.data.type === SHOW_WALLET) {
-      iFrame.style.display = 'initial';
-      document.body.style.overflow = 'hidden';
-      iFrame.width = '100%';
-      iFrame.height = '100%';
-    }
-    if (event.data && event.data.type && event.data.type === HIDE_WALLET) {
-      iFrame.style.display = 'none';
-      document.body.style.overflow = 'initial';
-      iFrame.width = '0';
-      iFrame.height = '0';
-
-    }
-  }));
   return iFrame;
 }
 


### PR DESCRIPTION
With this PR, `displayOutbox` is unused (as far as I can tell). Do we want to keep the wiring for `displayOutbox` around for future features?