### PR TITLE
fix storybook by embedding channel states in a wallet state

### DIFF
--- a/packages/wallet/src/__stories__/index.tsx
+++ b/packages/wallet/src/__stories__/index.tsx
@@ -1,12 +1,13 @@
 import React from 'react';
 import { storiesOf } from '@storybook/react';
-import Wallet from '../containers/Wallet';
+import WalletContainer from '../containers/Wallet';
 import { Provider } from 'react-redux';
 import * as walletStates from '../redux/states';
 import * as channelStates from '../redux/states/channels';
 import '../index.scss';
 import * as scenarios from '../redux/reducers/__tests__/test-scenarios';
 import { bigNumberify } from 'ethers/utils';
+import NetworkStatus from '../components/NetworkStatus';
 
 const {
   asAddress,
@@ -84,228 +85,190 @@ function walletStateFromChannelState<T extends channelStates.ChannelState>(
   };
 }
 
-const testState = state => () => (
-  <Provider store={fakeStore(state)}>
-    <Wallet />
+const channelStateRender = channelState => () => (
+  <Provider store={fakeStore(walletStateFromChannelState(channelState))}>
+    <WalletContainer />
   </Provider>
 );
 
 storiesOf('Network Status', module)
   .add(
     'Mainnet',
-    testState(walletStateFromChannelState(channelStates.approveFunding({ ...playerADefaults }), 1)),
-  )
+    () => (
+      <Provider store={fakeStore({networkId: 1})}>
+        <NetworkStatus />
+      </Provider>))
   .add(
     'Kovan',
-    testState(
-      walletStateFromChannelState(channelStates.approveFunding({ ...playerADefaults }), 42),
-    ),
-  )
+    () => (
+      <Provider store={fakeStore({networkId: 42})}>
+        <NetworkStatus />
+      </Provider>))
   .add(
     'Ropsten',
-    testState(walletStateFromChannelState(channelStates.approveFunding({ ...playerADefaults }), 3)),
-  )
+    () => (
+      <Provider store={fakeStore({networkId: 3})}>
+        <NetworkStatus />
+      </Provider>))
   .add(
     'Rinkeby',
-    testState(walletStateFromChannelState(channelStates.approveFunding({ ...playerADefaults }), 4)),
-  )
+    () => (
+      <Provider store={fakeStore({networkId: 4})}>
+        <NetworkStatus />
+      </Provider>))
   .add(
     'Ganache',
-    testState(
-      walletStateFromChannelState(channelStates.approveFunding({ ...playerADefaults }), 5777),
-    ),
+    () => (
+      <Provider store={fakeStore({networkId: 5777})}>
+        <NetworkStatus />
+      </Provider>)
   );
