### PR TITLE
Fix build path for ttt

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -10,7 +10,7 @@ steps:
 - name: gcr.io/cloud-builders/gsutil
   args: ["-m", "rsync", "-r", "-c", "-d", "./packages/rps/build", "gs://demo.magmo.com"]
 - name: gcr.io/cloud-builders/gsutil
-  args: ["-m", "rsync", "-r", "-c", "-d", "./packages/ttt/build", "gs://ttt.magmo.com"]
+  args: ["-m", "rsync", "-r", "-c", "-d", "./packages/tictactoe/build", "gs://ttt.magmo.com"]
 options:
  machineType: 'N1_HIGHCPU_8'
   


### PR DESCRIPTION
Fix the path to the build folder from `ttt` to `tictactoe`. 

We might want to rename the `tictactoe` package to `ttt` but for now I've just fixed `cloudbuild.yaml`, so the deploy can continue.