### PR TITLE
Handle devtools not being installed and metamask permissions errors

### DIFF
--- a/packages/wallet/src/containers/Initializing.tsx
+++ b/packages/wallet/src/containers/Initializing.tsx
@@ -1,0 +1,31 @@
+import * as states from '../states';
+import React, { PureComponent } from 'react';
+import SidebarLayout from '../components/SidebarLayout';
+import LandingPage from '../components/LandingPage';
+import { connect } from 'react-redux';
+interface Props {
+  state: states.InitializingState;
+}
+
+class InitializingContainer extends PureComponent<Props> {
+  render() {
+    const { state } = this.props;
+    switch (state.type) {
+      case states.METAMASK_ERROR:
+        return (
+          <SidebarLayout>
+            <h1>A metamask error has occurred.</h1>
+            <p>
+              Something went wrong loading metamask.
+              Please make sure metamask is installed and has permission to access {window.location.href}.
+            </p>
+          </SidebarLayout>
+        );
+      default:
+        return <LandingPage />;
+    }
+  }
+}
+export default connect(
+  () => ({}),
+)(InitializingContainer);

--- a/packages/wallet/src/containers/Wallet.tsx
+++ b/packages/wallet/src/containers/Wallet.tsx
@@ -7,6 +7,7 @@ import FundingContainer from './Funding';
 import RespondingContainer from './Responding';
 import ChallengingContainer from './Challenging';
 import WithdrawingContainer from './Withdrawing';
+import InitializingContainer from './Initializing';
 import ClosingContainer from './Closing';
 import LandingPage from '../components/LandingPage';
 
@@ -29,6 +30,8 @@ class Wallet extends PureComponent<WalletProps> {
         return <RespondingContainer state={state} />;
       case states.CLOSING:
         return <ClosingContainer state={state} />;
+      case states.INITIALIZING:
+        return <InitializingContainer state={state} />;
       default:
         return <LandingPage />;
     }

--- a/packages/wallet/src/redux/actions/index.ts
+++ b/packages/wallet/src/redux/actions/index.ts
@@ -340,6 +340,12 @@ export const approveClose = () => ({
 });
 export type ApproveClose = ReturnType<typeof approveClose>;
 
+export const METAMASK_LOAD_ERROR = 'METAMASK_LOAD_ERROR';
+export const metamaskLoadError = () => ({
+  type: METAMASK_LOAD_ERROR as typeof METAMASK_LOAD_ERROR,
+});
+export type MetamaskLoadError = ReturnType<typeof metamaskLoadError>;
+
 // TODO: This is getting large, we should probably split this up into separate types for each stage
 export type WalletAction = (
   | LoggedIn
@@ -389,4 +395,5 @@ export type WalletAction = (
   | ApproveClose
   | FundingDeclinedAcknowledged
   | ConcludeRejected
+  | MetamaskLoadError
 );

--- a/packages/wallet/src/redux/reducers/__tests__/initializing.test.ts
+++ b/packages/wallet/src/redux/reducers/__tests__/initializing.test.ts
@@ -26,5 +26,14 @@ describe('when in WaitForAddress', () => {
     const updatedState = walletReducer(state, action);
 
     itTransitionsToStateType(states.WAIT_FOR_CHANNEL, updatedState);
+
+  });
+
+  describe('when a metamask load error occurs',()=>{
+    const action = actions.metamaskLoadError();
+    const updatedState = walletReducer(state, action);
+
+    itTransitionsToStateType(states.METAMASK_ERROR, updatedState);
+
   });
 });

--- a/packages/wallet/src/redux/reducers/initializing.ts
+++ b/packages/wallet/src/redux/reducers/initializing.ts
@@ -6,12 +6,14 @@ import {
   WaitForAddress,
   WAIT_FOR_LOGIN,
   WAIT_FOR_ADDRESS,
-  waitForAddress
+  waitForAddress,
+  metaMaskError,
+  METAMASK_ERROR
 } from '../../states';
 
-import { WalletAction, KEYS_LOADED, LOGGED_IN } from '../actions';
+import { WalletAction, KEYS_LOADED, LOGGED_IN, METAMASK_LOAD_ERROR } from '../actions';
 import { unreachable } from '../../utils/reducer-utils';