+  
 storiesOf('Wallet Screens / Funding / Player A', module)
   .add(
     'ApproveFunding',
-    testState(walletStateFromChannelState(channelStates.approveFunding(playerADefaults))),
-  )
+   channelStateRender(channelStates.approveFunding(playerADefaults)))
   .add(
     'AWaitForDepositToBeSentToMetaMask',
-    testState(
-      walletStateFromChannelState(channelStates.aWaitForDepositToBeSentToMetaMask(playerADefaults)),
-    ),
-  )
+   channelStateRender(
+      (channelStates.aWaitForDepositToBeSentToMetaMask(playerADefaults))))
   .add(
     'ASubmitDepositInMetaMask',
-    testState(walletStateFromChannelState(channelStates.aSubmitDepositInMetaMask(playerADefaults))),
-  )
+   channelStateRender(channelStates.aSubmitDepositInMetaMask(playerADefaults)))
   .add(
     'AWaitForDepositConfirmation',
-    testState(
-      walletStateFromChannelState(channelStates.aWaitForDepositConfirmation(playerADefaults)),
-    ),
-  )
+   channelStateRender(
+      (channelStates.aWaitForDepositConfirmation(playerADefaults))))
   .add(
     'AWaitForOpponentDeposit',
-    testState(walletStateFromChannelState(channelStates.aWaitForOpponentDeposit(playerADefaults))),
-  )
+   channelStateRender(channelStates.aWaitForOpponentDeposit(playerADefaults)))
   .add(
     'AWaitForPostFundSetup',
-    testState(walletStateFromChannelState(channelStates.aWaitForPostFundSetup(playerADefaults))),
-  )
+   channelStateRender(channelStates.aWaitForPostFundSetup(playerADefaults)))
   .add(
     'AcknowledgeFundingSuccess',
-    testState(
-      walletStateFromChannelState(channelStates.acknowledgeFundingSuccess(playerADefaults)),
+   channelStateRender(
+      (channelStates.acknowledgeFundingSuccess(playerADefaults)),
     ),
   );
 
 storiesOf('Wallet Screens / Funding / Player B', module)
   .add(
     'ApproveFunding',
-    testState(walletStateFromChannelState(channelStates.approveFunding(playerBDefaults))),
-  )
+   channelStateRender(channelStates.approveFunding(playerBDefaults)))
   .add(
     'BWaitForOpponentDeposit',
-    testState(walletStateFromChannelState(channelStates.bWaitForOpponentDeposit(playerBDefaults))),
-  )
+   channelStateRender(channelStates.bWaitForOpponentDeposit(playerBDefaults)))
   .add(
     'BWaitForDepositToBeSentToMetaMask',
-    testState(
-      walletStateFromChannelState(channelStates.bWaitForDepositToBeSentToMetaMask(playerBDefaults)),
-    ),
-  )
+   channelStateRender(
+    channelStates.bWaitForDepositToBeSentToMetaMask(playerBDefaults)))
   .add(
     'BSubmitDepositInMetaMask',
-    testState(walletStateFromChannelState(channelStates.bSubmitDepositInMetaMask(playerBDefaults))),
-  )
+   channelStateRender(channelStates.bSubmitDepositInMetaMask(playerBDefaults)))
   .add(
     'BWaitForDepositConfirmation',
-    testState(
-      walletStateFromChannelState(channelStates.bWaitForDepositConfirmation(playerBDefaults)),
-    ),
-  )
+   channelStateRender(
+      (channelStates.bWaitForDepositConfirmation(playerBDefaults))))
   .add(
     'BWaitForPostFundSetup',
-    testState(walletStateFromChannelState(channelStates.bWaitForPostFundSetup(playerBDefaults))),
-  )
+   channelStateRender(channelStates.bWaitForPostFundSetup(playerBDefaults)))
   .add(
     'AcknowledgeFundingSuccess',
-    testState(
-      walletStateFromChannelState(channelStates.acknowledgeFundingSuccess(playerBDefaults)),
-    ),
+   channelStateRender(
+      (channelStates.acknowledgeFundingSuccess(playerBDefaults)))
   );
 
 storiesOf('Wallet Screens / Withdrawing', module)
   .add(
     'ApproveWithdrawal',
-    testState(walletStateFromChannelState(channelStates.approveWithdrawal(playerADefaults))),
-  )
+   channelStateRender(channelStates.approveWithdrawal(playerADefaults)))
   .add(
     'WaitForWithdrawalInitiation',
-    testState(
-      walletStateFromChannelState(channelStates.waitForWithdrawalInitiation(playerADefaults)),
-    ),
-  )
+   channelStateRender(
+      (channelStates.waitForWithdrawalInitiation(playerADefaults))))
   .add(
     'WaitForWithdrawalConfirmation',
-    testState(
-      walletStateFromChannelState(channelStates.waitForWithdrawalConfirmation(playerADefaults)),
-    ),
-  )
+   channelStateRender(
+      (channelStates.waitForWithdrawalConfirmation(playerADefaults))))
   .add(
     'AcknowledgeWithdrawalSuccess',
-    testState(
-      walletStateFromChannelState(channelStates.acknowledgeWithdrawalSuccess(playerADefaults)),
-    ),
+   channelStateRender(
+      (channelStates.acknowledgeWithdrawalSuccess(playerADefaults)))
   );
