### PR TITLE
Sent funds to metamask account address

### DIFF
--- a/packages/wallet/src/__stories__/index.tsx
+++ b/packages/wallet/src/__stories__/index.tsx
@@ -33,6 +33,7 @@ const defaults = {
   networkId: 123,
   challengeExpiry: 0,
   transactionHash: '0x0',
+  userAddress: '0x0',
 };
 const playerADefaults = {
   ...defaults,

--- a/packages/wallet/src/components/withdrawing/SelectAddress.tsx
+++ b/packages/wallet/src/components/withdrawing/SelectAddress.tsx
@@ -1,0 +1,47 @@
+import React from 'react';
+
+import SidebarLayout from '../SidebarLayout';
+import YesOrNo from '../YesOrNo';
+
+interface Props {
+  approveWithdrawal: (address: string) => void;
+  declineWithdrawal: () => void;
+}
+interface State {
+  withdrawAddress: string;
+}
+export default class SelectAddress extends React.PureComponent<Props, State> {
+  constructor(props) {
+    super(props);
+    const currentAddress = web3.eth.defaultAccount;
+    this.state = { withdrawAddress: currentAddress };
+
+    this.handleSubmitAddress = this.handleSubmitAddress.bind(this);
+    ethereum.on('accountsChanged', (accounts) => {
+      this.setState({ withdrawAddress: accounts[0] });
+    });
+  }
+
+  render() {
+    const { declineWithdrawal } = this.props;
+    return (
+      <SidebarLayout>
+        <h1>Approve Withdrawal</h1>
+        <p>
+          Do you wish to withdraw your funds from this channel?
+        </p>
+        <p>
+          The funds will be sent to your current metamask account:
+        </p>
+        <input disabled={true} style={{ width: '95%' }} type="text" readOnly={true} defaultValue={this.state.withdrawAddress} />
+        <YesOrNo yesAction={this.handleSubmitAddress} noAction={declineWithdrawal} yesMessage="Withdraw" noMessage="Cancel" />
+
+      </SidebarLayout>
+    );
+  }
+  handleSubmitAddress() {
+    this.props.approveWithdrawal(this.state.withdrawAddress);
+  }
+
+}
+

--- a/packages/wallet/src/containers/Withdrawing.tsx
+++ b/packages/wallet/src/containers/Withdrawing.tsx
@@ -8,7 +8,6 @@ import * as actions from '../redux/actions';
 import AcknowledgeX from '../components/AcknowledgeX';
 import WaitForXConfirmation from '../components/WaitForXConfirmation';
 import WaitForXInitiation from '../components/WaitForXInitiation';
-// import ApproveX from '../components/ApproveX';
 import { unreachable } from '../utils/reducer-utils';
 import TransactionFailed from '../components/TransactionFailed';
 import SelectAddress from '../components/withdrawing/SelectAddress';

--- a/packages/wallet/src/containers/Withdrawing.tsx
+++ b/packages/wallet/src/containers/Withdrawing.tsx
@@ -8,9 +8,10 @@ import * as actions from '../redux/actions';
 import AcknowledgeX from '../components/AcknowledgeX';
 import WaitForXConfirmation from '../components/WaitForXConfirmation';
 import WaitForXInitiation from '../components/WaitForXInitiation';
-import ApproveX from '../components/ApproveX';
+// import ApproveX from '../components/ApproveX';
 import { unreachable } from '../utils/reducer-utils';
 import TransactionFailed from '../components/TransactionFailed';
+import SelectAddress from '../components/withdrawing/SelectAddress';
 
 interface Props {
   state: states.WithdrawingState;
@@ -25,23 +26,17 @@ class WithdrawingContainer extends PureComponent<Props> {
     const {
       state,
       withdrawalApproved,
-      withdrawalRejected,
       withdrawalSuccessAcknowledged,
+      withdrawalRejected,
       retryTransaction,
     } = this.props;
 
     switch (state.type) {
       case states.APPROVE_WITHDRAWAL:
-
         return (
-          <ApproveX
-            title="Withdraw your funds"
-            description="Do you wish to withdraw your funds from this channel?"
-            approvalAction={() => withdrawalApproved('todo address')}
-            rejectionAction={withdrawalRejected}
-            yesMessage="Withdraw"
-            noMessage="Cancel"
-          />
+          <SelectAddress
+            approveWithdrawal={withdrawalApproved}
+            declineWithdrawal={withdrawalRejected} />
         );
       case states.WAIT_FOR_WITHDRAWAL_INITIATION:
         return <WaitForXInitiation name="withdrawal" />;

--- a/packages/wallet/src/redux/reducers/__tests__/withdrawing.test.ts
+++ b/packages/wallet/src/redux/reducers/__tests__/withdrawing.test.ts
@@ -6,6 +6,7 @@ import * as actions from '../../actions';
 import { itTransitionsToStateType } from './helpers';
 import * as scenarios from './test-scenarios';
 import * as TransactionGenerator from '../../../utils/transaction-generator';
+import * as SigningUtil from '../../../utils/signing-utils';
 
 const {
   asPrivateKey,
@@ -32,6 +33,7 @@ const defaults = {
   privateKey: asPrivateKey,
   networkId: 23213,
   transactionHash: '0x0',
+  userAddress: '0x0'
 };
 
 
@@ -40,15 +42,16 @@ describe('when in ApproveWithdrawal', () => {
 
   describe('and the user approves the withdrawal', () => {
     const destinationAddress = '0x123';
+    const createWithdrawTxMock = jest.fn();
+    Object.defineProperty(TransactionGenerator, 'createWithdrawTransaction', { value: createWithdrawTxMock });
+    const signMock = jest.fn().mockReturnValue('0x0');
+    Object.defineProperty(SigningUtil, 'signVerificationData', { value: signMock });
+
     const action = actions.withdrawalApproved(destinationAddress);
     const updatedState = walletReducer(state, action);
 
     itTransitionsToStateType(states.WAIT_FOR_WITHDRAWAL_INITIATION, updatedState);
-
-    it.skip('puts the withdrawal transaction in the outbox', () => {
-      expect(updatedState.transactionOutbox).toBe(expect.anything());
-      // todo
-    });
+    expect(createWithdrawTxMock.mock.calls.length).toBe(1);
   });
 
   describe('and the user rejects the withdrawal', () => {
@@ -80,6 +83,9 @@ describe('when in withdrawTransactionFailed', () => {
   describe('and the transaction is retried', () => {
     const createWithdrawTxMock = jest.fn();
     Object.defineProperty(TransactionGenerator, 'createWithdrawTransaction', { value: createWithdrawTxMock });
+    const signMock = jest.fn().mockReturnValue('0x0');
+    Object.defineProperty(SigningUtil, 'signVerificationData', { value: signMock });
+
     const state = states.withdrawTransactionFailed(defaults);
     const action = actions.retryTransaction();
     const updatedState = walletReducer(state, action);

--- a/packages/wallet/src/redux/reducers/withdrawing.ts
+++ b/packages/wallet/src/redux/reducers/withdrawing.ts
@@ -31,8 +31,8 @@ const withdrawTransactionFailedReducer = (state: states.WithdrawTransactionFaile
   switch (action.type) {
     case actions.RETRY_TRANSACTION:
       const myAddress = state.participants[state.ourIndex];
-      const signature = signVerificationData(myAddress, myAddress, state.channelId, state.privateKey);
-      const transactionOutbox = createWithdrawTransaction(state.adjudicator, myAddress, myAddress, state.channelId, signature);
+      const signature = signVerificationData(myAddress, state.userAddress, state.channelId, state.privateKey);
+      const transactionOutbox = createWithdrawTransaction(state.adjudicator, myAddress, state.userAddress, state.channelId, signature);
       return states.waitForWithdrawalInitiation({ ...state, transactionOutbox });
   }
   return state;
@@ -42,9 +42,10 @@ const approveWithdrawalReducer = (state: states.ApproveWithdrawal, action: actio
   switch (action.type) {
     case actions.WITHDRAWAL_APPROVED:
       const myAddress = state.participants[state.ourIndex];
-      const signature = signVerificationData(myAddress, myAddress, state.channelId, state.privateKey);
-      const transactionOutbox = createWithdrawTransaction(state.adjudicator, myAddress, myAddress, state.channelId, signature);
-      return states.waitForWithdrawalInitiation({ ...state, transactionOutbox });
+      console.log('addresses ', myAddress, action.destinationAddress);
+      const signature = signVerificationData(myAddress, action.destinationAddress, state.channelId, state.privateKey);
+      const transactionOutbox = createWithdrawTransaction(state.adjudicator, myAddress, action.destinationAddress, state.channelId, signature);
+      return states.waitForWithdrawalInitiation({ ...state, transactionOutbox, userAddress: action.destinationAddress });
     case actions.WITHDRAWAL_REJECTED:
       return states.acknowledgeCloseSuccess(state);
     default:

--- a/packages/wallet/src/states/shared.ts
+++ b/packages/wallet/src/states/shared.ts
@@ -56,6 +56,10 @@ export interface ChallengeExists extends AdjudicatorExists {
   challengeExpiry?: number;
 }
 
+export interface UserAddressExists extends AdjudicatorExists {
+  userAddress: string;
+}
+
 // creators
 export function base<T extends Base>(params: T): Base {
   const { messageOutbox, transactionOutbox, displayOutbox } = params;
@@ -92,4 +96,8 @@ export function adjudicatorExists<T extends AdjudicatorExists>(params: T): Adjud
 
 export function challengeExists<T extends ChallengeExists>(params: T): ChallengeExists {
   return { ...adjudicatorExists(params), challengeExpiry: params.challengeExpiry };
+}
+
+export function userAddressExists<T extends UserAddressExists>(params: T): UserAddressExists {
+  return { ...adjudicatorExists(params), userAddress: params.userAddress };
 }

--- a/packages/wallet/src/states/withdrawing.ts
+++ b/packages/wallet/src/states/withdrawing.ts
@@ -1,4 +1,4 @@
-import { AdjudicatorExists, adjudicatorExists, TransactionExists } from './shared';
+import { AdjudicatorExists, adjudicatorExists, TransactionExists, UserAddressExists, userAddressExists } from './shared';
 
 // stage
 export const WITHDRAWING = 'STAGE.WITHDRAWING';
@@ -10,7 +10,7 @@ export const WAIT_FOR_WITHDRAWAL_CONFIRMATION = 'WAIT_FOR_WITHDRAWAL_CONFIRMATIO
 export const ACKNOWLEDGE_WITHDRAWAL_SUCCESS = 'ACKNOWLEDGE_WITHDRAWAL_SUCCESS';
 export const WITHDRAW_TRANSACTION_FAILED = 'WITHDRAW_TRANSACTION_FAILED';
 
-export interface WithdrawTransactionFailed extends AdjudicatorExists {
+export interface WithdrawTransactionFailed extends UserAddressExists {
   type: typeof WITHDRAW_TRANSACTION_FAILED;
   stage: typeof WITHDRAWING;
 }
@@ -20,12 +20,12 @@ export interface ApproveWithdrawal extends AdjudicatorExists {
   stage: typeof WITHDRAWING;
 }
 
-export interface WaitForWithdrawalInitiation extends AdjudicatorExists {
+export interface WaitForWithdrawalInitiation extends UserAddressExists {
   type: typeof WAIT_FOR_WITHDRAWAL_INITIATION;
   stage: typeof WITHDRAWING;
 }
 
-export interface WaitForWithdrawalConfirmation extends AdjudicatorExists, TransactionExists {
+export interface WaitForWithdrawalConfirmation extends UserAddressExists, TransactionExists {
   type: typeof WAIT_FOR_WITHDRAWAL_CONFIRMATION;
   stage: typeof WITHDRAWING;
 }
@@ -39,20 +39,20 @@ export function approveWithdrawal<T extends AdjudicatorExists>(params: T): Appro
   return { ...adjudicatorExists(params), type: APPROVE_WITHDRAWAL, stage: WITHDRAWING };
 }
 
-export function waitForWithdrawalInitiation<T extends AdjudicatorExists>(params: T): WaitForWithdrawalInitiation {
-  return { ...adjudicatorExists(params), type: WAIT_FOR_WITHDRAWAL_INITIATION, stage: WITHDRAWING };
+export function waitForWithdrawalInitiation<T extends UserAddressExists>(params: T): WaitForWithdrawalInitiation {
+  return { ...userAddressExists(params), type: WAIT_FOR_WITHDRAWAL_INITIATION, stage: WITHDRAWING };
 }
 
-export function waitForWithdrawalConfirmation<T extends AdjudicatorExists & TransactionExists>(params: T): WaitForWithdrawalConfirmation {
-  return { ...adjudicatorExists(params), transactionHash: params.transactionHash, type: WAIT_FOR_WITHDRAWAL_CONFIRMATION, stage: WITHDRAWING };
+export function waitForWithdrawalConfirmation<T extends UserAddressExists & TransactionExists>(params: T): WaitForWithdrawalConfirmation {
+  return { ...userAddressExists(params), transactionHash: params.transactionHash, type: WAIT_FOR_WITHDRAWAL_CONFIRMATION, stage: WITHDRAWING };
 }
 
 export function acknowledgeWithdrawalSuccess<T extends AdjudicatorExists>(params: T): AcknowledgeWithdrawalSuccess {
   return { ...adjudicatorExists(params), type: ACKNOWLEDGE_WITHDRAWAL_SUCCESS, stage: WITHDRAWING };
 }
 
-export function withdrawTransactionFailed<T extends AdjudicatorExists>(params: T): WithdrawTransactionFailed {
-  return { type: WITHDRAW_TRANSACTION_FAILED, stage: WITHDRAWING, ...adjudicatorExists(params) };
+export function withdrawTransactionFailed<T extends UserAddressExists>(params: T): WithdrawTransactionFailed {
+  return { type: WITHDRAW_TRANSACTION_FAILED, stage: WITHDRAWING, ...userAddressExists(params) };
 }
 export type WithdrawingState = (
   | ApproveWithdrawal


### PR DESCRIPTION
Addresses #119.

We now withdraw to the user's current metamask address. We show the user this address and they can change their account before approving the withdraw.

![image](https://user-images.githubusercontent.com/1620336/52016003-43a49800-2498-11e9-9332-e4bf27fb81b9.png)
