### PR TITLE
shifting imperatives by 2

### DIFF
--- a/packages/tictactoe/src/core/results.ts
+++ b/packages/tictactoe/src/core/results.ts
@@ -23,8 +23,8 @@ export enum AbsoluteResult {
 }
 
 export enum Imperative {
-  Choose = 3,
-  Wait = 4,
+  Choose = 5,
+  Wait = 6,
 }
 
 


### PR DESCRIPTION
without this, you will see "Game Over!" instead of "Choose Move" or "Wait for opponent" in the bottom status bar.