+
 
 storiesOf('Wallet Screens / Challenging', module)
   .add(
     'ApproveChallenge',
-    testState(walletStateFromChannelState(channelStates.approveChallenge(playerADefaults))),
-  )
+   channelStateRender(channelStates.approveChallenge(playerADefaults)))
   .add(
     'WaitForChallengeInitiation',
-    testState(
-      walletStateFromChannelState(channelStates.waitForChallengeInitiation(playerADefaults)),
-    ),
-  )
+   channelStateRender(
+      (channelStates.waitForChallengeInitiation(playerADefaults))))
   .add(
     'WaitForChallengeSubmission',
-    testState(
-      walletStateFromChannelState(channelStates.waitForChallengeSubmission(playerADefaults)),
-    ),
-  )
+   channelStateRender(
+      (channelStates.waitForChallengeSubmission(playerADefaults))))
   .add(
     'WaitForChallengeConfirmation',
-    testState(
-      walletStateFromChannelState(channelStates.waitForChallengeConfirmation(playerADefaults)),
-    ),
-  )
+   channelStateRender(
+      (channelStates.waitForChallengeConfirmation(playerADefaults))))
   .add(
     'WaitForResponseOrTimeout',
-    testState(walletStateFromChannelState(channelStates.waitForResponseOrTimeout(playerADefaults))),
-  )
+   channelStateRender(channelStates.waitForResponseOrTimeout(playerADefaults)))
   .add(
     'AcknowledgeChallengeResponse',
-    testState(
-      walletStateFromChannelState(channelStates.acknowledgeChallengeResponse(playerADefaults)),
-    ),
-  )
+   channelStateRender(
+      (channelStates.acknowledgeChallengeResponse(playerADefaults))))
   .add(
     'AcknowledgeChallengeTimeout',
-    testState(
-      walletStateFromChannelState(channelStates.acknowledgeChallengeTimeout(playerADefaults)),
-    ),
+   channelStateRender(
+      (channelStates.acknowledgeChallengeTimeout(playerADefaults)))
   );
 
 storiesOf('Wallet Screens / Responding', module)
   .add(
     'ChooseResponse',
-    testState(walletStateFromChannelState(channelStates.chooseResponse(playerADefaults))),
-  )
+   channelStateRender(channelStates.chooseResponse(playerADefaults)))
   .add(
     'AcknowledgeChallengeTimeout',
-    testState(
-      walletStateFromChannelState(
-        channelStates.challengeeAcknowledgeChallengeTimeOut(playerADefaults),
-      ),
-    ),
-  )
+   channelStateRender(
+    channelStates.challengeeAcknowledgeChallengeTimeOut(playerADefaults)))
   .add(
     'TakeMoveInApp',
-    testState(walletStateFromChannelState(channelStates.takeMoveInApp(playerADefaults))),
-  )
+   channelStateRender(channelStates.takeMoveInApp(playerADefaults)))
   .add(
     'InitiateResponse',
-    testState(walletStateFromChannelState(channelStates.initiateResponse(playerADefaults))),
-  )
+   channelStateRender(channelStates.initiateResponse(playerADefaults)))
   .add(
     'WaitForResponseSubmission',
-    testState(
-      walletStateFromChannelState(channelStates.waitForResponseSubmission(playerADefaults)),
-    ),
-  )
+   channelStateRender(
+      (channelStates.waitForResponseSubmission(playerADefaults))))
   .add(
     'WaitForResponseConfirmation',
-    testState(
-      walletStateFromChannelState(channelStates.waitForResponseConfirmation(playerADefaults)),
-    ),
-  )
+   channelStateRender(
+      (channelStates.waitForResponseConfirmation(playerADefaults))))
   .add(
     'AcknowledgeChallengeComplete',
-    testState(
-      walletStateFromChannelState(channelStates.acknowledgeChallengeComplete(playerADefaults)),
+   channelStateRender(
+      (channelStates.acknowledgeChallengeComplete(playerADefaults)),
     ),
   );
 
 storiesOf('Wallet Screens / Closing', module)
   .add(
     'ApproveConclude',
-    testState(walletStateFromChannelState(channelStates.approveConclude(playerADefaults))),
-  )
+   channelStateRender(channelStates.approveConclude(playerADefaults)))
   .add(
     'WaitForOpponentConclude',
-    testState(walletStateFromChannelState(channelStates.waitForOpponentConclude(playerADefaults))),
-  )
+   channelStateRender(channelStates.waitForOpponentConclude(playerADefaults)))
   .add(
     'AcknowledgeConcludeSuccess',
-    testState(walletStateFromChannelState(channelStates.approveCloseOnChain(playerADefaults))),
+   channelStateRender(channelStates.approveCloseOnChain(playerADefaults))
   );
 
 storiesOf('Wallet Landing Page', module).add(
   'Landing Page',
-  testState(walletStates.waitForLogin({ outboxState: {} })),
+ channelStateRender(walletStates.waitForLogin({ outboxState: {} })),
 );

--- a/packages/wallet/src/__stories__/index.tsx
+++ b/packages/wallet/src/__stories__/index.tsx
@@ -92,183 +92,161 @@ const channelStateRender = channelState => () => (
 );
 
 storiesOf('Network Status', module)
