### PR TITLE
Handle challenge expiry when trying to respond

### DIFF
--- a/packages/wallet/src/redux/reducers/__tests__/responding.test.ts
+++ b/packages/wallet/src/redux/reducers/__tests__/responding.test.ts
@@ -120,6 +120,11 @@ describe('when in INITIATE_RESPONSE', () => {
     itTransitionsToStateType(states.WAIT_FOR_RESPONSE_SUBMISSION, updatedState);
 
   });
+  describe('when the challenge times out', () => {
+    const action = actions.blockMined({ number: 1, timestamp: 2 });
+    const updatedState = walletReducer(state, action);
+    itTransitionsToStateType(states.ACKNOWLEDGE_CHALLENGE_TIMEOUT, updatedState);
+  });
 });
 
 describe('when in WAIT_FOR_RESPONSE_SUBMISSION', () => {
@@ -134,6 +139,11 @@ describe('when in WAIT_FOR_RESPONSE_SUBMISSION', () => {
     const updatedState = walletReducer(state, action);
     itTransitionsToStateType(states.RESPONSE_TRANSACTION_FAILED, updatedState);
   });
+  describe('when the challenge times out', () => {
+    const action = actions.blockMined({ number: 1, timestamp: 2 });
+    const updatedState = walletReducer(state, action);
+    itTransitionsToStateType(states.ACKNOWLEDGE_CHALLENGE_TIMEOUT, updatedState);
+  });
 });
 
 describe('when in WAIT_FOR_RESPONSE_CONFIRMED', () => {
@@ -142,7 +152,11 @@ describe('when in WAIT_FOR_RESPONSE_CONFIRMED', () => {
     const action = actions.transactionConfirmed();
     const updatedState = walletReducer(state, action);
     itTransitionsToStateType(states.ACKNOWLEDGE_CHALLENGE_COMPLETE, updatedState);
-
+  });
+  describe('when the challenge times out', () => {
+    const action = actions.blockMined({ number: 1, timestamp: 2 });
+    const updatedState = walletReducer(state, action);
+    itTransitionsToStateType(states.ACKNOWLEDGE_CHALLENGE_TIMEOUT, updatedState);
   });
 });
 
@@ -166,5 +180,10 @@ describe('when in RESPONSE_TRANSACTION_FAILED', () => {
     itTransitionsToStateType(states.INITIATE_RESPONSE, updatedState);
     expect(createRespondTxMock.mock.calls.length).toBe(1);
 
+  });
+  describe('when the challenge times out', () => {
+    const action = actions.blockMined({ number: 1, timestamp: 2 });
+    const updatedState = walletReducer(state, action);
+    itTransitionsToStateType(states.ACKNOWLEDGE_CHALLENGE_TIMEOUT, updatedState);
   });
 });

--- a/packages/wallet/src/redux/reducers/responding.ts
+++ b/packages/wallet/src/redux/reducers/responding.ts
@@ -50,6 +50,12 @@ const responseTransactionFailedReducer = (state: states.ResponseTransactionFaile
         ...state,
         transactionOutbox: transaction,
       });
+    case actions.BLOCK_MINED:
+      if (typeof state.challengeExpiry !== 'undefined' && action.block.timestamp >= state.challengeExpiry) {
+        return challengeStates.acknowledgeChallengeTimeout({ ...state });
+      } else {
+        return state;
+      }
   }
   return state;
 };
@@ -62,7 +68,7 @@ export const acknowledgeChallengeReducer = (state: states.AcknowledgeChallenge, 
     case actions.BLOCK_MINED:
       if (typeof state.challengeExpiry !== 'undefined' && action.block.timestamp >= state.challengeExpiry) {
         return challengeStates.acknowledgeChallengeTimeout({ ...state });
-      }else{
+      } else {
         return state;
       }
     default:
@@ -86,7 +92,7 @@ export const chooseResponseReducer = (state: states.ChooseResponse, action: Wall
     case actions.BLOCK_MINED:
       if (typeof state.challengeExpiry !== 'undefined' && action.block.timestamp >= state.challengeExpiry) {
         return challengeStates.acknowledgeChallengeTimeout({ ...state });
-      }else{
+      } else {
         return state;
       }
     default:
@@ -119,7 +125,7 @@ export const takeMoveInAppReducer = (state: states.TakeMoveInApp, action: Wallet
     case actions.BLOCK_MINED:
       if (typeof state.challengeExpiry !== 'undefined' && action.block.timestamp >= state.challengeExpiry) {
         return challengeStates.acknowledgeChallengeTimeout({ ...state });
-      }else{
+      } else {
         return state;
       }
     default:
@@ -131,6 +137,12 @@ export const initiateResponseReducer = (state: states.InitiateResponse, action: 
   switch (action.type) {
     case actions.TRANSACTION_SENT_TO_METAMASK:
       return states.waitForResponseSubmission(state);
+    case actions.BLOCK_MINED:
+      if (typeof state.challengeExpiry !== 'undefined' && action.block.timestamp >= state.challengeExpiry) {
+        return challengeStates.acknowledgeChallengeTimeout({ ...state });
+      } else {
+        return state;
+      }
     default:
       return state;
   }
@@ -143,6 +155,12 @@ export const waitForResponseSubmissionReducer = (state: states.WaitForResponseSu
       return states.waitForResponseConfirmation({ ...state, transactionHash: action.transactionHash });
     case actions.TRANSACTION_SUBMISSION_FAILED:
       return states.responseTransactionFailed(state);
+    case actions.BLOCK_MINED:
+      if (typeof state.challengeExpiry !== 'undefined' && action.block.timestamp >= state.challengeExpiry) {
+        return challengeStates.acknowledgeChallengeTimeout({ ...state });
+      } else {
+        return state;
+      }
     default:
       return state;
   }
@@ -150,6 +168,12 @@ export const waitForResponseSubmissionReducer = (state: states.WaitForResponseSu
 
 export const waitForResponseConfirmationReducer = (state: states.WaitForResponseConfirmation, action: WalletAction): WalletState => {
   switch (action.type) {
+    case actions.BLOCK_MINED:
+      if (typeof state.challengeExpiry !== 'undefined' && action.block.timestamp >= state.challengeExpiry) {
+        return challengeStates.acknowledgeChallengeTimeout({ ...state });
+      } else {
+        return state;
+      }
     case actions.TRANSACTION_CONFIRMED:
       return states.acknowledgeChallengeComplete(state);
     default:


### PR DESCRIPTION
Partially fixes #200.

We now handle a `BLOCK_MINED` action when submitting a response transaction or when a response transaction fails.

Ideally we should be able to tell by the metamask failure why the  the transaction failed and alert the user that the challenge has expired. Unfortunately  the  errors that come back from metamask isn't very informative, and seems to differ between the beta version and the regular version.