-import { initializationSuccess } from 'wallet-client/lib/wallet-events';
+import { initializationSuccess, showWallet } from 'wallet-client/lib/wallet-events';
 
 
 export const initializingReducer = (state: InitializingState, action: WalletAction): WalletState => {
@@ -20,6 +22,10 @@ export const initializingReducer = (state: InitializingState, action: WalletActi
       return waitForLoginReducer(state, action);
     case WAIT_FOR_ADDRESS:
       return waitForAddressReducer(state, action);
+    case METAMASK_ERROR:
+      // We stay in the metamask error state until a change to 
+      // metamask settings forces a refresh 
+      return state;
     default:
       return unreachable(state);
   }
@@ -37,6 +43,8 @@ const waitForLoginReducer = (state: WaitForLogin, action: any) => {
 
 const waitForAddressReducer = (state: WaitForAddress, action: any) => {
   switch (action.type) {
+    case METAMASK_LOAD_ERROR:
+      return metaMaskError({ ...state, displayOutbox: showWallet() });
     case KEYS_LOADED:
       const { address, privateKey, networkId } = action;
       return waitForChannel({

--- a/packages/wallet/src/redux/reducers/opening.ts
+++ b/packages/wallet/src/redux/reducers/opening.ts
@@ -63,10 +63,10 @@ const waitForChannelReducer = (state: states.WaitForChannel, action: actions.Wal
       // all these checks will fail silently for the time being
       // check it's a PreFundSetupA
       if (opponentPosition.stateType !== State.StateType.PreFundSetup) {
-         return {...state, messageOutbox: validationFailure('Other','Expected a prefund setup position') };
+        return { ...state, messageOutbox: validationFailure('Other', 'Expected a prefund setup position') };
       }
       if (opponentPosition.stateCount !== 0) {
-         return {...state, messageOutbox: validationFailure('Other','Expected state count to be 0') };
+        return { ...state, messageOutbox: validationFailure('Other', 'Expected state count to be 0') };
       }
 
 
@@ -138,9 +138,9 @@ const waitForPreFundSetupReducer = (state: states.WaitForPreFundSetup, action: a
       }
       const opponentAddress2 = state.participants[1 - state.ourIndex];
 
-      if (!validSignature(action.data, action.signature, opponentAddress2)) { 
-        return {...state, messageOutbox:validationFailure('InvalidSignature')};
-       }
+      if (!validSignature(action.data, action.signature, opponentAddress2)) {
+        return { ...state, messageOutbox: validationFailure('InvalidSignature') };
+      }
 
       // if so, unpack its contents into the state
       return states.waitForFundingRequest({

--- a/packages/wallet/src/redux/sagas/key-loader.ts
+++ b/packages/wallet/src/redux/sagas/key-loader.ts
@@ -2,7 +2,7 @@ import { call, put, select } from 'redux-saga/effects';
 
 import { default as firebase, reduxSagaFirebase } from '../../../gateways/firebase';
 import ChannelWallet from '../../domain/ChannelWallet';
-import { keysLoaded } from '../actions';
+import { keysLoaded, metamaskLoadError } from '../actions';
 import { getProvider } from '../../utils/contract-utils';
 import { ethers } from 'ethers';
 import { WAIT_FOR_ADDRESS, WalletState } from '../../states';
@@ -24,10 +24,13 @@ export function* keyLoader() {
     // fetch again instead of using return val, just in case another wallet was created in the interim
     wallet = yield* fetchWallet(uid);
   }
-  // TODO: This should probably be its own saga? or at least its
-  const provider: ethers.providers.BaseProvider = yield call(getProvider);
-  const network = yield provider.getNetwork();
-  yield put(keysLoaded(wallet.address, wallet.privateKey, network.chainId));
+  if (typeof web3 === 'undefined') {
+  yield put(metamaskLoadError());
+  } else {
+      const provider: ethers.providers.BaseProvider = yield call(getProvider);
+      const network = yield provider.getNetwork();
+      yield put(keysLoaded(wallet.address, wallet.privateKey, network.chainId));
+    }
 }
 
 const walletTransformer = (data: any) =>

--- a/packages/wallet/src/redux/store.ts
+++ b/packages/wallet/src/redux/store.ts
@@ -7,7 +7,7 @@ const sagaMiddleware = createSagaMiddleware();
 import { walletReducer } from './reducers';
 import { sagaManager } from './sagas/saga-manager';
 
-const composeEnhancers = (window as any).__REDUX_DEVTOOLS_EXTENSION_COMPOSE__({ name: 'Wallet' }) || compose;
+const composeEnhancers = (window as any).__REDUX_DEVTOOLS_EXTENSION_COMPOSE__ || compose;
 const enhancers = composeEnhancers(
   applyMiddleware(sagaMiddleware),
 );

--- a/packages/wallet/src/states/initializing.ts
+++ b/packages/wallet/src/states/initializing.ts
@@ -4,6 +4,8 @@ export const INITIALIZING = 'INITIALIZING';
 
 export const WAIT_FOR_LOGIN = 'WAIT_FOR_LOGIN';
 export const WAIT_FOR_ADDRESS = 'WAIT_FOR_ADDRESS';
+export const METAMASK_ERROR = 'METAMASK_ERROR';
+
 
 export interface WaitForLogin extends Base {
   type: typeof WAIT_FOR_LOGIN;
@@ -22,7 +24,20 @@ export function waitForAddress<T extends LoggedIn>(params: T): WaitForAddress {
   return { ...loggedIn(params), type: WAIT_FOR_ADDRESS, stage: INITIALIZING };
 }
 
+
+export interface MetaMaskError extends Base {
+  type: typeof METAMASK_ERROR;
+  stage: typeof INITIALIZING;
+}
+
+export function metaMaskError<T extends Base>(params: T): MetaMaskError {
+  return { type: METAMASK_ERROR, stage: INITIALIZING, ...base(params) };
+}
+
+
+
 export type InitializingState = (
   | WaitForLogin
   | WaitForAddress
+  | MetaMaskError
 );


### PR DESCRIPTION
I've fixed the issue with the app crashing when `redux dev tools` is not installed.

I've also added a basic pop up in the wallet if metamask is not installed or has does not have permissions on the wallet domain.

Ideally we'd want to just let the `onClick` metamask permissions to work with the iframe as well but I'm not sure how to get that working with the cross domain iframe. So for now we'll just show a message pop up.