-  .add(
-    'Mainnet',
-    () => (
-      <Provider store={fakeStore({networkId: 1})}>
-        <NetworkStatus />
-      </Provider>))
-  .add(
-    'Kovan',
-    () => (
-      <Provider store={fakeStore({networkId: 42})}>
-        <NetworkStatus />
-      </Provider>))
-  .add(
-    'Ropsten',
-    () => (
-      <Provider store={fakeStore({networkId: 3})}>
-        <NetworkStatus />
-      </Provider>))
-  .add(
-    'Rinkeby',
-    () => (
-      <Provider store={fakeStore({networkId: 4})}>
-        <NetworkStatus />
-      </Provider>))
-  .add(
-    'Ganache',
-    () => (
-      <Provider store={fakeStore({networkId: 5777})}>
-        <NetworkStatus />
-      </Provider>)
-  );
-  
+  .add('Mainnet', () => (
+    <Provider store={fakeStore({ networkId: 1 })}>
+      <NetworkStatus />
+    </Provider>
+  ))
+  .add('Kovan', () => (
+    <Provider store={fakeStore({ networkId: 42 })}>
+      <NetworkStatus />
+    </Provider>
+  ))
+  .add('Ropsten', () => (
+    <Provider store={fakeStore({ networkId: 3 })}>
+      <NetworkStatus />
+    </Provider>
+  ))
+  .add('Rinkeby', () => (
+    <Provider store={fakeStore({ networkId: 4 })}>
+      <NetworkStatus />
+    </Provider>
+  ))
+  .add('Ganache', () => (
+    <Provider store={fakeStore({ networkId: 5777 })}>
+      <NetworkStatus />
+    </Provider>
+  ));
+
 storiesOf('Wallet Screens / Funding / Player A', module)
-  .add(
-    'ApproveFunding',
-   channelStateRender(channelStates.approveFunding(playerADefaults)))
+  .add('ApproveFunding', channelStateRender(channelStates.approveFunding(playerADefaults)))
   .add(
     'AWaitForDepositToBeSentToMetaMask',
-   channelStateRender(
-      (channelStates.aWaitForDepositToBeSentToMetaMask(playerADefaults))))
+    channelStateRender(channelStates.aWaitForDepositToBeSentToMetaMask(playerADefaults)),
+  )
   .add(
     'ASubmitDepositInMetaMask',
-   channelStateRender(channelStates.aSubmitDepositInMetaMask(playerADefaults)))
+    channelStateRender(channelStates.aSubmitDepositInMetaMask(playerADefaults)),
+  )
   .add(
     'AWaitForDepositConfirmation',
-   channelStateRender(
-      (channelStates.aWaitForDepositConfirmation(playerADefaults))))
+    channelStateRender(channelStates.aWaitForDepositConfirmation(playerADefaults)),
+  )
   .add(
     'AWaitForOpponentDeposit',
-   channelStateRender(channelStates.aWaitForOpponentDeposit(playerADefaults)))
+    channelStateRender(channelStates.aWaitForOpponentDeposit(playerADefaults)),
+  )
   .add(
     'AWaitForPostFundSetup',
-   channelStateRender(channelStates.aWaitForPostFundSetup(playerADefaults)))
+    channelStateRender(channelStates.aWaitForPostFundSetup(playerADefaults)),
+  )
   .add(
     'AcknowledgeFundingSuccess',
-   channelStateRender(
-      (channelStates.acknowledgeFundingSuccess(playerADefaults)),
-    ),
+    channelStateRender(channelStates.acknowledgeFundingSuccess(playerADefaults)),
   );
 
 storiesOf('Wallet Screens / Funding / Player B', module)
-  .add(
-    'ApproveFunding',
-   channelStateRender(channelStates.approveFunding(playerBDefaults)))
+  .add('ApproveFunding', channelStateRender(channelStates.approveFunding(playerBDefaults)))
   .add(
     'BWaitForOpponentDeposit',
-   channelStateRender(channelStates.bWaitForOpponentDeposit(playerBDefaults)))
+    channelStateRender(channelStates.bWaitForOpponentDeposit(playerBDefaults)),
+  )
   .add(
     'BWaitForDepositToBeSentToMetaMask',
-   channelStateRender(
-    channelStates.bWaitForDepositToBeSentToMetaMask(playerBDefaults)))
+    channelStateRender(channelStates.bWaitForDepositToBeSentToMetaMask(playerBDefaults)),
+  )
   .add(
     'BSubmitDepositInMetaMask',
-   channelStateRender(channelStates.bSubmitDepositInMetaMask(playerBDefaults)))
+    channelStateRender(channelStates.bSubmitDepositInMetaMask(playerBDefaults)),
+  )
   .add(
     'BWaitForDepositConfirmation',
-   channelStateRender(
-      (channelStates.bWaitForDepositConfirmation(playerBDefaults))))
+    channelStateRender(channelStates.bWaitForDepositConfirmation(playerBDefaults)),
+  )
   .add(
     'BWaitForPostFundSetup',
-   channelStateRender(channelStates.bWaitForPostFundSetup(playerBDefaults)))
+    channelStateRender(channelStates.bWaitForPostFundSetup(playerBDefaults)),
+  )
   .add(
     'AcknowledgeFundingSuccess',
-   channelStateRender(
-      (channelStates.acknowledgeFundingSuccess(playerBDefaults)))
+    channelStateRender(channelStates.acknowledgeFundingSuccess(playerBDefaults)),
   );
 
 storiesOf('Wallet Screens / Withdrawing', module)
