### PR TITLE
Wait for iFrame to load

### DIFF
--- a/packages/rps/src/containers/SiteContainer.tsx
+++ b/packages/rps/src/containers/SiteContainer.tsx
@@ -11,12 +11,14 @@ import LoadingPage from '../components/LoadingPage';
 import { createWalletIFrame } from 'wallet-client';
 import { WALLET_IFRAME_ID, WALLET_URL } from '../constants';
 import LoginErrorPage from '../components/LoginErrorPage';
+import * as actions from '../redux/login/actions';
 interface SiteProps {
   isAuthenticated: boolean;
   metamaskError: MetamaskError | null;
   loginError: string | undefined;
   loading: boolean;
   walletVisible: boolean;
+  walletIFrameLoaded: () => void;
 }
 
 class Site extends React.PureComponent<SiteProps>{
@@ -27,6 +29,9 @@ class Site extends React.PureComponent<SiteProps>{
   }
   componentDidMount() {
     const walletIframe = createWalletIFrame(WALLET_IFRAME_ID, WALLET_URL);
+    walletIframe.addEventListener('load', () => {
+      this.props.walletIFrameLoaded();
+    });
     this.walletDiv.current.appendChild(walletIframe);
 
   }
@@ -64,7 +69,7 @@ class Site extends React.PureComponent<SiteProps>{
 }
 
 
-const mapStateToProps = (state: SiteState): SiteProps => {
+const mapStateToProps = (state: SiteState) => {
   return {
     isAuthenticated: state.login && state.login.loggedIn,
     loading: state.metamask.loading,
@@ -73,5 +78,7 @@ const mapStateToProps = (state: SiteState): SiteProps => {
     loginError: state.login.error,
   };
 };
-
-export default connect(mapStateToProps)(Site);
+const mapDispatchToProps = {
+  walletIFrameLoaded: actions.walletIframeLoaded,
+};
+export default connect(mapStateToProps, mapDispatchToProps)(Site);

--- a/packages/rps/src/redux/login/actions.ts
+++ b/packages/rps/src/redux/login/actions.ts
@@ -6,6 +6,12 @@ export const LOGIN_SUCCESS = 'LOGIN.SUCCESS';
 export const LOGIN_FAILURE = 'LOGIN.FAILURE';
 
 
+export const WALLET_IFRAME_LOADED = 'LOGIN.WALLET_IFRAME_LOADED';
+export const walletIframeLoaded = () => ({
+  type: WALLET_IFRAME_LOADED as typeof WALLET_IFRAME_LOADED,
+});
+export type WalletIframeLoaded = ReturnType<typeof walletIframeLoaded>;
+
 export const INITIALIZE_WALLET_SUCCESS = 'LOGIN.INITIALIZE_WALLET_SUCCESS';
 export const initializeWalletSuccess = (address: string) => ({
   type: INITIALIZE_WALLET_SUCCESS as typeof INITIALIZE_WALLET_SUCCESS,

--- a/packages/rps/src/redux/login/saga.ts
+++ b/packages/rps/src/redux/login/saga.ts
@@ -35,7 +35,6 @@ function* loginStatusWatcherSaga() {
     const { user } = yield take(channel);
 
     if (user) {
-      // TODO: pass uid to wallet
       const libraryAddress = yield getLibraryAddress();
       if (!libraryAddress) {
         yield put(loginActions.loginFailure(`Could not find the deployed game library for the ${process.env.TARGET_NETWORK} network.`));

--- a/packages/rps/src/redux/login/saga.ts
+++ b/packages/rps/src/redux/login/saga.ts
@@ -52,6 +52,7 @@ function* loginStatusWatcherSaga() {
 }
 
 export default function* loginRootSaga() {
+  yield take(loginActions.WALLET_IFRAME_LOADED);
   const metaMask = yield metamaskSaga();
 
   // If metamask is not properly set up we can halt processing and wait for the reload

--- a/packages/tictactoe/src/containers/SiteContainer.tsx
+++ b/packages/tictactoe/src/containers/SiteContainer.tsx
@@ -11,12 +11,14 @@ import LoadingPage from '../components/LoadingPage';
 import { createWalletIFrame } from 'wallet-client';
 import { WALLET_IFRAME_ID, WALLET_URL } from '../constants';
 import LoginErrorPage from '../components/LoginErrorPage';
+import * as actions from '../redux/login/actions';
 interface SiteProps {
   isAuthenticated: boolean;
   metamaskError: MetamaskError | null;
   loginError: string | undefined;
   loading: boolean;
   walletVisible: boolean;
+  walletIFrameLoaded: () => void;
 }
 
 class Site extends React.PureComponent<SiteProps>{
@@ -27,6 +29,9 @@ class Site extends React.PureComponent<SiteProps>{
   }
   componentDidMount() {
     const walletIframe = createWalletIFrame(WALLET_IFRAME_ID, WALLET_URL);
+    walletIframe.addEventListener('load', () => {
+      this.props.walletIFrameLoaded();
+    });
     this.walletDiv.current.appendChild(walletIframe);
 
   }
@@ -62,7 +67,8 @@ class Site extends React.PureComponent<SiteProps>{
   }
 }
 
-const mapStateToProps = (state: SiteState): SiteProps => {
+
+const mapStateToProps = (state: SiteState) => {
   return {
     isAuthenticated: state.login && state.login.loggedIn,
     loading: state.metamask.loading,
@@ -71,5 +77,7 @@ const mapStateToProps = (state: SiteState): SiteProps => {
     loginError: state.login.error,
   };
 };
-
-export default connect(mapStateToProps)(Site);
+const mapDispatchToProps = {
+  walletIFrameLoaded: actions.walletIframeLoaded,
+};
+export default connect(mapStateToProps, mapDispatchToProps)(Site);

--- a/packages/tictactoe/src/redux/login/actions.ts
+++ b/packages/tictactoe/src/redux/login/actions.ts
@@ -6,6 +6,11 @@ export const LOGIN_SUCCESS = 'LOGIN.SUCCESS';
 export const LOGIN_FAILURE = 'LOGIN.FAILURE';
 
 
+export const WALLET_IFRAME_LOADED = 'LOGIN.WALLET_IFRAME_LOADED';
+export const walletIframeLoaded = () => ({
+  type: WALLET_IFRAME_LOADED as typeof WALLET_IFRAME_LOADED,
+});
+export type WalletIframeLoaded = ReturnType<typeof walletIframeLoaded>;
 export const INITIALIZE_WALLET_SUCCESS = 'LOGIN.INITIALIZE_WALLET_SUCCESS';
 export const initializeWalletSuccess = (address: string) => ({
   type: INITIALIZE_WALLET_SUCCESS as typeof INITIALIZE_WALLET_SUCCESS,

--- a/packages/tictactoe/src/redux/login/saga.ts
+++ b/packages/tictactoe/src/redux/login/saga.ts
@@ -35,7 +35,6 @@ function* loginStatusWatcherSaga() {
     const { user } = yield take(channel);
 
     if (user) {
-      // TODO: pass uid to wallet
       const libraryAddress = yield getLibraryAddress();
       if (!libraryAddress) {
         yield put(loginActions.loginFailure(`Could not find the deployed game library for the ${process.env.TARGET_NETWORK} network.`));

--- a/packages/tictactoe/src/redux/login/saga.ts
+++ b/packages/tictactoe/src/redux/login/saga.ts
@@ -52,6 +52,7 @@ function* loginStatusWatcherSaga() {
 }
 
 export default function* loginRootSaga() {
+  yield take(loginActions.WALLET_IFRAME_LOADED);
   const metaMask = yield metamaskSaga();
 
   // If metamask is not properly set up we can halt processing and wait for the reload


### PR DESCRIPTION
Fixes #170 .

Ideally I think the `wallet-client` library would wait for the iFrame to load but that would change the `createWalletIframe` function into an `async` function which makes it more awkward to integrate into a react component.