### PR TITLE
remove run-s, run npx lerna bootstrap

### DIFF
--- a/packages/magmo-wallet-client/package.json
+++ b/packages/magmo-wallet-client/package.json
@@ -22,7 +22,7 @@
   },
   "scripts": {
     "test": "echo \"Error: run tests from root\" && exit 1",
-    "prepare": "run-s prettier:check lint build",
+    "prepare": "yarn prettier:check && yarn lint && yarn build",
     "build": "npx tsc",
     "lint": "npx tslint -c tslint.json 'src/**/*.ts'",
     "prettier:check": "npx prettier --check 'src/**/*.{ts,tsx}'",

--- a/packages/rps/yarn.lock
+++ b/packages/rps/yarn.lock
@@ -14259,7 +14259,7 @@ typescript-eslint-parser@^17.0.1:
     lodash.unescape "4.0.1"
     semver "5.5.0"
 
-typescript@^3.3.0:
+typescript@^3.0.1:
   version "3.3.3333"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.3.3333.tgz#171b2c5af66c59e9431199117a3bcadc66fdcfd6"
   integrity sha512-JjSKsAfuHBE/fB2oZ8NxtRTk5iGcg6hkYXMnZ3Wc+b2RSqejEqTaem11mHASMnFilHrax3sLK0GDzcJrekZYLw==


### PR DESCRIPTION
run-s was responsible for some unexpected behaviour, where upon running `npx lerna bootstrap` *all* packages were getting a `prettier:check`, `lint` and `build`, despite these commands appearing as if they should be silo-ed to the `magmo-wallet-client` package. 

In particular this fix will decouple bootstrapping from any build issues in TTT, including an existing issue in that package when targeting 'development' that prevents it from compiling. 

Thanks to @andrewgordstewart and @kerzhner for help troubleshooting. 