-  .add(
-    'ApproveWithdrawal',
-   channelStateRender(channelStates.approveWithdrawal(playerADefaults)))
+  .add('ApproveWithdrawal', channelStateRender(channelStates.approveWithdrawal(playerADefaults)))
   .add(
     'WaitForWithdrawalInitiation',
-   channelStateRender(
-      (channelStates.waitForWithdrawalInitiation(playerADefaults))))
+    channelStateRender(channelStates.waitForWithdrawalInitiation(playerADefaults)),
+  )
   .add(
     'WaitForWithdrawalConfirmation',
-   channelStateRender(
-      (channelStates.waitForWithdrawalConfirmation(playerADefaults))))
+    channelStateRender(channelStates.waitForWithdrawalConfirmation(playerADefaults)),
+  )
   .add(
     'AcknowledgeWithdrawalSuccess',
-   channelStateRender(
-      (channelStates.acknowledgeWithdrawalSuccess(playerADefaults)))
+    channelStateRender(channelStates.acknowledgeWithdrawalSuccess(playerADefaults)),
   );
 
-
 storiesOf('Wallet Screens / Challenging', module)
-  .add(
-    'ApproveChallenge',
-   channelStateRender(channelStates.approveChallenge(playerADefaults)))
+  .add('ApproveChallenge', channelStateRender(channelStates.approveChallenge(playerADefaults)))
   .add(
     'WaitForChallengeInitiation',
-   channelStateRender(
-      (channelStates.waitForChallengeInitiation(playerADefaults))))
+    channelStateRender(channelStates.waitForChallengeInitiation(playerADefaults)),
+  )
   .add(
     'WaitForChallengeSubmission',
-   channelStateRender(
-      (channelStates.waitForChallengeSubmission(playerADefaults))))
+    channelStateRender(channelStates.waitForChallengeSubmission(playerADefaults)),
+  )
   .add(
     'WaitForChallengeConfirmation',
-   channelStateRender(
-      (channelStates.waitForChallengeConfirmation(playerADefaults))))
+    channelStateRender(channelStates.waitForChallengeConfirmation(playerADefaults)),
+  )
   .add(
     'WaitForResponseOrTimeout',
-   channelStateRender(channelStates.waitForResponseOrTimeout(playerADefaults)))
+    channelStateRender(channelStates.waitForResponseOrTimeout(playerADefaults)),
+  )
   .add(
     'AcknowledgeChallengeResponse',
-   channelStateRender(
-      (channelStates.acknowledgeChallengeResponse(playerADefaults))))
+    channelStateRender(channelStates.acknowledgeChallengeResponse(playerADefaults)),
+  )
   .add(
     'AcknowledgeChallengeTimeout',
-   channelStateRender(
-      (channelStates.acknowledgeChallengeTimeout(playerADefaults)))
+    channelStateRender(channelStates.acknowledgeChallengeTimeout(playerADefaults)),
   );
 
 storiesOf('Wallet Screens / Responding', module)
-  .add(
-    'ChooseResponse',
-   channelStateRender(channelStates.chooseResponse(playerADefaults)))
+  .add('ChooseResponse', channelStateRender(channelStates.chooseResponse(playerADefaults)))
   .add(
     'AcknowledgeChallengeTimeout',
-   channelStateRender(
-    channelStates.challengeeAcknowledgeChallengeTimeOut(playerADefaults)))
-  .add(
-    'TakeMoveInApp',
-   channelStateRender(channelStates.takeMoveInApp(playerADefaults)))
-  .add(
-    'InitiateResponse',
-   channelStateRender(channelStates.initiateResponse(playerADefaults)))
+    channelStateRender(channelStates.challengeeAcknowledgeChallengeTimeOut(playerADefaults)),
+  )
+  .add('TakeMoveInApp', channelStateRender(channelStates.takeMoveInApp(playerADefaults)))
+  .add('InitiateResponse', channelStateRender(channelStates.initiateResponse(playerADefaults)))
   .add(
     'WaitForResponseSubmission',
-   channelStateRender(
-      (channelStates.waitForResponseSubmission(playerADefaults))))
+    channelStateRender(channelStates.waitForResponseSubmission(playerADefaults)),
+  )
   .add(
     'WaitForResponseConfirmation',
-   channelStateRender(
-      (channelStates.waitForResponseConfirmation(playerADefaults))))
+    channelStateRender(channelStates.waitForResponseConfirmation(playerADefaults)),
+  )
   .add(
     'AcknowledgeChallengeComplete',
-   channelStateRender(
-      (channelStates.acknowledgeChallengeComplete(playerADefaults)),
-    ),
+    channelStateRender(channelStates.acknowledgeChallengeComplete(playerADefaults)),
   );
 
 storiesOf('Wallet Screens / Closing', module)
