### PR TITLE
Properly exit case statement if its not message we expect

### DIFF
--- a/packages/rps/config/webpack.config.js
+++ b/packages/rps/config/webpack.config.js
@@ -522,6 +522,7 @@ module.exports = function (webpackEnv) {
         async: false,
         checkSyntacticErrors: true,
         tsconfig: paths.appTsConfig,
+        tslint: true,
         compilerOptions: {
           module: 'esnext',
           moduleResolution: 'node',

--- a/packages/rps/src/__stories__/index.tsx
+++ b/packages/rps/src/__stories__/index.tsx
@@ -166,5 +166,5 @@ storiesOf("Game Opening", module)
   .add("Game Proposed", testState(gameProposed))
   .add("Confirm Game", testState(confirmGame));
 
-storiesOf("Game Screens", module)
-storiesOf("Game Over", module)
+storiesOf("Game Screens", module);
+storiesOf("Game Over", module);

--- a/packages/rps/src/containers/SiteContainer.tsx
+++ b/packages/rps/src/containers/SiteContainer.tsx
@@ -36,7 +36,7 @@ class Site extends React.PureComponent<SiteProps>{
     if (this.props.loading) {
       component = <LoadingPage />;
     } else if (this.props.loginError) {
-      component = <LoginErrorPage error={this.props.loginError} />
+      component = <LoginErrorPage error={this.props.loginError} />;
 
     } else if (this.props.metamaskError !== null) {
       component = <MetamaskErrorPage error={this.props.metamaskError} />;

--- a/packages/rps/tslint.json
+++ b/packages/rps/tslint.json
@@ -22,9 +22,14 @@
     "ordered-imports": false,
     "jsx-no-lambda": false,
     "interface-name": false,
-    "trailing-comma": [true, {"multiline":{"objects": "always"}}],
+    "trailing-comma": [true, {
+      "multiline": {
+        "objects": "always"
+      }
+    }],
     "max-classes-per-file": false,
     "variable-name": [true, "ban-keywords", "check-format", "allow-pascal-case", "allow-leading-underscore"],
-    "semicolon": [true, "always"]
+    "semicolon": [true, "always"],
+    "no-switch-case-fall-through": true
   }
 }

--- a/packages/tictactoe/config/webpack.config.js
+++ b/packages/tictactoe/config/webpack.config.js
@@ -417,7 +417,7 @@ module.exports = function (webpackEnv) {
         }),
       new webpack.EnvironmentPlugin({
         FIREBASE_PROJECT: isEnvProduction ? 'tic-tac-toe123' : 'tic-tac-toe-dev-3a21f',
-        FIREBASE_API_KEY: isEnvProduction ? 'AIzaSyBLmBfruupmeMDfE0YKPIqKps0fp3aMg94' : 'AIzaSyAFlVSCTROvaGr4HcrnjpFhBGSkEMklcb8',        
+        FIREBASE_API_KEY: isEnvProduction ? 'AIzaSyBLmBfruupmeMDfE0YKPIqKps0fp3aMg94' : 'AIzaSyAFlVSCTROvaGr4HcrnjpFhBGSkEMklcb8',
         TARGET_NETWORK: process.env.TARGET_NETWORK,
         WALLET_URL: isEnvProduction ? 'https://wallet.magmo.com' : 'http://localhost:3000',
       }),
@@ -522,6 +522,7 @@ module.exports = function (webpackEnv) {
         async: false,
         checkSyntacticErrors: true,
         tsconfig: paths.appTsConfig,
+        tslint: true,
         compilerOptions: {
           module: 'esnext',
           moduleResolution: 'node',

--- a/packages/tictactoe/src/containers/SiteContainer.tsx
+++ b/packages/tictactoe/src/containers/SiteContainer.tsx
@@ -36,7 +36,7 @@ class Site extends React.PureComponent<SiteProps>{
     if (this.props.loading) {
       component = <LoadingPage />;
     } else if (this.props.loginError) {
-      component = <LoginErrorPage error={this.props.loginError} />
+      component = <LoginErrorPage error={this.props.loginError} />;
     } else if (this.props.metamaskError !== null) {
       component = <MetamaskErrorPage error={this.props.metamaskError} />;
     } else if (this.props.isAuthenticated) {

--- a/packages/tictactoe/tslint.json
+++ b/packages/tictactoe/tslint.json
@@ -22,10 +22,15 @@
     "ordered-imports": false,
     "jsx-no-lambda": false,
     "interface-name": false,
-    "trailing-comma": [true, {"multiline":{"objects": "always"}}],
+    "trailing-comma": [true, {
+      "multiline": {
+        "objects": "always"
+      }
+    }],
     "max-classes-per-file": false,
     "variable-name": [true, "ban-keywords", "check-format", "allow-pascal-case", "allow-leading-underscore"],
     "semicolon": [true, "always"],
-    "no-bitwise": false
+    "no-bitwise": false,
+    "no-switch-case-fall-through": true
   }
 }

--- a/packages/wallet/config/webpack.config.js
+++ b/packages/wallet/config/webpack.config.js
@@ -521,6 +521,7 @@ module.exports = function (webpackEnv) {
         async: false,
         checkSyntacticErrors: true,
         tsconfig: paths.appTsConfig,
+        tslint: true,
         compilerOptions: {
           module: 'esnext',
           moduleResolution: 'node',

--- a/packages/wallet/src/redux/reducers/__tests__/closing.test.ts
+++ b/packages/wallet/src/redux/reducers/__tests__/closing.test.ts
@@ -6,7 +6,7 @@ import * as outgoing from 'wallet-client/lib/wallet-events';
 import * as TransactionGenerator from '../../../utils/transaction-generator';
 import * as SigningUtils from '../../../utils/signing-utils';
 import * as scenarios from './test-scenarios';
-import { itTransitionsToStateType } from './helpers';
+import { itTransitionsToStateType, itDoesntTransition } from './helpers';
 
 const {
   asAddress,
@@ -151,6 +151,15 @@ describe('start in ApproveCloseOnChain', () => {
     const action = actions.messageReceived('CloseStarted', '0x0');
     const updatedState = walletReducer(state, action);
     itTransitionsToStateType(states.WAIT_FOR_OPPONENT_CLOSE, updatedState);
+  });
+
+  describe('action taken: opponent sends incorrect message', () => {
+    const validateSignatureMock = jest.fn();
+    validateSignatureMock.mockReturnValue(true);
+    Object.defineProperty(SigningUtils, 'validSignature', { value: validateSignatureMock });
+    const action = actions.messageReceived('WRONG MESSAGE', '0x0');
+    const updatedState = walletReducer(state, action);
+    itDoesntTransition(state, updatedState);
   });
 
 });

--- a/packages/wallet/src/redux/reducers/__tests__/withdrawing.test.ts
+++ b/packages/wallet/src/redux/reducers/__tests__/withdrawing.test.ts
@@ -33,7 +33,7 @@ const defaults = {
   privateKey: asPrivateKey,
   networkId: 23213,
   transactionHash: '0x0',
-  userAddress: '0x0'
+  userAddress: '0x0',
 };
 
 

--- a/packages/wallet/src/redux/reducers/challenging.ts
+++ b/packages/wallet/src/redux/reducers/challenging.ts
@@ -114,7 +114,8 @@ const waitForResponseOrTimeoutReducer = (state: states.WaitForResponseOrTimeout,
     case actions.BLOCK_MINED:
       if (typeof state.challengeExpiry !== 'undefined' && action.block.timestamp >= state.challengeExpiry) {
         return states.acknowledgeChallengeTimeout({ ...state });
-      }
+      } else { return state; }
+
     default:
       return state;
   }

--- a/packages/wallet/src/redux/reducers/closing.ts
+++ b/packages/wallet/src/redux/reducers/closing.ts
@@ -156,6 +156,7 @@ const approveCloseOnChainReducer = (state: states.ApproveCloseOnChain, action: a
       if (action.data === 'CloseStarted' && validSignature(action.data, action.signature || '0x0', opponentAddress)) {
         return states.waitForOpponentClose(state);
       }
+      break;
     case actions.GAME_CONCLUDED_EVENT:
       return states.approveWithdrawal(state);
   }

--- a/packages/wallet/src/redux/reducers/funding.ts
+++ b/packages/wallet/src/redux/reducers/funding.ts
@@ -152,6 +152,8 @@ const approveFundingReducer = (state: states.ApproveFunding, action: actions.Wal
             ...state,
             adjudicator: action.data,
           });
+        }else{
+          return state;
         }
       }
     default:

