### PR TITLE
Allow the wallet to be initialized repeatedly before a channel is open

### DIFF
--- a/packages/wallet/src/redux/reducers/__tests__/opening.test.ts
+++ b/packages/wallet/src/redux/reducers/__tests__/opening.test.ts
@@ -31,6 +31,13 @@ const defaults = {
 };
 
 describe('when in WaitForChannel', () => {
+  describe("when another user logs in ", () => {
+    const state = states.waitForChannel(defaults);
+    const action = actions.loggedIn(defaults.uid);
+    const updatedState = walletReducer(state, action);
+    itTransitionsToStateType(states.WAIT_FOR_ADDRESS, updatedState);
+  });
+
   describe('when we send in a PreFundSetupA', () => { // preFundSetupA is A's move, so in this case we need to be player A
     const state = states.waitForChannel(defaults);
     const action = actions.ownPositionReceived(preFundSetupAHex);

--- a/packages/wallet/src/redux/reducers/opening.ts
+++ b/packages/wallet/src/redux/reducers/opening.ts
@@ -22,6 +22,9 @@ export const openingReducer = (state: states.OpeningState, action: actions.Walle
 
 const waitForChannelReducer = (state: states.WaitForChannel, action: actions.WalletAction) => {
   switch (action.type) {
+    case actions.LOGGED_IN:
+      const { uid } = action;
+      return states.waitForAddress({ ...state, uid });
     case actions.OWN_POSITION_RECEIVED:
       const data = action.data;
       const ownPosition = decode(data);


### PR DESCRIPTION
Fixes #181.

The wallet can now be initialized multiple times before channel is open. This allows the wallet to be initialized for a different user before being used.