-  .add(
-    'ApproveConclude',
-   channelStateRender(channelStates.approveConclude(playerADefaults)))
+  .add('ApproveConclude', channelStateRender(channelStates.approveConclude(playerADefaults)))
   .add(
     'WaitForOpponentConclude',
-   channelStateRender(channelStates.waitForOpponentConclude(playerADefaults)))
+    channelStateRender(channelStates.waitForOpponentConclude(playerADefaults)),
+  )
   .add(
     'AcknowledgeConcludeSuccess',
-   channelStateRender(channelStates.approveCloseOnChain(playerADefaults))
+    channelStateRender(channelStates.approveCloseOnChain(playerADefaults)),
   );
 
 storiesOf('Wallet Landing Page', module).add(
   'Landing Page',
- channelStateRender(walletStates.waitForLogin({ outboxState: {} })),
+  channelStateRender(walletStates.waitForLogin({ outboxState: {} })),
 );

--- a/packages/wallet/src/__stories__/index.tsx
+++ b/packages/wallet/src/__stories__/index.tsx
@@ -62,6 +62,28 @@ const fakeStore = state => ({
   },
 });
 
+const initializedWalletState = walletStates.channelInitialized({
+  ...walletStates.waitForLogin(),
+  unhandledAction: undefined,
+  outboxState: {},
+  channelState: channelStates.approveFunding({ ...playerADefaults }),
+  networkId: 4,
+  adjudicator: '',
+  uid: '',
+});
+
+// Want to return top level wallet state, not the channel state
+function walletStateFromChannelState<T extends channelStates.ChannelState>(
+  channelState: T,
+  networkId?: number,
+): walletStates.WalletState {
+  return {
+    ...initializedWalletState,
+    channelState: { ...channelState },
+    networkId: networkId || 3,
+  };
+}
+
 const testState = state => () => (
   <Provider store={fakeStore(state)}>
     <Wallet />
@@ -69,120 +91,219 @@ const testState = state => () => (
 );
 
 storiesOf('Network Status', module)
-  .add('Mainnet', testState(channelStates.approveFunding({ ...playerADefaults, networkId: 1 })))
-  .add('Kovan', testState(channelStates.approveFunding({ ...playerADefaults, networkId: 4 })))
-  .add('Ropsten', testState(channelStates.approveFunding({ ...playerADefaults, networkId: 3 })))
-  .add('Rinkeby', testState(channelStates.approveFunding({ ...playerADefaults, networkId: 42 })))
-  .add('Ganache', testState(channelStates.approveFunding({ ...playerADefaults, networkId: 5777 })));
+  .add(
+    'Mainnet',
+    testState(walletStateFromChannelState(channelStates.approveFunding({ ...playerADefaults }), 1)),
+  )
+  .add(
+    'Kovan',
+    testState(
+      walletStateFromChannelState(channelStates.approveFunding({ ...playerADefaults }), 42),
+    ),
+  )
+  .add(
+    'Ropsten',
+    testState(walletStateFromChannelState(channelStates.approveFunding({ ...playerADefaults }), 3)),
+  )
+  .add(
+    'Rinkeby',
+    testState(walletStateFromChannelState(channelStates.approveFunding({ ...playerADefaults }), 4)),
+  )
+  .add(
+    'Ganache',
+    testState(
+      walletStateFromChannelState(channelStates.approveFunding({ ...playerADefaults }), 5777),
+    ),
+  );
 storiesOf('Wallet Screens / Funding / Player A', module)
-  .add('ApproveFunding', testState(channelStates.approveFunding(playerADefaults)))
+  .add(
+    'ApproveFunding',
+    testState(walletStateFromChannelState(channelStates.approveFunding(playerADefaults))),
+  )
   .add(
     'AWaitForDepositToBeSentToMetaMask',
-    testState(channelStates.aWaitForDepositToBeSentToMetaMask(playerADefaults)),
+    testState(
+      walletStateFromChannelState(channelStates.aWaitForDepositToBeSentToMetaMask(playerADefaults)),
+    ),
   )
   .add(
     'ASubmitDepositInMetaMask',
-    testState(channelStates.aSubmitDepositInMetaMask(playerADefaults)),
+    testState(walletStateFromChannelState(channelStates.aSubmitDepositInMetaMask(playerADefaults))),
   )
   .add(
     'AWaitForDepositConfirmation',
-    testState(channelStates.aWaitForDepositConfirmation(playerADefaults)),
+    testState(
+      walletStateFromChannelState(channelStates.aWaitForDepositConfirmation(playerADefaults)),
+    ),
   )
-  .add('AWaitForOpponentDeposit', testState(channelStates.aWaitForOpponentDeposit(playerADefaults)))
-  .add('AWaitForPostFundSetup', testState(channelStates.aWaitForPostFundSetup(playerADefaults)))
+  .add(
+    'AWaitForOpponentDeposit',
+    testState(walletStateFromChannelState(channelStates.aWaitForOpponentDeposit(playerADefaults))),
+  )
+  .add(
+    'AWaitForPostFundSetup',
+    testState(walletStateFromChannelState(channelStates.aWaitForPostFundSetup(playerADefaults))),
+  )
   .add(
     'AcknowledgeFundingSuccess',
-    testState(channelStates.acknowledgeFundingSuccess(playerADefaults)),
+    testState(
+      walletStateFromChannelState(channelStates.acknowledgeFundingSuccess(playerADefaults)),
+    ),
   );
 
 storiesOf('Wallet Screens / Funding / Player B', module)
-  .add('ApproveFunding', testState(channelStates.approveFunding(playerBDefaults)))
-  .add('BWaitForOpponentDeposit', testState(channelStates.bWaitForOpponentDeposit(playerBDefaults)))
+  .add(
+    'ApproveFunding',
+    testState(walletStateFromChannelState(channelStates.approveFunding(playerBDefaults))),
+  )
+  .add(
+    'BWaitForOpponentDeposit',
+    testState(walletStateFromChannelState(channelStates.bWaitForOpponentDeposit(playerBDefaults))),
+  )
   .add(
     'BWaitForDepositToBeSentToMetaMask',
-    testState(channelStates.bWaitForDepositToBeSentToMetaMask(playerBDefaults)),
+    testState(
+      walletStateFromChannelState(channelStates.bWaitForDepositToBeSentToMetaMask(playerBDefaults)),
+    ),
   )
   .add(
     'BSubmitDepositInMetaMask',
-    testState(channelStates.bSubmitDepositInMetaMask(playerBDefaults)),
+    testState(walletStateFromChannelState(channelStates.bSubmitDepositInMetaMask(playerBDefaults))),
   )
   .add(
     'BWaitForDepositConfirmation',
-    testState(channelStates.bWaitForDepositConfirmation(playerBDefaults)),
+    testState(
+      walletStateFromChannelState(channelStates.bWaitForDepositConfirmation(playerBDefaults)),
+    ),
   )
-  .add('BWaitForPostFundSetup', testState(channelStates.bWaitForPostFundSetup(playerBDefaults)))
+  .add(
+    'BWaitForPostFundSetup',
+    testState(walletStateFromChannelState(channelStates.bWaitForPostFundSetup(playerBDefaults))),
+  )
   .add(
     'AcknowledgeFundingSuccess',
-    testState(channelStates.acknowledgeFundingSuccess(playerBDefaults)),
+    testState(
+      walletStateFromChannelState(channelStates.acknowledgeFundingSuccess(playerBDefaults)),
+    ),
   );
 
 storiesOf('Wallet Screens / Withdrawing', module)
-  .add('ApproveWithdrawal', testState(channelStates.approveWithdrawal(playerADefaults)))
+  .add(
+    'ApproveWithdrawal',
+    testState(walletStateFromChannelState(channelStates.approveWithdrawal(playerADefaults))),
+  )
   .add(
     'WaitForWithdrawalInitiation',
-    testState(channelStates.waitForWithdrawalInitiation(playerADefaults)),
+    testState(
+      walletStateFromChannelState(channelStates.waitForWithdrawalInitiation(playerADefaults)),
+    ),
   )
   .add(
     'WaitForWithdrawalConfirmation',
-    testState(channelStates.waitForWithdrawalConfirmation(playerADefaults)),
+    testState(
+      walletStateFromChannelState(channelStates.waitForWithdrawalConfirmation(playerADefaults)),
+    ),
   )
   .add(
     'AcknowledgeWithdrawalSuccess',
-    testState(channelStates.acknowledgeWithdrawalSuccess(playerADefaults)),
+    testState(
+      walletStateFromChannelState(channelStates.acknowledgeWithdrawalSuccess(playerADefaults)),
+    ),
   );
 
 storiesOf('Wallet Screens / Challenging', module)
-  .add('ApproveChallenge', testState(channelStates.approveChallenge(playerADefaults)))
+  .add(
+    'ApproveChallenge',
+    testState(walletStateFromChannelState(channelStates.approveChallenge(playerADefaults))),
+  )
   .add(
     'WaitForChallengeInitiation',
-    testState(channelStates.waitForChallengeInitiation(playerADefaults)),
+    testState(
+      walletStateFromChannelState(channelStates.waitForChallengeInitiation(playerADefaults)),
+    ),
   )
   .add(
     'WaitForChallengeSubmission',
-    testState(channelStates.waitForChallengeSubmission(playerADefaults)),
+    testState(
+      walletStateFromChannelState(channelStates.waitForChallengeSubmission(playerADefaults)),
+    ),
   )
   .add(
     'WaitForChallengeConfirmation',
-    testState(channelStates.waitForChallengeConfirmation(playerADefaults)),
+    testState(
+      walletStateFromChannelState(channelStates.waitForChallengeConfirmation(playerADefaults)),
+    ),
   )
   .add(
     'WaitForResponseOrTimeout',
-    testState(channelStates.waitForResponseOrTimeout(playerADefaults)),
+    testState(walletStateFromChannelState(channelStates.waitForResponseOrTimeout(playerADefaults))),
   )
   .add(
     'AcknowledgeChallengeResponse',
-    testState(channelStates.acknowledgeChallengeResponse(playerADefaults)),
+    testState(
+      walletStateFromChannelState(channelStates.acknowledgeChallengeResponse(playerADefaults)),
+    ),
   )
   .add(
     'AcknowledgeChallengeTimeout',
-    testState(channelStates.acknowledgeChallengeTimeout(playerADefaults)),
+    testState(
+      walletStateFromChannelState(channelStates.acknowledgeChallengeTimeout(playerADefaults)),
+    ),
   );
 
 storiesOf('Wallet Screens / Responding', module)
-  .add('ChooseResponse', testState(channelStates.chooseResponse(playerADefaults)))
+  .add(
+    'ChooseResponse',
+    testState(walletStateFromChannelState(channelStates.chooseResponse(playerADefaults))),
+  )
   .add(
     'AcknowledgeChallengeTimeout',
-    testState(channelStates.challengeeAcknowledgeChallengeTimeOut(playerADefaults)),
+    testState(
+      walletStateFromChannelState(
+        channelStates.challengeeAcknowledgeChallengeTimeOut(playerADefaults),
+      ),
+    ),
   )
-  .add('TakeMoveInApp', testState(channelStates.takeMoveInApp(playerADefaults)))
-  .add('InitiateResponse', testState(channelStates.initiateResponse(playerADefaults)))
+  .add(
+    'TakeMoveInApp',
+    testState(walletStateFromChannelState(channelStates.takeMoveInApp(playerADefaults))),
+  )
+  .add(
+    'InitiateResponse',
+    testState(walletStateFromChannelState(channelStates.initiateResponse(playerADefaults))),
+  )
   .add(
     'WaitForResponseSubmission',
-    testState(channelStates.waitForResponseSubmission(playerADefaults)),
+    testState(
+      walletStateFromChannelState(channelStates.waitForResponseSubmission(playerADefaults)),
+    ),
   )
   .add(
     'WaitForResponseConfirmation',
-    testState(channelStates.waitForResponseConfirmation(playerADefaults)),
+    testState(
+      walletStateFromChannelState(channelStates.waitForResponseConfirmation(playerADefaults)),
+    ),
   )
   .add(
     'AcknowledgeChallengeComplete',
-    testState(channelStates.acknowledgeChallengeComplete(playerADefaults)),
+    testState(
+      walletStateFromChannelState(channelStates.acknowledgeChallengeComplete(playerADefaults)),
+    ),
   );
 
 storiesOf('Wallet Screens / Closing', module)
-  .add('ApproveConclude', testState(channelStates.approveConclude(playerADefaults)))
-  .add('WaitForOpponentConclude', testState(channelStates.waitForOpponentConclude(playerADefaults)))
-  .add('AcknowledgeConcludeSuccess', testState(channelStates.approveCloseOnChain(playerADefaults)));
+  .add(
+    'ApproveConclude',
+    testState(walletStateFromChannelState(channelStates.approveConclude(playerADefaults))),
+  )
+  .add(
+    'WaitForOpponentConclude',
+    testState(walletStateFromChannelState(channelStates.waitForOpponentConclude(playerADefaults))),
+  )
+  .add(
+    'AcknowledgeConcludeSuccess',
+    testState(walletStateFromChannelState(channelStates.approveCloseOnChain(playerADefaults))),
+  );
 
 storiesOf('Wallet Landing Page', module).add(
   'Landing Page',


### PR DESCRIPTION
Otherwise the Wallet container switch is not fed the correct `stage`, and we fall through to the default case every time. 

