### PR TITLE
Add retry for transaction failure

### DIFF
--- a/packages/wallet/src/components/TransactionFailed.tsx
+++ b/packages/wallet/src/components/TransactionFailed.tsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import SidebarLayout from './SidebarLayout';
+import { Button } from 'reactstrap';
+import magmoFireBall from '../images/fireball.svg';
+
+interface Props {
+  name: string;
+  retryAction: () => void;
+}
+
+export default class TransactionFailed extends React.PureComponent<Props> {
+
+  render() {
+    const { name, retryAction } = this.props;
+    return (
+      <SidebarLayout>
+        <h1>Transaction Failed</h1>
+        <p>The {name} transaction was not submitted to the network. Hit retry to try again.</p>
+
+        <Button onClick={retryAction} >
+          <img src={magmoFireBall} />&nbsp;&nbsp;Retry
+        </Button>
+
+      </SidebarLayout>
+    );
+  }
+}

--- a/packages/wallet/src/containers/Challenging.tsx
+++ b/packages/wallet/src/containers/Challenging.tsx
@@ -12,6 +12,7 @@ import WaitForXConfirmation from '../components/WaitForXConfirmation';
 import WaitForXInitiation from '../components/WaitForXInitiation';
 import SubmitX from '../components/SubmitX';
 import { unreachable } from '../utils/reducer-utils';