--- a/packages/wallet/src/redux/reducers/responding.ts
+++ b/packages/wallet/src/redux/reducers/responding.ts
@@ -62,6 +62,8 @@ export const acknowledgeChallengeReducer = (state: states.AcknowledgeChallenge, 
     case actions.BLOCK_MINED:
       if (typeof state.challengeExpiry !== 'undefined' && action.block.timestamp >= state.challengeExpiry) {
         return challengeStates.acknowledgeChallengeTimeout({ ...state });
+      }else{
+        return state;
       }
     default:
       return state;
@@ -84,6 +86,8 @@ export const chooseResponseReducer = (state: states.ChooseResponse, action: Wall
     case actions.BLOCK_MINED:
       if (typeof state.challengeExpiry !== 'undefined' && action.block.timestamp >= state.challengeExpiry) {
         return challengeStates.acknowledgeChallengeTimeout({ ...state });
+      }else{
+        return state;
       }
     default:
       return state;
@@ -115,6 +119,8 @@ export const takeMoveInAppReducer = (state: states.TakeMoveInApp, action: Wallet
     case actions.BLOCK_MINED:
       if (typeof state.challengeExpiry !== 'undefined' && action.block.timestamp >= state.challengeExpiry) {
         return challengeStates.acknowledgeChallengeTimeout({ ...state });
+      }else{
+        return state;
       }
     default:
       return state;

--- a/packages/wallet/tslint.json
+++ b/packages/wallet/tslint.json
@@ -22,9 +22,14 @@
     "ordered-imports": false,
     "jsx-no-lambda": false,
     "interface-name": false,
-    "trailing-comma": [true, {"multiline":{"objects": "always"}}],
+    "trailing-comma": [true, {
+      "multiline": {
+        "objects": "always"
+      }
+    }],
     "max-classes-per-file": false,
     "variable-name": [true, "ban-keywords", "check-format", "allow-pascal-case", "allow-leading-underscore"],
-    "semicolon": [true, "always"]
+    "semicolon": [true, "always"],
+    "no-switch-case-fall-through": true
   }
 }


### PR DESCRIPTION
Fixes #176.

The bot was sending a message that we didn't expect and since we lacked the `break` we would cascade into the next case statement and transition to the wrong state.