### PR TITLE
Move wallet to use 8503 for ganache for tests

### DIFF
--- a/packages/wallet/package.json
+++ b/packages/wallet/package.json
@@ -74,7 +74,7 @@
     "start": "node scripts/start.js",
     "build": "node scripts/build.js",
     "test": "run-s 'test:app --all'",
-    "test:ci": "DEV_GANACHE_PORT=8504 run-s build 'test:contracts --all --ci' 'test:app --all --ci --runInBand'",
+    "test:ci": "DEV_GANACHE_PORT=8503 run-s build 'test:contracts --all --ci' 'test:app --all --ci --runInBand'",
     "test:app": "npx run-jest -c ./config/jest/jest.config.js",
     "deployContracts": "npx deploy-contracts",
     "ganache:start": "npx start-ganache",


### PR DESCRIPTION
Change the wallet to use port 8503 to prevent issues with `circleCI`. We probably want a nicer fix for this in the future but this should help with the flickering tests for now.