+import TransactionFailed from '../components/TransactionFailed';
 
 interface Props {
   state: states.ChallengingState;
@@ -19,6 +20,7 @@ interface Props {
   challengeResponseAcknowledged: () => void;
   challengeApproved: () => void;
   challengeRejected: () => void;
+  retryTransaction: () => void;
 }
 
 class ChallengingContainer extends PureComponent<Props> {
@@ -29,6 +31,7 @@ class ChallengingContainer extends PureComponent<Props> {
       challengeResponseAcknowledged,
       challengeApproved,
       challengeRejected,
+      retryTransaction,
     } = this.props;
 
     switch (state.type) {
@@ -72,6 +75,9 @@ class ChallengingContainer extends PureComponent<Props> {
             actionTitle="Withdraw your funds"
           />
         );
+      case states.CHALLENGE_TRANSACTION_FAILED:
+        return <TransactionFailed name='challenge' retryAction={retryTransaction} />;
+
       default:
         return unreachable(state);
     }
@@ -83,6 +89,7 @@ const mapDispatchToProps = {
   challengeResponseAcknowledged: actions.challengeResponseAcknowledged,
   challengeApproved: actions.challengeApproved,
   challengeRejected: actions.challengeRejected,
+  retryTransaction: actions.retryTransaction,
 };
 
 export default connect(

--- a/packages/wallet/src/containers/Closing.tsx
+++ b/packages/wallet/src/containers/Closing.tsx
@@ -11,6 +11,7 @@ import { unreachable } from '../utils/reducer-utils';
 import WaitForOtherPlayer from '../components/WaitForOtherPlayer';
 import WaitForXConfirmation from '../components/WaitForXConfirmation';
 import WaitForXInitiation from '../components/WaitForXInitiation';
+import TransactionFailed from '../components/TransactionFailed';
 
 interface Props {
   state: states.ClosingState;
@@ -19,6 +20,7 @@ interface Props {
   closeOnChain: () => void;
   closeSuccessAcknowledged: () => void;
   closedOnChainAcknowledged: () => void;
+  retryTransaction: () => void;
 }
 
 class ClosingContainer extends PureComponent<Props> {
@@ -30,6 +32,7 @@ class ClosingContainer extends PureComponent<Props> {
       closeSuccessAcknowledged,
       closedOnChainAcknowledged,
       closeOnChain,
+      retryTransaction,
     } = this.props;
 
     switch (state.type) {
@@ -91,6 +94,8 @@ class ClosingContainer extends PureComponent<Props> {
             actionTitle="Ok!"
           />
         );
+      case states.CLOSE_TRANSACTION_FAILED:
+        return <TransactionFailed name='conclude' retryAction={retryTransaction} />;
       default:
         return unreachable(state);
     }
@@ -103,6 +108,7 @@ const mapDispatchToProps = {
   closeSuccessAcknowledged: actions.closeSuccessAcknowledged,
   closedOnChainAcknowledged: actions.closedOnChainAcknowledged,
   closeOnChain: actions.approveClose,
+  retryTransaction: actions.retryTransaction,
 };
 
 export default connect(

--- a/packages/wallet/src/containers/Funding.tsx
+++ b/packages/wallet/src/containers/Funding.tsx
@@ -14,13 +14,15 @@ import SubmitX from '../components/SubmitX';
 import ApproveX from '../components/ApproveX';
 import { unreachable } from '../utils/reducer-utils';
 import WaitForOtherPlayer from '../components/WaitForOtherPlayer';
+import TransactionFailed from '../components/TransactionFailed';
 
 interface Props {
   state: states.FundingState;
   fundingApproved: () => void;
   fundingRejected: () => void;
   fundingSuccessAcknowledged: () => void;
-  fundingDeclinedAcknowledged:()=> void;
+  fundingDeclinedAcknowledged: () => void;
+  retryTransactionAction: () => void;
 }
 
 class FundingContainer extends PureComponent<Props> {
@@ -31,6 +33,7 @@ class FundingContainer extends PureComponent<Props> {
       fundingRejected,
       fundingSuccessAcknowledged,
       fundingDeclinedAcknowledged,
+      retryTransactionAction,
     } = this.props;
 
     switch (state.type) {
@@ -90,6 +93,10 @@ class FundingContainer extends PureComponent<Props> {
         />);
       case states.SEND_FUNDING_DECLINED_MESSAGE:
         return null;
+      case states.DEPLOY_TRANSACTION_FAILED:
+        return <TransactionFailed name="deploy" retryAction={retryTransactionAction} />;
+      case states.DEPOSIT_TRANSACTION_FAILED:
+        return <TransactionFailed name="deposit" retryAction={retryTransactionAction} />;
       default:
         return unreachable(state);
     }
@@ -101,6 +108,7 @@ const mapDispatchToProps = {
   fundingRejected: actions.fundingRejected,
   fundingSuccessAcknowledged: actions.fundingSuccessAcknowledged,
   fundingDeclinedAcknowledged: actions.fundingDeclinedAcknowledged,
+  retryTransactionAction: actions.retryTransaction,
 };
 
 // why does it think that mapStateToProps can return undefined??

--- a/packages/wallet/src/containers/Responding.tsx
+++ b/packages/wallet/src/containers/Responding.tsx
@@ -10,6 +10,7 @@ import WaitForXConfirmation from '../components/WaitForXConfirmation';
 import SubmitX from '../components/SubmitX';
 import { unreachable } from '../utils/reducer-utils';
 import ChooseResponse, { ChallengeOptions } from '../components/responding/ChooseResponse';
+import TransactionFailed from '../components/TransactionFailed';
 
 interface Props {
   state: states.RespondingState;
@@ -17,6 +18,7 @@ interface Props {
   challengeResponseAcknowledged: () => void;
   selectRespondWithMove: () => void;
   selectRespondWithExistingMove: () => void;
+  retryTransaction: () => void;
 }
 
 class RespondingContainer extends PureComponent<Props> {
@@ -27,6 +29,7 @@ class RespondingContainer extends PureComponent<Props> {
       challengeResponseAcknowledged,
       selectRespondWithMove,
       selectRespondWithExistingMove,
+      retryTransaction,
     } = this.props;
 
     switch (state.type) {
@@ -68,6 +71,8 @@ class RespondingContainer extends PureComponent<Props> {
             actionTitle="Return to app"
           />
         );
+      case states.RESPONSE_TRANSACTION_FAILED:
+        return <TransactionFailed name='challenge response' retryAction={retryTransaction} />;
       default:
         return unreachable(state);
     }
@@ -79,6 +84,7 @@ const mapDispatchToProps = {
   challengeResponseAcknowledged: actions.challengeResponseAcknowledged,
   selectRespondWithMove: actions.respondWithMoveChosen,
   selectRespondWithExistingMove: actions.respondWithExistingMoveChosen,
+  retryTransaction: actions.retryTransaction,
 };
 
 export default connect(

--- a/packages/wallet/src/containers/Withdrawing.tsx
+++ b/packages/wallet/src/containers/Withdrawing.tsx
@@ -10,12 +10,14 @@ import WaitForXConfirmation from '../components/WaitForXConfirmation';
 import WaitForXInitiation from '../components/WaitForXInitiation';
 import ApproveX from '../components/ApproveX';
 import { unreachable } from '../utils/reducer-utils';
+import TransactionFailed from '../components/TransactionFailed';
 
 interface Props {
   state: states.WithdrawingState;
   withdrawalApproved: (destinationAddress: string) => void;
   withdrawalRejected: () => void;
   withdrawalSuccessAcknowledged: () => void;
+  retryTransaction: () => void;
 }
 
 class WithdrawingContainer extends PureComponent<Props> {
@@ -25,6 +27,7 @@ class WithdrawingContainer extends PureComponent<Props> {
       withdrawalApproved,
       withdrawalRejected,
       withdrawalSuccessAcknowledged,
+      retryTransaction,
     } = this.props;
 
     switch (state.type) {
@@ -53,6 +56,8 @@ class WithdrawingContainer extends PureComponent<Props> {
             actionTitle="Return to app"
           />
         );
+      case states.WITHDRAW_TRANSACTION_FAILED:
+        return <TransactionFailed name='withdraw' retryAction={retryTransaction} />;
       default:
         return unreachable(state);
     }
@@ -63,6 +68,7 @@ const mapDispatchToProps = {
   withdrawalApproved: actions.withdrawalApproved,
   withdrawalRejected: actions.withdrawalRejected,
   withdrawalSuccessAcknowledged: actions.withdrawalSuccessAcknowledged,
+  retryTransaction: actions.retryTransaction,
 };
 
 // why does it think that mapStateToProps can return undefined??

--- a/packages/wallet/src/redux/actions/index.ts
+++ b/packages/wallet/src/redux/actions/index.ts
@@ -346,6 +346,12 @@ export const metamaskLoadError = () => ({
 });
 export type MetamaskLoadError = ReturnType<typeof metamaskLoadError>;
 
+export const RETRY_TRANSACTION = 'RETRY_TRANSACTION';
+export const retryTransaction = () => ({
+  type: RETRY_TRANSACTION as typeof RETRY_TRANSACTION,
+});
+export type RetryTransaction = ReturnType<typeof retryTransaction>;
+
 // TODO: This is getting large, we should probably split this up into separate types for each stage
 export type WalletAction = (
   | LoggedIn
@@ -396,4 +402,5 @@ export type WalletAction = (
   | FundingDeclinedAcknowledged
   | ConcludeRejected
   | MetamaskLoadError
+  | RetryTransaction
 );

--- a/packages/wallet/src/redux/reducers/__tests__/closing.test.ts
+++ b/packages/wallet/src/redux/reducers/__tests__/closing.test.ts
@@ -198,6 +198,12 @@ describe('start in WaitForCloseSubmission', () => {
     const updatedState = walletReducer(state, action);
     itTransitionsToStateType(states.WAIT_FOR_CLOSE_CONFIRMED, updatedState);
   });
+  describe('action taken: transaction submitted', () => {
+
+    const action = actions.transactionSubmissionFailed({ code: 0 });
+    const updatedState = walletReducer(state, action);
+    itTransitionsToStateType(states.CLOSE_TRANSACTION_FAILED, updatedState);
+  });
   describe('action taken: game concluded event', () => {
     const action = actions.gameConcludedEvent();
     const updatedState = walletReducer(state, action);
@@ -205,6 +211,23 @@ describe('start in WaitForCloseSubmission', () => {
   });
 });
 
+describe('start in closeTransactionFailed', () => {
+  const state = states.closeTransactionFailed({
+    ...defaultsA,
+    penultimatePosition: { data: aResignsAfterOneRound.concludeHex, signature: aResignsAfterOneRound.conclude2Sig },
+    lastPosition: { data: aResignsAfterOneRound.conclude2Hex, signature: aResignsAfterOneRound.conclude2Sig },
+    turnNum: 9,
+  });
+
+  describe('action taken: retry transaction', () => {
+    const createCloseTxMock = jest.fn();
+    Object.defineProperty(TransactionGenerator, 'createConcludeTransaction', { value: createCloseTxMock });
+    const action = actions.retryTransaction();
+    const updatedState = walletReducer(state, action);
+    itTransitionsToStateType(states.WAIT_FOR_CLOSE_SUBMISSION, updatedState);
+    expect(createCloseTxMock.mock.calls.length).toBe(1);
+  });
+});
 
 describe('start in WaitForCloseConfirmed', () => {
   const state = states.waitForCloseConfirmed({

--- a/packages/wallet/src/redux/reducers/__tests__/funding.test.ts
+++ b/packages/wallet/src/redux/reducers/__tests__/funding.test.ts
@@ -184,7 +184,7 @@ describe('start in aSubmitDeployInMetaMask', () => {
     const action = actions.transactionSubmissionFailed({ code: "1234" });
     const updatedState = walletReducer(state, action);
 
-    itTransitionsToStateType(states.WAIT_FOR_CHANNEL, updatedState);
+    itTransitionsToStateType(states.DEPLOY_TRANSACTION_FAILED, updatedState);
   });
 
   describe('incoming action: Funding declined message received', () => {
@@ -240,7 +240,7 @@ describe('start in WaitForDeployConfirmation', () => {
 
 describe('start in AWaitForDeposit', () => {
   describe('incoming action: Funding declined message received', () => {
-  const testDefaults = { ...defaultsA, ...justReceivedPreFundSetupB };
+    const testDefaults = { ...defaultsA, ...justReceivedPreFundSetupB };
     const state = states.aWaitForDeposit(testDefaults);
     const action = actions.messageReceived("FundingDeclined");
     const updatedState = walletReducer(state, action);
@@ -312,7 +312,7 @@ describe('start in BSubmitDepositInMetaMask', () => {
     const action = actions.transactionSubmissionFailed({ code: "1234" });
     const updatedState = walletReducer(state, action);
 
-    itTransitionsToStateType(states.WAIT_FOR_CHANNEL, updatedState);
+    itTransitionsToStateType(states.DEPOSIT_TRANSACTION_FAILED, updatedState);
   });
 
 });
@@ -353,6 +353,34 @@ describe('start in WaitForDepositConfirmation', () => {
     itTransitionsToStateType(states.WAIT_FOR_DEPOSIT_CONFIRMATION, updatedState);
     itIncreasesTurnNumBy(0, state, updatedState);
     expect((updatedState as WaitForDepositConfirmation).unhandledAction).toEqual(action);
+  });
+});
+
+describe('start in depositTransactionFailed', () => {
+  describe('incoming action: retry transaction', () => {
+    const createDepositTxMock = jest.fn();
+    Object.defineProperty(TransactionGenerator, 'createDepositTransaction', { value: createDepositTxMock });
+    const testDefaults = { ...defaultsB, ...justReceivedPreFundSetupB };
+    const state = states.depositTransactionFailed(testDefaults);
+    const action = actions.retryTransaction();
+    const updatedState = walletReducer(state, action);
+
+    itTransitionsToStateType(states.B_WAIT_FOR_DEPOSIT_TO_BE_SENT_TO_METAMASK, updatedState);
+    expect(createDepositTxMock.mock.calls.length).toBe(1);
+  });
+});
+
+describe('start in deployTransactionFailure', () => {
+  describe('incoming action: retry transaction', () => {
+    const createDeployTxMock = jest.fn();
+    Object.defineProperty(TransactionGenerator, 'createDeployTransaction', { value: createDeployTxMock });
+    const testDefaults = { ...defaultsB, ...justReceivedPreFundSetupB };
+    const state = states.deployTransactionFailed(testDefaults);
+    const action = actions.retryTransaction();
+    const updatedState = walletReducer(state, action);
+
+    itTransitionsToStateType(states.A_WAIT_FOR_DEPLOY_TO_BE_SENT_TO_METAMASK, updatedState);
+    expect(createDeployTxMock.mock.calls.length).toBe(1);
   });
 });
 

--- a/packages/wallet/src/redux/reducers/__tests__/withdrawing.test.ts
+++ b/packages/wallet/src/redux/reducers/__tests__/withdrawing.test.ts
@@ -5,6 +5,7 @@ import * as actions from '../../actions';
 
 import { itTransitionsToStateType } from './helpers';
 import * as scenarios from './test-scenarios';
+import * as TransactionGenerator from '../../../utils/transaction-generator';
 
 const {
   asPrivateKey,
@@ -66,6 +67,25 @@ describe('when in WaitForWithdrawalInitiation', () => {
     const updatedState = walletReducer(state, action);
 
     itTransitionsToStateType(states.WAIT_FOR_WITHDRAWAL_CONFIRMATION, updatedState);
+  });
+  describe('and the transaction submission errors', () => {
+    const action = actions.transactionSubmissionFailed({ code: 0 });
+    const updatedState = walletReducer(state, action);
+
+    itTransitionsToStateType(states.WITHDRAW_TRANSACTION_FAILED, updatedState);
+  });
+});
+
+describe('when in withdrawTransactionFailed', () => {
+  describe('and the transaction is retried', () => {
+    const createWithdrawTxMock = jest.fn();
+    Object.defineProperty(TransactionGenerator, 'createWithdrawTransaction', { value: createWithdrawTxMock });
+    const state = states.withdrawTransactionFailed(defaults);
+    const action = actions.retryTransaction();
+    const updatedState = walletReducer(state, action);
+
+    itTransitionsToStateType(states.WAIT_FOR_WITHDRAWAL_INITIATION, updatedState);
+    expect(createWithdrawTxMock.mock.calls.length).toBe(1);
   });
 });
 

--- a/packages/wallet/src/redux/reducers/closing.ts
+++ b/packages/wallet/src/redux/reducers/closing.ts
@@ -52,7 +52,7 @@ const closeTransactionFailedReducer = (state: states.CloseTransactionFailed, act
       return states.waitForCloseSubmission({ ...state, transactionOutbox });
   }
   return state;
-}
+};
 
 const acknowledgeConcludeReducer = (state: states.AcknowledgeConclude, action: actions.WalletAction) => {
   switch (action.type) {

--- a/packages/wallet/src/redux/reducers/closing.ts
+++ b/packages/wallet/src/redux/reducers/closing.ts
@@ -32,11 +32,27 @@ export const closingReducer = (state: ClosingState, action: WalletAction): Walle
       return waitForOpponentCloseReducer(state, action);
     case states.ACKNOWLEDGE_CONCLUDE:
       return acknowledgeConcludeReducer(state, action);
-
+    case states.CLOSE_TRANSACTION_FAILED:
+      return closeTransactionFailedReducer(state, action);
     default:
       return unreachable(state);
   }
 };
+
+const closeTransactionFailedReducer = (state: states.CloseTransactionFailed, action: actions.WalletAction) => {
+  switch (action.type) {
+    case actions.RETRY_TRANSACTION:
+      const { penultimatePosition: from, lastPosition: to } = state;
+      const transactionOutbox = createConcludeTransaction(
+        state.adjudicator,
+        from.data,
+        to.data,
+        from.signature,
+        to.signature);
+      return states.waitForCloseSubmission({ ...state, transactionOutbox });
+  }
+  return state;
+}
 
 const acknowledgeConcludeReducer = (state: states.AcknowledgeConclude, action: actions.WalletAction) => {
   switch (action.type) {
@@ -97,6 +113,8 @@ const waitForCloseInitiatorReducer = (state: states.WaitForCloseInitiation, acti
 
 const waitForCloseSubmissionReducer = (state: states.WaitForCloseSubmission, action: actions.WalletAction) => {
   switch (action.type) {
+    case actions.TRANSACTION_SUBMISSION_FAILED:
+      return states.closeTransactionFailed(state);
     case actions.TRANSACTION_SUBMITTED:
       return states.waitForCloseConfirmed({ ...state, transactionHash: action.transactionHash });
     case actions.GAME_CONCLUDED_EVENT:

--- a/packages/wallet/src/redux/sagas/transaction-sender.ts
+++ b/packages/wallet/src/redux/sagas/transaction-sender.ts
@@ -13,7 +13,6 @@ export function* transactionSender(transaction) {
   try {
     transactionResult = yield call([signer, signer.sendTransaction], transaction);
   } catch (err) {
-    console.error(err);
     yield put(transactionSubmissionFailed(err));
     return;
   }

--- a/packages/wallet/src/states/challenging.ts
+++ b/packages/wallet/src/states/challenging.ts
@@ -12,11 +12,26 @@ export const WAIT_FOR_CHALLENGE_CONFIRMATION = 'WAIT_FOR_CHALLENGE_CONFIRMATION'
 export const WAIT_FOR_RESPONSE_OR_TIMEOUT = 'WAIT_FOR_RESPONSE_OR_TIMEOUT';
 export const ACKNOWLEDGE_CHALLENGE_RESPONSE = 'ACKNOWLEDGE_CHALLENGE_RESPONSE';
 export const ACKNOWLEDGE_CHALLENGE_TIMEOUT = 'ACKNOWLEDGE_CHALLENGE_TIMEOUT';
+export const CHALLENGE_TRANSACTION_FAILED = 'CHALLENGE_TRANSACTION_FAILED';
+
+export interface ChallengeTransactionFailed extends AdjudicatorExists {
+  type: typeof CHALLENGE_TRANSACTION_FAILED;
+  stage: typeof CHALLENGING;
+}
+
+export function challengeTransactionFailed<T extends AdjudicatorExists>(params: T): ChallengeTransactionFailed {
+  return {
+    type: CHALLENGE_TRANSACTION_FAILED,
+    stage: CHALLENGING,
+    ...adjudicatorExists(params),
+  };
+}
 
 export interface ApproveChallenge extends AdjudicatorExists {
   type: typeof APPROVE_CHALLENGE;
   stage: typeof CHALLENGING;
 }
+
 
 export function approveChallenge<T extends AdjudicatorExists>(params: T): ApproveChallenge {
   return {
@@ -113,4 +128,5 @@ export type ChallengingState = (
   | AcknowledgeChallengeResponse
   | AcknowledgeChallengeTimeout
   | ApproveChallenge
+  | ChallengeTransactionFailed
 );

--- a/packages/wallet/src/states/closing.ts
+++ b/packages/wallet/src/states/closing.ts
@@ -14,7 +14,12 @@ export const WAIT_FOR_CLOSE_SUBMISSION = 'WAIT_FOR_CLOSE_SUBMISSION';
 export const WAIT_FOR_CLOSE_CONFIRMED = 'WAIT_FOR_CLOSE_CONFIRMED';
 export const WAIT_FOR_OPPONENT_CLOSE = 'WAIT_FOR_OPPONENT_CLOSE';
 export const ACKNOWLEDGE_CONCLUDE = 'ACKNOWLEDGE_CONCLUDE';
+export const CLOSE_TRANSACTION_FAILED = 'CLOSE_TRANSACTION_FAILED';
 
+export interface CloseTransactionFailed extends AdjudicatorExists {
+  type: typeof CLOSE_TRANSACTION_FAILED;
+  stage: typeof CLOSING;
+}
 
 export interface AcknowledgeConclude extends AdjudicatorMightExist {
   type: typeof ACKNOWLEDGE_CONCLUDE;
@@ -109,6 +114,9 @@ export function acknowledgeConclude<T extends AdjudicatorMightExist>(params: T):
   return { type: ACKNOWLEDGE_CONCLUDE, stage: CLOSING, ...adjudicatorMightExist(params) };
 }
 
+export function closeTransactionFailed<T extends AdjudicatorExists>(params: T): CloseTransactionFailed {
+  return { type: CLOSE_TRANSACTION_FAILED, stage: CLOSING, ...adjudicatorExists(params) };
+}
 
 export type ClosingState = (
   | ApproveConclude
@@ -121,4 +129,5 @@ export type ClosingState = (
   | WaitForCloseConfirmed
   | WaitForOpponentClose
   | AcknowledgeConclude
+  | CloseTransactionFailed
 );

--- a/packages/wallet/src/states/funding.ts
+++ b/packages/wallet/src/states/funding.ts
@@ -19,6 +19,18 @@ export const B_WAIT_FOR_POST_FUND_SETUP = 'B_WAIT_FOR_POST_FUND_SETUP';
 export const ACKNOWLEDGE_FUNDING_SUCCESS = 'ACKNOWLEDGE_FUNDING_SUCCESS';
 export const SEND_FUNDING_DECLINED_MESSAGE = 'SEND_FUNDING_DECLINED_MESSAGE';
 export const ACKNOWLEDGE_FUNDING_DECLINED = 'ACKNOWLEDGE_FUNDING_DECLINED';
+export const DEPLOY_TRANSACTION_FAILED = 'DEPLOY_TRANSACTION_FAILED';
+export const DEPOSIT_TRANSACTION_FAILED = 'DEPOSIT_TRANSACTION_FAILED';
+
+export interface DeployTransactionFailed extends ChannelOpen {
+  type: typeof DEPLOY_TRANSACTION_FAILED;
+  stage: typeof FUNDING;
+}
+
+export interface DepositTransactionFailed extends AdjudicatorExists {
+  type: typeof DEPOSIT_TRANSACTION_FAILED;
+  stage: typeof FUNDING;
+}
 
 export interface SendFundingDeclinedMessage extends ChannelOpen {
   type: typeof SEND_FUNDING_DECLINED_MESSAGE;
@@ -156,6 +168,13 @@ export function acknowledgeFundingDeclined<T extends ChannelOpen>(params: T): Ac
 
 }
 
+export function deployTransactionFailed<T extends ChannelOpen>(params: T): DeployTransactionFailed {
+  return { type: DEPLOY_TRANSACTION_FAILED, stage: FUNDING, ...channelOpen(params) };
+}
+export function depositTransactionFailed<T extends AdjudicatorExists>(params: T): DepositTransactionFailed {
+  return { type: DEPOSIT_TRANSACTION_FAILED, stage: FUNDING, ...adjudicatorExists(params) };
+}
+
 export type FundingState = (
   | WaitForFundingRequest
   | ApproveFunding
@@ -172,4 +191,6 @@ export type FundingState = (
   | AcknowledgeFundingSuccess
   | SendFundingDeclinedMessage
   | AcknowledgeFundingDeclined
+  | DeployTransactionFailed
+  | DepositTransactionFailed
 );

--- a/packages/wallet/src/states/responding.ts
+++ b/packages/wallet/src/states/responding.ts
@@ -11,6 +11,17 @@ export const INITIATE_RESPONSE = 'INITIATE_RESPONSE';
 export const WAIT_FOR_RESPONSE_CONFIRMATION = 'WAIT_FOR_RESPONSE_CONFIRMATION';
 export const WAIT_FOR_RESPONSE_SUBMISSION = 'WAIT_FOR_RESPONSE_SUBMISSION';
 export const ACKNOWLEDGE_CHALLENGE_COMPLETE = 'ACKNOWLEDGE_CHALLENGE_COMPLETE';
+export const RESPONSE_TRANSACTION_FAILED = 'RESPONSE_TRANSACTION_FAILED';
+
+export interface ResponseTransactionFailed extends ChallengeExists {
+  type: typeof RESPONSE_TRANSACTION_FAILED;
+  stage: typeof RESPONDING;
+}
+
+export function responseTransactionFailed<T extends ChallengeExists>(params: T): ResponseTransactionFailed {
+  return { type: RESPONSE_TRANSACTION_FAILED, stage: RESPONDING, ...challengeExists(params) };
+}
+
 export interface AcknowledgeChallenge extends ChallengeExists {
   type: typeof ACKNOWLEDGE_CHALLENGE;
   stage: typeof RESPONDING;
@@ -74,4 +85,5 @@ export type RespondingState = (
   | WaitForResponseSubmission
   | WaitForResponseConfirmation
   | AcknowledgeChallengeComplete
+  | ResponseTransactionFailed
 );

--- a/packages/wallet/src/states/withdrawing.ts
+++ b/packages/wallet/src/states/withdrawing.ts
@@ -8,13 +8,17 @@ export const APPROVE_WITHDRAWAL = 'APPROVE_WITHDRAWAL';
 export const WAIT_FOR_WITHDRAWAL_INITIATION = 'WAIT_FOR_WITHDRAWAL_INITIATION';
 export const WAIT_FOR_WITHDRAWAL_CONFIRMATION = 'WAIT_FOR_WITHDRAWAL_CONFIRMATION';
 export const ACKNOWLEDGE_WITHDRAWAL_SUCCESS = 'ACKNOWLEDGE_WITHDRAWAL_SUCCESS';
+export const WITHDRAW_TRANSACTION_FAILED = 'WITHDRAW_TRANSACTION_FAILED';
+
+export interface WithdrawTransactionFailed extends AdjudicatorExists {
+  type: typeof WITHDRAW_TRANSACTION_FAILED;
+  stage: typeof WITHDRAWING;
+}
 
 export interface ApproveWithdrawal extends AdjudicatorExists {
   type: typeof APPROVE_WITHDRAWAL;
   stage: typeof WITHDRAWING;
 }
-
-
 
 export interface WaitForWithdrawalInitiation extends AdjudicatorExists {
   type: typeof WAIT_FOR_WITHDRAWAL_INITIATION;
@@ -47,10 +51,13 @@ export function acknowledgeWithdrawalSuccess<T extends AdjudicatorExists>(params
   return { ...adjudicatorExists(params), type: ACKNOWLEDGE_WITHDRAWAL_SUCCESS, stage: WITHDRAWING };
 }
 
-
+export function withdrawTransactionFailed<T extends AdjudicatorExists>(params: T): WithdrawTransactionFailed {
+  return { type: WITHDRAW_TRANSACTION_FAILED, stage: WITHDRAWING, ...adjudicatorExists(params) };
+}
 export type WithdrawingState = (
   | ApproveWithdrawal
   | WaitForWithdrawalInitiation
   | WaitForWithdrawalConfirmation
   | AcknowledgeWithdrawalSuccess
+  | WithdrawTransactionFailed
 );


### PR DESCRIPTION
Whenever a transaction submission fails (IE: user rejects a transaction) we now catch that and allow then to retry the transaction.