### PR TITLE
Fix funding container issue

### DIFF
--- a/packages/wallet/src/__stories__/index.tsx
+++ b/packages/wallet/src/__stories__/index.tsx
@@ -10,7 +10,6 @@ import * as scenarios from '../redux/__tests__/test-scenarios';
 import { bigNumberify } from 'ethers/utils';
 import NetworkStatus from '../components/NetworkStatus';
 import { channelFunded } from '../redux/fundingState/state';
-import { emptyState } from '../redux/state';
 
 const {
   asAddress,
@@ -88,20 +87,26 @@ const initializedWalletState = walletStates.initialized({
   ...walletStates.waitForLogin(),
   unhandledAction: undefined,
   outboxState: {},
-  channelState: { [channelId]: channelStates.approveFunding({ ...playerADefaults }) },
+  channelState: {
+    initializedChannels: { [channelId]: channelStates.approveFunding({ ...playerADefaults }) },
+    initializingChannels: {},
+  },
   networkId: 4,
   adjudicator: '',
   uid: '',
 });
 
 // Want to return top level wallet state, not the channel state
-function walletStateFromChannelState<T extends channelStates.OpenedChannelState>(
+function walletStateFromChannelState<T extends channelStates.OpenedState>(
   channelState: T,
   networkId?: number,
 ): walletStates.WalletState {
   return {
     ...initializedWalletState,
-    channelState: { [channelState.channelId]: channelState },
+    channelState: {
+      initializedChannels: { [channelState.channelId]: channelState },
+      initializingChannels: {},
+    },
     networkId: networkId || 3,
   };
 }
@@ -299,5 +304,5 @@ addStoriesFromCollection(WalletScreendsClosing, 'Wallet Screens / Closing');
 
 storiesOf('Wallet Landing Page', module).add(
   'Landing Page',
-  channelStateRender(walletStates.waitForLogin(emptyState)),
+  channelStateRender(walletStates.waitForLogin()),
 );

--- a/packages/wallet/src/__stories__/index.tsx
+++ b/packages/wallet/src/__stories__/index.tsx
@@ -10,6 +10,7 @@ import * as scenarios from '../redux/__tests__/test-scenarios';
 import { bigNumberify } from 'ethers/utils';
 import NetworkStatus from '../components/NetworkStatus';
 import { channelFunded } from '../redux/fundingState/state';
+import { emptyState } from '../redux/state';
 
 const {
   asAddress,
@@ -83,24 +84,24 @@ const fakeStore = state => ({
   },
 });
 
-const initializedWalletState = walletStates.channelInitialized({
+const initializedWalletState = walletStates.initialized({
   ...walletStates.waitForLogin(),
   unhandledAction: undefined,
   outboxState: {},
-  channelState: channelStates.approveFunding({ ...playerADefaults }),
+  channelState: { [channelId]: channelStates.approveFunding({ ...playerADefaults }) },
   networkId: 4,
   adjudicator: '',
   uid: '',
 });
 
 // Want to return top level wallet state, not the channel state
-function walletStateFromChannelState<T extends channelStates.ChannelState>(
+function walletStateFromChannelState<T extends channelStates.OpenedChannelState>(
   channelState: T,
   networkId?: number,
 ): walletStates.WalletState {
   return {
     ...initializedWalletState,
-    channelState: { ...channelState },
+    channelState: { [channelState.channelId]: channelState },
     networkId: networkId || 3,
   };
 }
@@ -298,5 +299,5 @@ addStoriesFromCollection(WalletScreendsClosing, 'Wallet Screens / Closing');
 
 storiesOf('Wallet Landing Page', module).add(
   'Landing Page',
-  channelStateRender(walletStates.waitForLogin({ outboxState: {} })),
+  channelStateRender(walletStates.waitForLogin(emptyState)),
 );

--- a/packages/wallet/src/components/NetworkStatus.tsx
+++ b/packages/wallet/src/components/NetworkStatus.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faDotCircle } from '@fortawesome/free-solid-svg-icons';
 import { connect } from 'react-redux';
-import * as states from '../redux/channelState/state';
 import { AdjudicatorKnown } from '../redux/shared/state';
 
 interface NetworkStatusProps {
@@ -53,11 +52,7 @@ export class NetworkStatus extends React.PureComponent<NetworkStatusProps> {
   }
 }
 
-interface ChannelInFundingState extends AdjudicatorKnown {
-  channelState: states.FundingState;
-}
-
-const mapStateToProps = (state: ChannelInFundingState): NetworkStatusProps => ({
+const mapStateToProps = (state: AdjudicatorKnown): NetworkStatusProps => ({
   networkId: state.networkId,
 });
 

--- a/packages/wallet/src/containers/Channel.tsx
+++ b/packages/wallet/src/containers/Channel.tsx
@@ -11,7 +11,7 @@ import ClosingContainer from './Closing';
 import LandingPage from '../components/LandingPage';
 
 interface ChannelProps {
-  state: states.ChannelState;
+  state: states.ChannelStatus;
 }
 
 class ChannelContainer extends PureComponent<ChannelProps> {

--- a/packages/wallet/src/containers/Initialized.tsx
+++ b/packages/wallet/src/containers/Initialized.tsx
@@ -2,17 +2,27 @@ import * as states from '../redux/state';
 import React, { PureComponent } from 'react';
 import SidebarLayout from '../components/SidebarLayout';
 import { connect } from 'react-redux';
+import ChannelContainer from './Channel';
 interface Props {
   state: states.InitializedState;
 }
 
 class WalletInitializedContainer extends PureComponent<Props> {
   render() {
-    return (
-      <SidebarLayout>
-        <h1>Wallet niitialized</h1>
-      </SidebarLayout>
-    );
+    const { state } = this.props;
+    if (state.channelState.activeAppChannelId) {
+      return (
+        <ChannelContainer
+          state={state.channelState.initializedChannels[state.channelState.activeAppChannelId]}
+        />
+      );
+    } else {
+      return (
+        <SidebarLayout>
+          <h1>Wallet initialized</h1>
+        </SidebarLayout>
+      );
+    }
   }
 }
 

--- a/packages/wallet/src/containers/Initialized.tsx
+++ b/packages/wallet/src/containers/Initialized.tsx
@@ -1,34 +1,18 @@
 import * as states from '../redux/state';
 import React, { PureComponent } from 'react';
 import SidebarLayout from '../components/SidebarLayout';
-import LandingPage from '../components/LandingPage';
 import { connect } from 'react-redux';
-import ChannelContainer from './Channel';
 interface Props {
   state: states.InitializedState;
 }
 
 class WalletInitializedContainer extends PureComponent<Props> {
   render() {
-    const { state } = this.props;
-    switch (state.type) {
-      case states.WAITING_FOR_CHANNEL_INITIALIZATION:
-        return (
-          <SidebarLayout>
-            <h1>Waiting for channel initialization</h1>
-          </SidebarLayout>
-        );
-      case states.INITIALIZING_CHANNEL:
-        return (
-          <SidebarLayout>
-            <h1>Channel initializing.</h1>
-          </SidebarLayout>
-        );
-      case states.CHANNEL_INITIALIZED:
-        return <ChannelContainer state={state.channelState} />;
-      default:
-        return <LandingPage />;
-    }
+    return (
+      <SidebarLayout>
+        <h1>Wallet niitialized</h1>
+      </SidebarLayout>
+    );
   }
 }
 

--- a/packages/wallet/src/redux/__tests__/helpers.ts
+++ b/packages/wallet/src/redux/__tests__/helpers.ts
@@ -1,16 +1,16 @@
-import { ChannelState } from '../channelState/state';
+import { ChannelStatus } from '../channelState/state';
 import { OutboxState } from '../outbox/state';
 import { StateWithSideEffects } from '../shared/state';
 import { Commitment } from 'fmg-core';
 import * as outgoing from 'magmo-wallet-client/lib/wallet-events';
 
-export const itSendsAMessage = (state: StateWithSideEffects<ChannelState>) => {
+export const itSendsAMessage = (state: StateWithSideEffects<ChannelStatus>) => {
   it(`sends a message`, () => {
     expect(state.outboxState!.messageOutbox).toEqual(expect.anything());
   });
 };
 
-export const itSendsNoMessage = (state: StateWithSideEffects<ChannelState>) => {
+export const itSendsNoMessage = (state: StateWithSideEffects<ChannelStatus>) => {
   it(`sends no message`, () => {
     if (state.outboxState) {
       expect(state.outboxState!.messageOutbox).toBeUndefined();
@@ -32,7 +32,7 @@ export const itSendsThisMessage = (state: { outboxState?: OutboxState }, message
   }
 };
 
-export const itSendsThisDisplayEvent = (state: StateWithSideEffects<ChannelState>, event) => {
+export const itSendsThisDisplayEvent = (state: StateWithSideEffects<ChannelStatus>, event) => {
   it(`sends event ${event.type}`, () => {
     expect(state.outboxState!.displayOutbox!.type).toEqual(event);
   });
@@ -41,13 +41,13 @@ export const itSendsThisDisplayEvent = (state: StateWithSideEffects<ChannelState
 type CommitmentMessage = outgoing.FundingSuccess;
 
 export const expectThisCommitmentSent = (
-  state: StateWithSideEffects<ChannelState>,
+  state: StateWithSideEffects<ChannelStatus>,
   c: Partial<Commitment>,
 ) => {
   expect((state.outboxState!.messageOutbox! as CommitmentMessage).commitment).toMatchObject(c);
 };
 
-export const itSendsATransaction = (state: StateWithSideEffects<ChannelState>) => {
+export const itSendsATransaction = (state: StateWithSideEffects<ChannelStatus>) => {
   it(`sends a transaction`, () => {
     expect(state.outboxState!.transactionOutbox).toEqual(expect.anything());
   });
@@ -69,7 +69,7 @@ export const itSendsNoTransaction = (state: { outboxState?: OutboxState }) => {
 
 export const itTransitionsToChannelStateType = (
   type,
-  state: StateWithSideEffects<ChannelState>,
+  state: StateWithSideEffects<ChannelStatus>,
 ) => {
   it(`transitions to ${type}`, () => {
     expect(state.state.type).toEqual(type);
@@ -86,8 +86,8 @@ export const itTransitionsToStateType = (
 };
 
 export const itDoesntTransition = (
-  oldState: ChannelState,
-  newState: StateWithSideEffects<ChannelState>,
+  oldState: ChannelStatus,
+  newState: StateWithSideEffects<ChannelStatus>,
 ) => {
   it(`doesn't transition`, () => {
     expect(newState.state.type).toEqual(oldState.type);
@@ -96,8 +96,8 @@ export const itDoesntTransition = (
 
 export const itIncreasesTurnNumBy = (
   increase: number,
-  oldState: ChannelState,
-  newState: StateWithSideEffects<ChannelState>,
+  oldState: ChannelStatus,
+  newState: StateWithSideEffects<ChannelStatus>,
 ) => {
   it(`increases the turnNum by ${increase}`, () => {
     if (!('turnNum' in newState.state) || !('turnNum' in oldState)) {

--- a/packages/wallet/src/redux/__tests__/test-scenarios.ts
+++ b/packages/wallet/src/redux/__tests__/test-scenarios.ts
@@ -1,6 +1,7 @@
 import { Channel, CommitmentType, Commitment } from 'fmg-core';
 import { channelID } from 'fmg-core/lib/channel';
 import { bigNumberify } from 'ethers/utils';
+import { waitForPreFundSetup } from '../channelState/state';
 
 export const libraryAddress = '0x' + '1'.repeat(40);
 export const channelNonce = 4;
@@ -99,4 +100,22 @@ export const concludeCommitment2: Commitment = {
   turnNum: 52,
   allocation: [],
   destination: [],
+};
+
+export const initializedChannelState = {
+  [channelId]: waitForPreFundSetup({
+    channelId,
+    libraryAddress,
+    ourIndex: 0,
+    participants,
+    channelNonce,
+    funded: false,
+    address: asAddress,
+    privateKey: asPrivateKey,
+    lastCommitment: { commitment: preFundCommitment1, signature: 'signature' },
+    turnNum: 0,
+  }),
+};
+export const initializingChannelState = {
+  [asAddress]: { address: asAddress, privateKey: asPrivateKey },
 };

--- a/packages/wallet/src/redux/actions.ts
+++ b/packages/wallet/src/redux/actions.ts
@@ -1,4 +1,5 @@
 import { Commitment } from 'fmg-core';
+import * as internal from './internal/actions';
 
 export const LOGGED_IN = 'WALLET.LOGGED_IN';
 export const loggedIn = (uid: string) => ({
@@ -366,15 +367,10 @@ export const blockMined = (block: { timestamp: number; number: number }) => ({
 });
 export type BlockMined = ReturnType<typeof blockMined>;
 
-import * as internal from './internal/actions';
-
 export { internal };
 
-// TODO: This is getting large, we should probably split this up into separate types for each stage
-export type WalletAction =
-  | AdjudicatorKnown
+export type ChannelAction =  // TODO: Some of these actions probably also belong in a FundingAction type
   | ApproveClose
-  | BlockMined
   | ChallengeAcknowledged
   | ChallengeApproved
   | ChallengeCommitmentReceived
@@ -393,19 +389,9 @@ export type WalletAction =
   | concludedEvent
   | ConcludeRejected
   | ConcludeRequested
-  | DepositConfirmed
-  | DepositInitiated
-  | DisplayMessageSent
-  | FundingApproved
-  | FundingDeclinedAcknowledged
-  | FundingReceivedEvent
-  | FundingRejected
   | FundingRequested
   | FundingSuccessAcknowledged
-  | LoggedIn
   | MessageReceived
-  | MessageSent
-  | MetamaskLoadError
   | OpponentCommitmentReceived
   | OwnCommitmentReceived
   | PostFundSetupReceived
@@ -413,7 +399,6 @@ export type WalletAction =
   | RespondWithMoveChosen
   | RespondWithMoveEvent
   | RespondWithRefuteChosen
-  | RetryTransaction
   | TakeMoveInAppAcknowledged
   | TransactionConfirmed
   | TransactionSentToMetamask
@@ -424,3 +409,35 @@ export type WalletAction =
   | WithdrawalRequested
   | WithdrawalSuccessAcknowledged
   | internal.InternalAction;
+
+// TODO: This is getting large, we should probably split this up into separate types for each stage
+export type WalletAction =
+  | AdjudicatorKnown
+  | BlockMined
+  | DepositConfirmed
+  | DepositInitiated
+  | DisplayMessageSent
+  | FundingApproved
+  | FundingDeclinedAcknowledged
+  | FundingReceivedEvent
+  | FundingRejected
+  | LoggedIn
+  | MessageSent
+  | MetamaskLoadError
+  | RetryTransaction
+  | ChannelAction;
+
+export const isChannelAction = (action: WalletAction): action is ChannelAction => {
+  // In order for an action to act on a specific channel, it needs to somehow contain a
+  // channel id.
+  // By rights, the actions themselves should extend a ChannelAction interface
+  // that looks like { channelId: string }
+  // This might require a change to the wallet API
+  return 'channelId' in action || 'commitment' in action || action.type === CHANNEL_INITIALIZED;
+};
+
+export const isReceiveFirstCommitment = (
+  action: WalletAction,
+): action is OwnCommitmentReceived | OpponentCommitmentReceived => {
+  return 'commitment' in action && action.commitment.turnNum === 0;
+};

--- a/packages/wallet/src/redux/actions.ts
+++ b/packages/wallet/src/redux/actions.ts
@@ -279,7 +279,7 @@ export const fundingReceivedEvent = (
 export type FundingReceivedEvent = ReturnType<typeof fundingReceivedEvent>;
 
 export const CHALLENGE_CREATED_EVENT = 'CHALLENGE_CREATED_EVENT';
-export const challengeCreatedEvent = (channelId, commitment, finalizedAt) => ({
+export const challengeCreatedEvent = (channelId: string, commitment: Commitment, finalizedAt) => ({
   channelId,
   commitment,
   finalizedAt,

--- a/packages/wallet/src/redux/channelState/__tests__/channelState.test.ts
+++ b/packages/wallet/src/redux/channelState/__tests__/channelState.test.ts
@@ -1,0 +1,79 @@
+import * as actions from '../../actions';
+
+import * as scenarios from '../../__tests__/test-scenarios';
+import { channelStateReducer } from '../reducer';
+
+const {
+  initializingChannelState: initializingChannels,
+  initializedChannelState: initializedChannels,
+  channelId,
+  asAddress,
+  asPrivateKey,
+  preFundCommitment1,
+} = scenarios;
+
+const defaults = {
+  initializedChannels: {},
+  initializingChannels: {},
+};
+
+describe('when CHANNEL_INITIALIZED arrives', () => {
+  it('updates state.channelState.initializingChannels', async () => {
+    const state = defaults;
+    const action = actions.channelInitialized();
+
+    const updatedState = channelStateReducer(state, action);
+
+    const signingAddrs = Object.keys(updatedState.state.initializingChannels);
+    expect(signingAddrs.length).toEqual(1);
+
+    const addr = signingAddrs[0];
+    expect(updatedState.state.initializingChannels[addr]).toMatchObject({
+      privateKey: expect.any(String),
+    });
+  });
+});
+
+describe('when the channel is part of the initializedChannelState', () => {
+  describe('when the first commitment arrives', () => {
+    it('moves the channel from initializingChannels to initializedChannels', () => {
+      const state = { ...defaults, initializingChannels };
+      const action = actions.ownCommitmentReceived(preFundCommitment1);
+
+      const updatedState = channelStateReducer(state, action);
+
+      const signingAddrs = Object.keys(updatedState.state.initializingChannels);
+      expect(signingAddrs.length).toEqual(0);
+
+      expect(updatedState.state.initializedChannels).toMatchObject({
+        [channelId]: {
+          privateKey: asPrivateKey,
+          address: asAddress,
+          lastCommitment: { commitment: preFundCommitment1 },
+        },
+      });
+    });
+  });
+});
+
+describe('when the channel is part of the channelState', () => {
+  describe('when a channel action arrives', () => {
+    it.skip('delegates to the single channel reducer', async () => {
+      const state = { ...defaults, initializedChannels };
+      const action = actions.ownCommitmentReceived(preFundCommitment1);
+
+      const updatedState = channelStateReducer(state, action);
+
+      const signingAddrs = Object.keys(updatedState.state.initializingChannels);
+      expect(signingAddrs.length).toEqual(0);
+
+      expect(updatedState.state.initializedChannels).toMatchObject({
+        [channelId]: {
+          privateKey: asPrivateKey,
+          address: asAddress,
+          lastCommitment: { commitment: preFundCommitment1 },
+        },
+      });
+    });
+  });
+});

--- a/packages/wallet/src/redux/channelState/challenging/reducer.ts
+++ b/packages/wallet/src/redux/channelState/challenging/reducer.ts
@@ -15,7 +15,7 @@ import { StateWithSideEffects } from '../../shared/state';
 export const challengingReducer = (
   state: states.ChallengingState,
   action: WalletAction,
-): StateWithSideEffects<states.ChannelState> => {
+): StateWithSideEffects<states.ChannelStatus> => {
   // Handle any signature/validation request centrally to avoid duplicating code for each state
   if (
     action.type === actions.OWN_COMMITMENT_RECEIVED ||
@@ -51,7 +51,7 @@ export const challengingReducer = (
 const challengeTransactionFailedReducer = (
   state: states.ChallengeTransactionFailed,
   action: WalletAction,
-): StateWithSideEffects<states.ChannelState> => {
+): StateWithSideEffects<states.ChannelStatus> => {
   switch (action.type) {
     case actions.RETRY_TRANSACTION:
       const { commitment: fromPosition, signature: fromSignature } = state.penultimateCommitment;
@@ -73,7 +73,7 @@ const challengeTransactionFailedReducer = (
 const approveChallengeReducer = (
   state: states.ApproveChallenge,
   action: WalletAction,
-): StateWithSideEffects<states.ChannelState> => {
+): StateWithSideEffects<states.ChannelStatus> => {
   switch (action.type) {
     case actions.CHALLENGE_APPROVED:
       const { commitment: fromPosition, signature: fromSignature } = state.penultimateCommitment;
@@ -101,7 +101,7 @@ const approveChallengeReducer = (
 const initiateChallengeReducer = (
   state: states.WaitForChallengeInitiation,
   action: WalletAction,
-): StateWithSideEffects<states.ChannelState> => {
+): StateWithSideEffects<states.ChannelStatus> => {
   switch (action.type) {
     case actions.TRANSACTION_SENT_TO_METAMASK:
       return { state: states.waitForChallengeSubmission(state) };
@@ -113,7 +113,7 @@ const initiateChallengeReducer = (
 const waitForChallengeSubmissionReducer = (
   state: states.WaitForChallengeSubmission,
   action: WalletAction,
-): StateWithSideEffects<states.ChannelState> => {
+): StateWithSideEffects<states.ChannelStatus> => {
   switch (action.type) {
     case actions.CHALLENGE_CREATED_EVENT:
       return {
@@ -139,7 +139,7 @@ const waitForChallengeSubmissionReducer = (
 const waitForChallengeConfirmationReducer = (
   state: states.WaitForChallengeConfirmation,
   action: WalletAction,
-): StateWithSideEffects<states.ChannelState> => {
+): StateWithSideEffects<states.ChannelStatus> => {
   switch (action.type) {
     case actions.CHALLENGE_CREATED_EVENT:
       return {
@@ -163,7 +163,7 @@ const waitForChallengeConfirmationReducer = (
 const waitForResponseOrTimeoutReducer = (
   state: states.WaitForResponseOrTimeout,
   action: WalletAction,
-): StateWithSideEffects<states.ChannelState> => {
+): StateWithSideEffects<states.ChannelStatus> => {
   switch (action.type) {
     case actions.CHALLENGE_CREATED_EVENT:
       return {
@@ -204,7 +204,7 @@ const waitForResponseOrTimeoutReducer = (
 const acknowledgeChallengeResponseReducer = (
   state: states.AcknowledgeChallengeResponse,
   action: WalletAction,
-): StateWithSideEffects<states.ChannelState> => {
+): StateWithSideEffects<states.ChannelStatus> => {
   switch (action.type) {
     case actions.CHALLENGE_RESPONSE_ACKNOWLEDGED:
       return {
@@ -219,7 +219,7 @@ const acknowledgeChallengeResponseReducer = (
 const acknowledgeChallengeTimeoutReducer = (
   state: states.AcknowledgeChallengeTimeout,
   action: WalletAction,
-): StateWithSideEffects<states.ChannelState> => {
+): StateWithSideEffects<states.ChannelStatus> => {
   switch (action.type) {
     case actions.CHALLENGE_TIME_OUT_ACKNOWLEDGED:
       return {

--- a/packages/wallet/src/redux/channelState/closing/reducer.ts
+++ b/packages/wallet/src/redux/channelState/closing/reducer.ts
@@ -25,7 +25,7 @@ import { StateWithSideEffects } from '../../shared/state';
 export const closingReducer = (
   state: channelStates.ClosingState,
   action: WalletAction,
-): StateWithSideEffects<channelStates.ChannelState> => {
+): StateWithSideEffects<channelStates.ChannelStatus> => {
   // TODO: Clear funding status.
   switch (state.type) {
     case channelStates.APPROVE_CONCLUDE:
@@ -56,7 +56,7 @@ export const closingReducer = (
 const closeTransactionFailedReducer = (
   state: channelStates.CloseTransactionFailed,
   action: actions.WalletAction,
-): StateWithSideEffects<channelStates.ChannelState> => {
+): StateWithSideEffects<channelStates.ChannelStatus> => {
   switch (action.type) {
     case actions.RETRY_TRANSACTION:
       const { penultimateCommitment: from, lastCommitment: to } = state;
@@ -92,7 +92,7 @@ const closeTransactionFailedReducer = (
 const acknowledgeConcludeReducer = (
   state: channelStates.AcknowledgeConclude,
   action: actions.WalletAction,
-): StateWithSideEffects<channelStates.ChannelState> => {
+): StateWithSideEffects<channelStates.ChannelStatus> => {
   switch (action.type) {
     case actions.CONCLUDE_APPROVED:
       if (!ourTurn(state)) {
@@ -128,7 +128,7 @@ const acknowledgeConcludeReducer = (
 const waitForCloseConfirmedReducer = (
   state: channelStates.WaitForCloseConfirmed,
   action: actions.WalletAction,
-): StateWithSideEffects<channelStates.ChannelState> => {
+): StateWithSideEffects<channelStates.ChannelStatus> => {
   switch (action.type) {
     case actions.TRANSACTION_CONFIRMED:
       return {
@@ -142,7 +142,7 @@ const waitForCloseConfirmedReducer = (
 const waitForCloseInitiatorReducer = (
   state: channelStates.WaitForCloseInitiation,
   action: actions.WalletAction,
-): StateWithSideEffects<channelStates.ChannelState> => {
+): StateWithSideEffects<channelStates.ChannelStatus> => {
   switch (action.type) {
     case actions.TRANSACTION_SENT_TO_METAMASK:
       return { state: channelStates.waitForCloseSubmission(state) };
@@ -153,7 +153,7 @@ const waitForCloseInitiatorReducer = (
 const waitForCloseSubmissionReducer = (
   state: channelStates.WaitForCloseSubmission,
   action: actions.WalletAction,
-): StateWithSideEffects<channelStates.ChannelState> => {
+): StateWithSideEffects<channelStates.ChannelStatus> => {
   switch (action.type) {
     case actions.TRANSACTION_SUBMISSION_FAILED:
       return { state: channelStates.closeTransactionFailed(state) };
@@ -171,7 +171,7 @@ const waitForCloseSubmissionReducer = (
 const approveCloseOnChainReducer = (
   state: channelStates.ApproveCloseOnChain,
   action: actions.WalletAction,
-): StateWithSideEffects<channelStates.ChannelState> => {
+): StateWithSideEffects<channelStates.ChannelStatus> => {
   switch (action.type) {
     case actions.APPROVE_CLOSE:
       const { penultimateCommitment: from, lastCommitment: to } = state;
@@ -210,7 +210,7 @@ const approveCloseOnChainReducer = (
 const approveConcludeReducer = (
   state: channelStates.ApproveConclude,
   action: WalletAction,
-): StateWithSideEffects<channelStates.ChannelState> => {
+): StateWithSideEffects<channelStates.ChannelStatus> => {
   switch (action.type) {
     case actions.CONCLUDE_APPROVED:
       if (!ourTurn(state)) {
@@ -269,7 +269,7 @@ const approveConcludeReducer = (
 const waitForOpponentConclude = (
   state: channelStates.WaitForOpponentConclude,
   action: WalletAction,
-): StateWithSideEffects<channelStates.ChannelState> => {
+): StateWithSideEffects<channelStates.ChannelStatus> => {
   switch (action.type) {
     case actions.COMMITMENT_RECEIVED:
       const { commitment, signature } = action;
@@ -313,7 +313,7 @@ const waitForOpponentConclude = (
 const acknowledgeCloseSuccessReducer = (
   state: channelStates.AcknowledgeCloseSuccess,
   action: WalletAction,
-): StateWithSideEffects<channelStates.ChannelState> => {
+): StateWithSideEffects<channelStates.ChannelStatus> => {
   switch (action.type) {
     case actions.CLOSE_SUCCESS_ACKNOWLEDGED:
       return {
@@ -330,7 +330,7 @@ const acknowledgeCloseSuccessReducer = (
 const acknowledgeClosedOnChainReducer = (
   state: channelStates.AcknowledgeClosedOnChain,
   action: WalletAction,
-): StateWithSideEffects<channelStates.ChannelState> => {
+): StateWithSideEffects<channelStates.ChannelStatus> => {
   switch (action.type) {
     case actions.CLOSED_ON_CHAIN_ACKNOWLEDGED:
       return {

--- a/packages/wallet/src/redux/channelState/funding/reducer.ts
+++ b/packages/wallet/src/redux/channelState/funding/reducer.ts
@@ -20,7 +20,7 @@ import { StateWithSideEffects } from '../../shared/state';
 export const fundingReducer = (
   state: states.FundingState,
   action: actions.WalletAction,
-): StateWithSideEffects<states.ChannelState> => {
+): StateWithSideEffects<states.ChannelStatus> => {
   // Handle any signature/validation request centrally to avoid duplicating code for each state
   if (
     action.type === actions.OWN_COMMITMENT_RECEIVED ||
@@ -65,7 +65,7 @@ export const fundingReducer = (
 const waitForFundingRequestReducer = (
   state: states.WaitForFundingRequest,
   action: actions.WalletAction,
-): StateWithSideEffects<states.OpenedChannelState> => {
+): StateWithSideEffects<states.OpenedState> => {
   switch (action.type) {
     case actions.FUNDING_REQUESTED:
       return {
@@ -80,7 +80,7 @@ const waitForFundingRequestReducer = (
 const approveFundingReducer = (
   state: states.WaitForFundingApproval,
   action: actions.WalletAction,
-): StateWithSideEffects<states.OpenedChannelState> => {
+): StateWithSideEffects<states.OpenedState> => {
   switch (action.type) {
     case actions.FUNDING_APPROVED:
       const totalFundingRequired = state.lastCommitment.commitment.allocation.reduce(addHex);
@@ -126,7 +126,7 @@ const approveFundingReducer = (
 const waitForFundingAndPostFundSetupReducer = (
   state: states.WaitForFundingAndPostFundSetup,
   action: actions.WalletAction,
-): StateWithSideEffects<states.OpenedChannelState> => {
+): StateWithSideEffects<states.OpenedState> => {
   switch (action.type) {
     case actions.MESSAGE_RECEIVED:
       if (action.data === 'FundingDeclined') {
@@ -218,7 +218,7 @@ const waitForFundingAndPostFundSetupReducer = (
 const aWaitForPostFundSetupReducer = (
   state: states.AWaitForPostFundSetup,
   action: actions.WalletAction,
-): StateWithSideEffects<states.OpenedChannelState> => {
+): StateWithSideEffects<states.OpenedState> => {
   switch (action.type) {
     case actions.COMMITMENT_RECEIVED:
       const { commitment: postFundState, signature } = action;
@@ -242,7 +242,7 @@ const aWaitForPostFundSetupReducer = (
 const bWaitForPostFundSetupReducer = (
   state: states.BWaitForPostFundSetup,
   action: actions.WalletAction,
-): StateWithSideEffects<states.OpenedChannelState> => {
+): StateWithSideEffects<states.OpenedState> => {
   switch (action.type) {
     case actions.COMMITMENT_RECEIVED:
       const { commitment, signature } = action;
@@ -273,7 +273,7 @@ const bWaitForPostFundSetupReducer = (
 const waitForFundingConfirmationReducer = (
   state: states.WaitForFundingConfirmation,
   action: actions.WalletAction,
-): StateWithSideEffects<states.OpenedChannelState> => {
+): StateWithSideEffects<states.OpenedState> => {
   switch (action.type) {
     case actions.internal.DIRECT_FUNDING_CONFIRMED:
       if (state.channelId === action.channelId) {
@@ -306,7 +306,7 @@ const waitForFundingConfirmationReducer = (
 const acknowledgeFundingDeclinedReducer = (
   state: states.AcknowledgeFundingDeclined,
   action: actions.WalletAction,
-): StateWithSideEffects<states.ChannelState> => {
+): StateWithSideEffects<states.ChannelStatus> => {
   switch (action.type) {
     case actions.FUNDING_DECLINED_ACKNOWLEDGED:
       return {
@@ -343,7 +343,7 @@ const sendFundingDeclinedMessageReducer = (
 const acknowledgeFundingSuccessReducer = (
   state: states.AcknowledgeFundingSuccess,
   action: actions.WalletAction,
-): StateWithSideEffects<states.OpenedChannelState> => {
+): StateWithSideEffects<states.OpenedState> => {
   switch (action.type) {
     case actions.FUNDING_SUCCESS_ACKNOWLEDGED:
       return {

--- a/packages/wallet/src/redux/channelState/opening/reducer.ts
+++ b/packages/wallet/src/redux/channelState/opening/reducer.ts
@@ -16,7 +16,7 @@ import { StateWithSideEffects } from '../../shared/state';
 export const openingReducer = (
   state: channelStates.OpeningState,
   action: actions.WalletAction,
-): StateWithSideEffects<channelStates.ChannelState> => {
+): StateWithSideEffects<channelStates.ChannelStatus> => {
   switch (state.type) {
     case channelStates.WAIT_FOR_CHANNEL:
       return waitForChannelReducer(state, action);

--- a/packages/wallet/src/redux/channelState/opening/reducer.ts
+++ b/packages/wallet/src/redux/channelState/opening/reducer.ts
@@ -5,7 +5,6 @@ import {
   validationSuccess,
   signatureFailure,
   validationFailure,
-  channelInitializationSuccess,
 } from 'magmo-wallet-client/lib/wallet-events';
 
 import { unreachable } from '../../../utils/reducer-utils';
@@ -13,39 +12,18 @@ import { signCommitment, validCommitmentSignature } from '../../../utils/signing
 import { CommitmentType } from 'fmg-core';
 import { channelID } from 'fmg-core/lib/channel';
 import { StateWithSideEffects } from '../../shared/state';
-import { ethers } from 'ethers';
-import { waitForChannel } from './state';
 
 export const openingReducer = (
   state: channelStates.OpeningState,
   action: actions.WalletAction,
 ): StateWithSideEffects<channelStates.ChannelState> => {
   switch (state.type) {
-    case channelStates.WAIT_FOR_ADDRESS:
-      return waitForAddressReducer(state, action);
     case channelStates.WAIT_FOR_CHANNEL:
       return waitForChannelReducer(state, action);
     case channelStates.WAIT_FOR_PRE_FUND_SETUP:
       return waitForPreFundSetupReducer(state, action);
     default:
       return unreachable(state);
-  }
-};
-
-const waitForAddressReducer = (
-  state: channelStates.WaitForAddress,
-  action: actions.WalletAction,
-): StateWithSideEffects<channelStates.WaitForChannel | channelStates.WaitForAddress> => {
-  if (action.type === actions.CHANNEL_INITIALIZED) {
-    const wallet = ethers.Wallet.createRandom();
-    const { address, privateKey } = wallet;
-
-    return {
-      state: waitForChannel({ address, privateKey }),
-      outboxState: { messageOutbox: channelInitializationSuccess(wallet.address) },
-    };
-  } else {
-    return { state };
   }
 };
 

--- a/packages/wallet/src/redux/channelState/opening/state.ts
+++ b/packages/wallet/src/redux/channelState/opening/state.ts
@@ -9,13 +9,25 @@ import {
 export const OPENING = 'OPENING';
 
 // state type
-export const WAIT_FOR_PRE_FUND_SETUP = 'WAIT_FOR_PRE_FUND_SETUP';
+export const WAIT_FOR_ADDRESS = 'WAIT_FOR_ADDRESS';
 export const WAIT_FOR_CHANNEL = 'WAIT_FOR_CHANNEL';
+export const WAIT_FOR_PRE_FUND_SETUP = 'WAIT_FOR_PRE_FUND_SETUP';
 export const METAMASK_LOAD_ERROR = 'METAMASK_LOAD_ERROR';
 
+export interface WaitForAddress {
+  // The default channel state
+  type: typeof WAIT_FOR_ADDRESS;
+  stage: typeof OPENING;
+}
+
 export interface WaitForChannel extends SharedChannelState {
+  // In this state, the slot has been reserved for the channel, with
+  // the address and private key stored in it.
   type: typeof WAIT_FOR_CHANNEL;
   stage: typeof OPENING;
+}
+export function waitForAddress(): WaitForAddress {
+  return { type: WAIT_FOR_ADDRESS, stage: OPENING };
 }
 
 export function waitForChannel<T extends SharedChannelState>(params: T): WaitForChannel {
@@ -33,4 +45,4 @@ export function waitForPreFundSetup<T extends FirstCommitmentReceived>(
   return { type: WAIT_FOR_PRE_FUND_SETUP, stage: OPENING, ...firstCommitmentReceived(params) };
 }
 
-export type OpeningState = WaitForChannel | WaitForPreFundSetup;
+export type OpeningState = WaitForAddress | WaitForChannel | WaitForPreFundSetup;

--- a/packages/wallet/src/redux/channelState/opening/state.ts
+++ b/packages/wallet/src/redux/channelState/opening/state.ts
@@ -9,16 +9,9 @@ import {
 export const OPENING = 'OPENING';
 
 // state type
-export const WAIT_FOR_ADDRESS = 'WAIT_FOR_ADDRESS';
 export const WAIT_FOR_CHANNEL = 'WAIT_FOR_CHANNEL';
 export const WAIT_FOR_PRE_FUND_SETUP = 'WAIT_FOR_PRE_FUND_SETUP';
 export const METAMASK_LOAD_ERROR = 'METAMASK_LOAD_ERROR';
-
-export interface WaitForAddress {
-  // The default channel state
-  type: typeof WAIT_FOR_ADDRESS;
-  stage: typeof OPENING;
-}
 
 export interface WaitForChannel extends SharedChannelState {
   // In this state, the slot has been reserved for the channel, with
@@ -26,10 +19,6 @@ export interface WaitForChannel extends SharedChannelState {
   type: typeof WAIT_FOR_CHANNEL;
   stage: typeof OPENING;
 }
-export function waitForAddress(): WaitForAddress {
-  return { type: WAIT_FOR_ADDRESS, stage: OPENING };
-}
-
 export function waitForChannel<T extends SharedChannelState>(params: T): WaitForChannel {
   return { type: WAIT_FOR_CHANNEL, stage: OPENING, ...baseChannelState(params) };
 }
@@ -45,4 +34,4 @@ export function waitForPreFundSetup<T extends FirstCommitmentReceived>(
   return { type: WAIT_FOR_PRE_FUND_SETUP, stage: OPENING, ...firstCommitmentReceived(params) };
 }
 
-export type OpeningState = WaitForAddress | WaitForChannel | WaitForPreFundSetup;
+export type OpeningState = WaitForChannel | WaitForPreFundSetup;

--- a/packages/wallet/src/redux/channelState/reducer.ts
+++ b/packages/wallet/src/redux/channelState/reducer.ts
@@ -1,17 +1,4 @@
-import {
-  OPENING,
-  FUNDING,
-  RUNNING,
-  CHALLENGING,
-  RESPONDING,
-  WITHDRAWING,
-  CLOSING,
-  approveConclude,
-  ApproveConclude,
-  acknowledgeConclude,
-  AcknowledgeConclude,
-  ChannelState,
-} from './state';
+import * as states from './state';
 
 import { openingReducer } from './opening/reducer';
 import { fundingReducer } from './funding/reducer';
@@ -32,10 +19,10 @@ import { showWallet } from 'magmo-wallet-client/lib/wallet-events';
 import { CommitmentType } from 'fmg-core';
 import { StateWithSideEffects } from '../shared/state';
 
-export const channelReducer: ReducerWithSideEffects<ChannelState> = (
-  state: ChannelState,
+const channelReducer: ReducerWithSideEffects<states.ChannelStatus> = (
+  state: states.ChannelStatus,
   action: WalletAction,
-): StateWithSideEffects<ChannelState> => {
+): StateWithSideEffects<states.ChannelStatus> => {
   const conclusionStateFromOwnRequest = receivedValidOwnConclusionRequest(state, action);
   if (conclusionStateFromOwnRequest) {
     return {
@@ -53,19 +40,19 @@ export const channelReducer: ReducerWithSideEffects<ChannelState> = (
   }
 
   switch (state.stage) {
-    case OPENING:
+    case states.OPENING:
       return openingReducer(state, action);
-    case FUNDING:
+    case states.FUNDING:
       return fundingReducer(state, action);
-    case RUNNING:
+    case states.RUNNING:
       return runningReducer(state, action);
-    case CHALLENGING:
+    case states.CHALLENGING:
       return challengingReducer(state, action);
-    case RESPONDING:
+    case states.RESPONDING:
       return respondingReducer(state, action);
-    case WITHDRAWING:
+    case states.WITHDRAWING:
       return withdrawingReducer(state, action);
-    case CLOSING:
+    case states.CLOSING:
       return closingReducer(state, action);
     default:
       return unreachable(state);
@@ -73,23 +60,23 @@ export const channelReducer: ReducerWithSideEffects<ChannelState> = (
 };
 
 const receivedValidOwnConclusionRequest = (
-  state: ChannelState,
+  state: states.ChannelStatus,
   action: WalletAction,
-): ApproveConclude | null => {
-  if (state.stage !== FUNDING && state.stage !== RUNNING) {
+): states.ApproveConclude | null => {
+  if (state.stage !== states.FUNDING && state.stage !== states.RUNNING) {
     return null;
   }
   if (action.type !== CONCLUDE_REQUESTED || !ourTurn(state)) {
     return null;
   }
-  return approveConclude({ ...state });
+  return states.approveConclude({ ...state });
 };
 
 const receivedValidOpponentConclusionRequest = (
-  state: ChannelState,
+  state: states.ChannelStatus,
   action: WalletAction,
-): AcknowledgeConclude | null => {
-  if (state.stage !== FUNDING && state.stage !== RUNNING) {
+): states.AcknowledgeConclude | null => {
+  if (state.stage !== states.FUNDING && state.stage !== states.RUNNING) {
     return null;
   }
   if (action.type !== COMMITMENT_RECEIVED) {
@@ -110,7 +97,7 @@ const receivedValidOpponentConclusionRequest = (
     return null;
   }
 
-  return acknowledgeConclude({
+  return states.acknowledgeConclude({
     ...state,
     turnNum: commitment.turnNum,
     lastCommitment: { commitment, signature },

--- a/packages/wallet/src/redux/channelState/responding/reducer.ts
+++ b/packages/wallet/src/redux/channelState/responding/reducer.ts
@@ -16,7 +16,7 @@ import { StateWithSideEffects } from '../../shared/state';
 export const respondingReducer = (
   state: states.RespondingState,
   action: WalletAction,
-): StateWithSideEffects<states.ChannelState> => {
+): StateWithSideEffects<states.ChannelStatus> => {
   // Handle any signature/validation request centrally to avoid duplicating code for each state
   if (
     action.type === actions.OWN_COMMITMENT_RECEIVED ||
@@ -53,7 +53,7 @@ export const respondingReducer = (
 const responseTransactionFailedReducer = (
   state: states.ResponseTransactionFailed,
   action: WalletAction,
-): StateWithSideEffects<states.ChannelState> => {
+): StateWithSideEffects<states.ChannelStatus> => {
   switch (action.type) {
     case actions.RETRY_TRANSACTION:
       const transactionOutbox = createRespondWithMoveTransaction(
@@ -80,7 +80,7 @@ const responseTransactionFailedReducer = (
 export const chooseResponseReducer = (
   state: states.ChooseResponse,
   action: WalletAction,
-): StateWithSideEffects<states.ChannelState> => {
+): StateWithSideEffects<states.ChannelStatus> => {
   switch (action.type) {
     case actions.RESPOND_WITH_MOVE_CHOSEN:
       return {
@@ -115,7 +115,7 @@ export const chooseResponseReducer = (
 export const takeMoveInAppReducer = (
   state: states.TakeMoveInApp,
   action: WalletAction,
-): StateWithSideEffects<states.ChannelState> => {
+): StateWithSideEffects<states.ChannelStatus> => {
   switch (action.type) {
     case actions.CHALLENGE_COMMITMENT_RECEIVED:
       // check it's our turn
@@ -157,7 +157,7 @@ export const takeMoveInAppReducer = (
 export const initiateResponseReducer = (
   state: states.InitiateResponse,
   action: WalletAction,
-): StateWithSideEffects<states.ChannelState> => {
+): StateWithSideEffects<states.ChannelStatus> => {
   switch (action.type) {
     case actions.TRANSACTION_SENT_TO_METAMASK:
       return { state: states.waitForResponseSubmission(state) };
@@ -178,7 +178,7 @@ export const initiateResponseReducer = (
 export const waitForResponseSubmissionReducer = (
   state: states.WaitForResponseSubmission,
   action: WalletAction,
-): StateWithSideEffects<states.ChannelState> => {
+): StateWithSideEffects<states.ChannelStatus> => {
   switch (action.type) {
     case actions.TRANSACTION_SUBMITTED:
       return {
@@ -206,7 +206,7 @@ export const waitForResponseSubmissionReducer = (
 export const waitForResponseConfirmationReducer = (
   state: states.WaitForResponseConfirmation,
   action: WalletAction,
-): StateWithSideEffects<states.ChannelState> => {
+): StateWithSideEffects<states.ChannelStatus> => {
   switch (action.type) {
     case actions.BLOCK_MINED:
       if (
@@ -227,7 +227,7 @@ export const waitForResponseConfirmationReducer = (
 export const acknowledgeChallengeCompleteReducer = (
   state: states.AcknowledgeChallengeComplete,
   action: WalletAction,
-): StateWithSideEffects<states.ChannelState> => {
+): StateWithSideEffects<states.ChannelStatus> => {
   switch (action.type) {
     case actions.CHALLENGE_RESPONSE_ACKNOWLEDGED:
       return {
@@ -242,7 +242,7 @@ export const acknowledgeChallengeCompleteReducer = (
 const challengeeAcknowledgeChallengeTimeoutReducer = (
   state: states.ChallengeeAcknowledgeChallengeTimeout,
   action: WalletAction,
-): StateWithSideEffects<states.ChannelState> => {
+): StateWithSideEffects<states.ChannelStatus> => {
   switch (action.type) {
     case actions.CHALLENGE_TIME_OUT_ACKNOWLEDGED:
       return {

--- a/packages/wallet/src/redux/channelState/running/__tests__/running.test.ts
+++ b/packages/wallet/src/redux/channelState/running/__tests__/running.test.ts
@@ -72,7 +72,11 @@ describe('when in WaitForUpdate on our turn', () => {
   });
 
   describe('when the wallet detects an opponent challenge', () => {
-    const action = actions.challengeCreatedEvent(1, '0x0', defaults.challengeExpiry);
+    const action = actions.challengeCreatedEvent(
+      '0xf00',
+      scenarios.preFundCommitment1,
+      defaults.challengeExpiry,
+    );
     const updatedState = runningReducer(state, action);
 
     itTransitionsToChannelStateType(states.CHOOSE_RESPONSE, updatedState);
@@ -126,7 +130,11 @@ describe(`when in WaitForUpdate on our opponent's turn`, () => {
   });
 
   describe('when the wallet detects an opponent challenge', () => {
-    const action = actions.challengeCreatedEvent(1, '0x0', defaults.challengeExpiry);
+    const action = actions.challengeCreatedEvent(
+      '0xf00',
+      scenarios.preFundCommitment1,
+      defaults.challengeExpiry,
+    );
     const updatedState = runningReducer(state, action);
 
     itTransitionsToChannelStateType(states.CHOOSE_RESPONSE, updatedState);

--- a/packages/wallet/src/redux/channelState/shared/state.ts
+++ b/packages/wallet/src/redux/channelState/shared/state.ts
@@ -5,8 +5,6 @@ export interface SharedChannelState {
   privateKey: string;
 }
 
-export const CHANNEL_INITIALIZED = 'CHANNEL.INITIALIZED';
-
 export interface SignedCommitment {
   commitment: Commitment;
   signature: string;

--- a/packages/wallet/src/redux/channelState/state.ts
+++ b/packages/wallet/src/redux/channelState/state.ts
@@ -15,6 +15,10 @@ export type OpenedState =
   | ClosingState;
 
 export type ChannelStatus = OpeningState | OpenedState;
+// TODO: It would be helpful for channelId to have type Address
+export interface ChannelState {
+  [channelId: string]: ChannelStatus;
+}
 
 export * from './opening/state';
 export * from './running/state';

--- a/packages/wallet/src/redux/channelState/state.ts
+++ b/packages/wallet/src/redux/channelState/state.ts
@@ -6,6 +6,15 @@ import { RespondingState } from './responding/state';
 import { WithdrawingState } from './withdrawing/state';
 import { ClosingState } from './closing/state';
 
+export interface InitializingChannelStatus {
+  address: string;
+  privateKey: string;
+}
+
+export interface InitializingChannelState {
+  [participantAddress: string]: InitializingChannelStatus;
+}
+
 export type OpenedState =
   | FundingState
   | RunningState
@@ -16,8 +25,14 @@ export type OpenedState =
 
 export type ChannelStatus = OpeningState | OpenedState;
 // TODO: It would be helpful for channelId to have type Address
-export interface ChannelState {
+
+export interface InitializedChannelState {
   [channelId: string]: ChannelStatus;
+}
+export interface ChannelState {
+  initializingChannels: InitializingChannelState;
+  initializedChannels: InitializedChannelState;
+  activeAppChannelId?: string;
 }
 
 export * from './opening/state';

--- a/packages/wallet/src/redux/channelState/state.ts
+++ b/packages/wallet/src/redux/channelState/state.ts
@@ -24,7 +24,6 @@ export type OpenedState =
   | ClosingState;
 
 export type ChannelStatus = OpeningState | OpenedState;
-// TODO: It would be helpful for channelId to have type Address
 
 export interface InitializedChannelState {
   [channelId: string]: ChannelStatus;

--- a/packages/wallet/src/redux/channelState/state.ts
+++ b/packages/wallet/src/redux/channelState/state.ts
@@ -6,7 +6,7 @@ import { RespondingState } from './responding/state';
 import { WithdrawingState } from './withdrawing/state';
 import { ClosingState } from './closing/state';
 
-export type OpenedChannelState =
+export type OpenedState =
   | FundingState
   | RunningState
   | ChallengingState
@@ -14,7 +14,7 @@ export type OpenedChannelState =
   | WithdrawingState
   | ClosingState;
 
-export type ChannelState = OpeningState | OpenedChannelState;
+export type ChannelStatus = OpeningState | OpenedState;
 
 export * from './opening/state';
 export * from './running/state';

--- a/packages/wallet/src/redux/channelState/withdrawing/reducer.ts
+++ b/packages/wallet/src/redux/channelState/withdrawing/reducer.ts
@@ -10,7 +10,7 @@ import { StateWithSideEffects } from '../../shared/state';
 export const withdrawingReducer = (
   state: states.WithdrawingState,
   action: actions.WalletAction,
-): StateWithSideEffects<states.ChannelState> => {
+): StateWithSideEffects<states.ChannelStatus> => {
   // Handle any signature/validation request centrally to avoid duplicating code for each state
   if (
     action.type === actions.OWN_COMMITMENT_RECEIVED ||
@@ -40,7 +40,7 @@ export const withdrawingReducer = (
 const withdrawTransactionFailedReducer = (
   state: states.WithdrawTransactionFailed,
   action: actions.WalletAction,
-): StateWithSideEffects<states.ChannelState> => {
+): StateWithSideEffects<states.ChannelStatus> => {
   switch (action.type) {
     case actions.RETRY_TRANSACTION:
       const myAddress = state.participants[state.ourIndex];
@@ -71,7 +71,7 @@ const withdrawTransactionFailedReducer = (
 const approveWithdrawalReducer = (
   state: states.ApproveWithdrawal,
   action: actions.WalletAction,
-): StateWithSideEffects<states.ChannelState> => {
+): StateWithSideEffects<states.ChannelStatus> => {
   switch (action.type) {
     case actions.WITHDRAWAL_APPROVED:
       const myAddress = state.participants[state.ourIndex];
@@ -107,7 +107,7 @@ const approveWithdrawalReducer = (
 const waitForWithdrawalInitiationReducer = (
   state: states.WaitForWithdrawalInitiation,
   action: actions.WalletAction,
-): StateWithSideEffects<states.ChannelState> => {
+): StateWithSideEffects<states.ChannelStatus> => {
   switch (action.type) {
     case actions.TRANSACTION_SUBMITTED:
       return {
@@ -126,7 +126,7 @@ const waitForWithdrawalInitiationReducer = (
 const waitForWithdrawalConfirmationReducer = (
   state: states.WaitForWithdrawalConfirmation,
   action: actions.WalletAction,
-): StateWithSideEffects<states.ChannelState> => {
+): StateWithSideEffects<states.ChannelStatus> => {
   switch (action.type) {
     case actions.TRANSACTION_CONFIRMED:
       return { state: states.acknowledgeWithdrawalSuccess(state) };
@@ -138,7 +138,7 @@ const waitForWithdrawalConfirmationReducer = (
 const acknowledgeWithdrawalSuccessReducer = (
   state: states.AcknowledgeWithdrawalSuccess,
   action: actions.WalletAction,
-): StateWithSideEffects<states.ChannelState> => {
+): StateWithSideEffects<states.ChannelStatus> => {
   switch (action.type) {
     case actions.WITHDRAWAL_SUCCESS_ACKNOWLEDGED:
       // TODO: We shouldn't be sending out a close success in the withdrawal reducer

--- a/packages/wallet/src/redux/fundingState/__tests__/funding.test.ts
+++ b/packages/wallet/src/redux/fundingState/__tests__/funding.test.ts
@@ -27,6 +27,7 @@ const defaultsForB: directFundingStates.DirectFundingState = {
   ourIndex: 1,
   safeToDepositLevel: '0x',
   channelFundingStatus: directFundingStates.NOT_SAFE_TO_DEPOSIT,
+  depositStatus: directFundingStates.depositing.WAIT_FOR_TRANSACTION_SENT,
 };
 
 const TX = 'TX';

--- a/packages/wallet/src/redux/fundingState/directFunding/__tests__/directFunding.test.ts
+++ b/packages/wallet/src/redux/fundingState/directFunding/__tests__/directFunding.test.ts
@@ -27,6 +27,7 @@ const defaultsForA: states.DirectFundingState = {
   ourIndex: 0,
   safeToDepositLevel: '0x',
   channelFundingStatus: states.NOT_SAFE_TO_DEPOSIT,
+  depositStatus: states.depositing.WAIT_FOR_TRANSACTION_SENT,
 };
 
 const defaultsForB: states.DirectFundingState = {

--- a/packages/wallet/src/redux/fundingState/directFunding/depositing/__tests__/depositing.test.ts
+++ b/packages/wallet/src/redux/fundingState/directFunding/depositing/__tests__/depositing.test.ts
@@ -12,7 +12,7 @@ import {
 } from '../../../../__tests__/helpers';
 import * as TransactionGenerator from '../../../../../utils/transaction-generator';
 import { bigNumberify } from 'ethers/utils';
-import { DIRECT_FUNDING } from '../../../shared/state';
+import { DIRECT_FUNDING } from '../../../state';
 
 const { channelId } = scenarios;
 

--- a/packages/wallet/src/redux/fundingState/directFunding/depositing/state.ts
+++ b/packages/wallet/src/redux/fundingState/directFunding/depositing/state.ts
@@ -1,4 +1,4 @@
-import { BaseDirectFundingState, SAFE_TO_DEPOSIT, sharedDirectFundingState } from '../state';
+import { BaseDirectFundingState, SAFE_TO_DEPOSIT, baseDirectFundingState } from '../state';
 import { TransactionExists } from '../../../shared/state';
 
 // Deposit status
@@ -46,7 +46,7 @@ export function waitForTransactionSent<T extends BaseDirectFundingState>(
   params: T,
 ): WaitForTransactionSent {
   return {
-    ...sharedDirectFundingState(params),
+    ...baseDirectFundingState(params),
     depositStatus: WAIT_FOR_TRANSACTION_SENT,
     channelFundingStatus: SAFE_TO_DEPOSIT,
   };
@@ -56,7 +56,7 @@ export function waitForDepositApproval<T extends BaseDirectFundingState>(
   params: T,
 ): WaitForDepositApproval {
   return {
-    ...sharedDirectFundingState(params),
+    ...baseDirectFundingState(params),
     depositStatus: WAIT_FOR_DEPOSIT_APPROVAL,
     channelFundingStatus: SAFE_TO_DEPOSIT,
   };
@@ -65,7 +65,7 @@ export function waitForDepositConfirmation<T extends BaseWithTransaction>(
   params: T,
 ): WaitForDepositConfirmation {
   return {
-    ...sharedDirectFundingState(params),
+    ...baseDirectFundingState(params),
     depositStatus: WAIT_FOR_DEPOSIT_CONFIRMATION,
     channelFundingStatus: SAFE_TO_DEPOSIT,
     transactionHash: params.transactionHash,
@@ -75,7 +75,7 @@ export function depositTransactionFailed<T extends BaseDirectFundingState>(
   params: T,
 ): DepositTransactionFailed {
   return {
-    ...sharedDirectFundingState(params),
+    ...baseDirectFundingState(params),
     depositStatus: DEPOSIT_TRANSACTION_FAILED,
     channelFundingStatus: SAFE_TO_DEPOSIT,
   };

--- a/packages/wallet/src/redux/fundingState/directFunding/state.ts
+++ b/packages/wallet/src/redux/fundingState/directFunding/state.ts
@@ -1,5 +1,4 @@
-import { SharedDirectFundingState, DIRECT_FUNDING } from '../shared/state';
-export { SharedDirectFundingState, DIRECT_FUNDING };
+import { BaseFundingState } from '../shared/state';
 
 import * as depositing from './depositing/state';
 export { depositing };
@@ -15,7 +14,11 @@ export type ChannelFundingStatus =
   | typeof SAFE_TO_DEPOSIT
   | typeof CHANNEL_FUNDED;
 
-export interface BaseDirectFundingState extends SharedDirectFundingState {
+export const DIRECT_FUNDING = 'FUNDING_TYPE.DIRECT';
+
+export interface BaseDirectFundingState extends BaseFundingState {
+  fundingType: typeof DIRECT_FUNDING;
+  safeToDepositLevel: string;
   depositStatus?: depositing.DepositStatus;
   channelFundingStatus: ChannelFundingStatus;
 }
@@ -64,9 +67,9 @@ export const stateIsWaitForFundingConfirmation = (
 export const stateIsChannelFunded = guardGenerator<ChannelFunded>(CHANNEL_FUNDED);
 
 // constructors
-export function sharedDirectFundingState<T extends SharedDirectFundingState>(
+export function baseDirectFundingState<T extends BaseDirectFundingState>(
   params: T,
-): SharedDirectFundingState {
+): BaseDirectFundingState {
   const {
     requestedTotalFunds,
     requestedYourContribution,
@@ -83,12 +86,13 @@ export function sharedDirectFundingState<T extends SharedDirectFundingState>(
     ourIndex,
     safeToDepositLevel,
     channelFundingStatus,
+    depositStatus,
   };
 }
 
 export function notSafeToDeposit<T extends BaseDirectFundingState>(params: T): NotSafeToDeposit {
   return {
-    ...sharedDirectFundingState(params),
+    ...baseDirectFundingState(params),
     channelFundingStatus: NOT_SAFE_TO_DEPOSIT,
   };
 }
@@ -97,7 +101,7 @@ export function waitForFundingConfirmed<T extends BaseDirectFundingState>(
   params: T,
 ): WaitForFundingConfirmation {
   return {
-    ...sharedDirectFundingState(params),
+    ...baseDirectFundingState(params),
     depositStatus: depositing.DEPOSIT_CONFIRMED,
     channelFundingStatus: SAFE_TO_DEPOSIT,
   };
@@ -105,8 +109,7 @@ export function waitForFundingConfirmed<T extends BaseDirectFundingState>(
 
 export function channelFunded<T extends BaseDirectFundingState>(params: T): ChannelFunded {
   return {
-    ...sharedDirectFundingState(params),
-    depositStatus: depositing.DEPOSIT_CONFIRMED,
+    ...baseDirectFundingState(params),
     channelFundingStatus: CHANNEL_FUNDED,
   };
 }

--- a/packages/wallet/src/redux/fundingState/directFunding/state.ts
+++ b/packages/wallet/src/redux/fundingState/directFunding/state.ts
@@ -52,7 +52,8 @@ const guardGenerator = <T extends DirectFundingState>(type) => (
 export const stateIsNotSafeToDeposit = guardGenerator<NotSafeToDeposit>(NOT_SAFE_TO_DEPOSIT);
 export const stateIsDepositing = (state: DirectFundingState): state is depositing.Depositing => {
   return (
-    state.channelFundingStatus === SAFE_TO_DEPOSIT &&
+    (state.channelFundingStatus === SAFE_TO_DEPOSIT ||
+      state.channelFundingStatus === CHANNEL_FUNDED) &&
     state.depositStatus !== depositing.DEPOSIT_CONFIRMED
   );
 };

--- a/packages/wallet/src/redux/fundingState/directFunding/state.ts
+++ b/packages/wallet/src/redux/fundingState/directFunding/state.ts
@@ -19,7 +19,7 @@ export const DIRECT_FUNDING = 'FUNDING_TYPE.DIRECT';
 export interface BaseDirectFundingState extends BaseFundingState {
   fundingType: typeof DIRECT_FUNDING;
   safeToDepositLevel: string;
-  depositStatus?: depositing.DepositStatus;
+  depositStatus: depositing.DepositStatus;
   channelFundingStatus: ChannelFundingStatus;
 }
 
@@ -77,6 +77,7 @@ export function baseDirectFundingState<T extends BaseDirectFundingState>(
     ourIndex,
     safeToDepositLevel,
     channelFundingStatus,
+    depositStatus,
   } = params;
   return {
     fundingType: DIRECT_FUNDING,

--- a/packages/wallet/src/redux/fundingState/reducer.ts
+++ b/packages/wallet/src/redux/fundingState/reducer.ts
@@ -45,11 +45,11 @@ const unknownFundingTypeReducer = (
 
       const alreadySafeToDeposit =
         bigNumberify(safeToDepositLevel).eq('0x') ||
-        (state.destination === action.channelId &&
+        (state.channelId === action.channelId &&
           bigNumberify(action.safeToDepositLevel).lte(state.totalForDestination!));
       const alreadyFunded =
         bigNumberify(totalFundingRequired).eq('0x') ||
-        (state.destination === action.channelId &&
+        (state.channelId === action.channelId &&
           bigNumberify(action.totalFundingRequired).lte(state.totalForDestination!));
 
       const channelFundingStatus = alreadyFunded

--- a/packages/wallet/src/redux/fundingState/shared/state.ts
+++ b/packages/wallet/src/redux/fundingState/shared/state.ts
@@ -6,12 +6,6 @@ export interface BaseFundingState {
   channelFundingStatus: string;
 }
 
-export const DIRECT_FUNDING = 'FUNDING_TYPE.DIRECT';
-export interface SharedDirectFundingState extends BaseFundingState {
-  fundingType: typeof DIRECT_FUNDING;
-  safeToDepositLevel: string;
-}
-
 export const INDIRECT_FUNDING = 'FUNDING_TYPE.INDIRECT';
 export interface SharedIndirectFundingState extends BaseFundingState {
   fundingType: typeof INDIRECT_FUNDING;

--- a/packages/wallet/src/redux/fundingState/state.ts
+++ b/packages/wallet/src/redux/fundingState/state.ts
@@ -6,7 +6,7 @@ export const FUNDING_NOT_STARTED = 'FUNDING_NOT_STARTED';
 
 interface SharedFundingState {
   totalForDestination?: string;
-  destination?: string;
+  channelId?: string;
 }
 export interface UnknownFundingState extends SharedFundingState {
   fundingType: typeof UNKNOWN_FUNDING_TYPE;

--- a/packages/wallet/src/redux/initialized/__tests__/initialized.test.ts
+++ b/packages/wallet/src/redux/initialized/__tests__/initialized.test.ts
@@ -5,7 +5,7 @@ import * as fundingStates from '../../fundingState/state';
 import * as actions from '../../actions';
 import * as outgoing from 'magmo-wallet-client/lib/wallet-events';
 import * as scenarios from '../../__tests__/test-scenarios';
-import { itSendsThisMessage } from '../../__tests__/helpers';
+import { itSendsThisMessage, itDispatchesThisAction } from '../../__tests__/helpers';
 import { waitForUpdate } from '../../channelState/state';
 
 const { channelId } = scenarios;
@@ -83,7 +83,7 @@ describe('When the channel reducer declares a side effect', () => {
       initializingChannels: {},
       activeAppChannelId: channelId,
     },
-    outboxState: {},
+    outboxState: { actionOutbox: actions.internal.directFundingConfirmed('channelId') },
   });
 
   const action = actions.challengeRequested();
@@ -91,4 +91,5 @@ describe('When the channel reducer declares a side effect', () => {
   const updatedState = initializedReducer(state, action);
 
   itSendsThisMessage(updatedState, outgoing.CHALLENGE_REJECTED);
+  itDispatchesThisAction(actions.internal.DIRECT_FUNDING_CONFIRMED, updatedState);
 });

--- a/packages/wallet/src/redux/initialized/reducer.ts
+++ b/packages/wallet/src/redux/initialized/reducer.ts
@@ -1,55 +1,14 @@
-import {
-  initializingChannel,
-  InitializedState,
-  WALLET_INITIALIZED,
-  INITIALIZING_CHANNEL,
-  WAITING_FOR_CHANNEL_INITIALIZATION,
-  channelInitialized,
-} from './state';
+import { InitializedState } from './state';
 
-import { waitForFundingRequest } from '../fundingState/state';
-
-import { WalletAction, CHANNEL_INITIALIZED } from '../actions';
-import { channelInitializationSuccess } from 'magmo-wallet-client/lib/wallet-events';
-import { ethers } from 'ethers';
+import { WalletAction } from '../actions';
+import { combineReducersWithSideEffects } from '../../utils/reducer-utils';
 import { channelReducer } from '../channelState/reducer';
-import { unreachable, combineReducersWithSideEffects } from '../../utils/reducer-utils';
 import { fundingStateReducer } from '../fundingState/reducer';
 
-export const initializedReducer = (
+export const initializedReducer: (
   state: InitializedState,
   action: WalletAction,
-): InitializedState => {
-  if (state.stage !== WALLET_INITIALIZED) {
-    return state;
-  }
-
-  switch (state.type) {
-    case WAITING_FOR_CHANNEL_INITIALIZATION:
-      if (action.type === CHANNEL_INITIALIZED) {
-        const wallet = ethers.Wallet.createRandom();
-        const { address, privateKey } = wallet;
-
-        return initializingChannel({
-          ...state,
-          outboxState: { messageOutbox: channelInitializationSuccess(wallet.address) },
-          channelState: { address, privateKey },
-          fundingState: waitForFundingRequest(),
-        });
-      }
-      break;
-    case INITIALIZING_CHANNEL: // TODO: We could probably get rid of this stage
-    case CHANNEL_INITIALIZED: {
-      return channelInitialized(channelInitializedReducer(state, action));
-    }
-    default:
-      return unreachable(state);
-  }
-
-  return state;
-};
-
-const channelInitializedReducer = combineReducersWithSideEffects({
+) => InitializedState = combineReducersWithSideEffects({
   channelState: channelReducer,
   fundingState: fundingStateReducer,
 });

--- a/packages/wallet/src/redux/initialized/reducer.ts
+++ b/packages/wallet/src/redux/initialized/reducer.ts
@@ -4,13 +4,16 @@ import { WalletAction } from '../actions';
 import { combineReducersWithSideEffects } from '../../utils/reducer-utils';
 import { channelStateReducer } from '../channelState/reducer';
 import { fundingStateReducer } from '../fundingState/reducer';
+import { applySideEffects } from '../outbox';
 
 export function initializedReducer(
   state: InitializedState,
   action: WalletAction,
 ): InitializedState {
-  const { state: newState, outboxState } = combinedReducer(state, action);
-  return { ...state, ...newState, outboxState };
+  const { state: newState, outboxState: sideEffects } = combinedReducer(state, action);
+  // Since the wallet state itself has an outbox state, we need to apply the side effects
+  // by hand.
+  return { ...state, ...newState, outboxState: applySideEffects(state.outboxState, sideEffects) };
 }
 const combinedReducer = combineReducersWithSideEffects({
   channelState: channelStateReducer,

--- a/packages/wallet/src/redux/initialized/reducer.ts
+++ b/packages/wallet/src/redux/initialized/reducer.ts
@@ -2,13 +2,17 @@ import { InitializedState } from './state';
 
 import { WalletAction } from '../actions';
 import { combineReducersWithSideEffects } from '../../utils/reducer-utils';
-import { channelReducer } from '../channelState/reducer';
+import { channelStateReducer } from '../channelState/reducer';
 import { fundingStateReducer } from '../fundingState/reducer';
 
-export const initializedReducer: (
+export function initializedReducer(
   state: InitializedState,
   action: WalletAction,
-) => InitializedState = combineReducersWithSideEffects({
-  channelState: channelReducer,
+): InitializedState {
+  const { state: newState, outboxState } = combinedReducer(state, action);
+  return { ...state, ...newState, outboxState };
+}
+const combinedReducer = combineReducersWithSideEffects({
+  channelState: channelStateReducer,
   fundingState: fundingStateReducer,
 });

--- a/packages/wallet/src/redux/initialized/state.ts
+++ b/packages/wallet/src/redux/initialized/state.ts
@@ -1,85 +1,22 @@
 import { AdjudicatorKnown, adjudicatorKnown } from '../shared/state';
-import { SharedChannelState } from '../channelState/shared/state';
-import { waitForChannel, ChannelState, WaitForChannel } from '../channelState/state';
-
-interface BaseInitializingChannel extends AdjudicatorKnown {
-  channelState: SharedChannelState;
-}
-
-interface BaseInitializedChannel extends AdjudicatorKnown {
-  channelState: ChannelState;
-}
 
 // stage
 export const WALLET_INITIALIZED = 'WALLET.INITIALIZED';
 
-// types
-export const WAITING_FOR_CHANNEL_INITIALIZATION = 'WALLET.WAITING_FOR_CHANNEL_INITIALIZATION';
-export const INITIALIZING_CHANNEL = 'WALLET.INITIALIZING_CHANNEL';
-export const CHANNEL_INITIALIZED = 'WALLET.CHANNEL_INITIALIZED';
-
-export interface WaitingForChannelInitialization extends AdjudicatorKnown {
+export interface Initialized extends AdjudicatorKnown {
   stage: typeof WALLET_INITIALIZED;
-  type: typeof WAITING_FOR_CHANNEL_INITIALIZATION;
+  type: typeof WALLET_INITIALIZED;
 }
 
-export function waitingForChannelInitialization<T extends AdjudicatorKnown>(
-  params: T,
-): WaitingForChannelInitialization {
+export function initialized<T extends AdjudicatorKnown>(params: T): Initialized {
   const { outboxState, uid } = params;
   return {
     ...adjudicatorKnown(params),
-    type: WAITING_FOR_CHANNEL_INITIALIZATION,
     stage: WALLET_INITIALIZED,
+    type: WALLET_INITIALIZED,
     outboxState,
     uid,
   };
 }
 
-export interface InitializingChannel extends BaseInitializingChannel {
-  // In the InitializingChannel state, the wallet has reserved a slot for the channel, with
-  // the address and private key stored in it.
-  // However, no commitment is known, so it is not yet a "ChannelState"
-  stage: typeof WALLET_INITIALIZED;
-  type: typeof INITIALIZING_CHANNEL;
-  channelState: WaitForChannel;
-}
-
-export function initializingChannel<T extends BaseInitializingChannel>(
-  params: T,
-): InitializingChannel {
-  const { outboxState, channelState, fundingState } = params;
-  return {
-    ...adjudicatorKnown(params),
-    type: INITIALIZING_CHANNEL,
-    stage: WALLET_INITIALIZED,
-    outboxState,
-    channelState: waitForChannel(channelState),
-    fundingState,
-  };
-}
-
-export interface ChannelInitialized extends BaseInitializingChannel {
-  stage: typeof WALLET_INITIALIZED;
-  type: typeof CHANNEL_INITIALIZED;
-  channelState: ChannelState;
-}
-
-export function channelInitialized<T extends BaseInitializedChannel>(
-  params: T,
-): ChannelInitialized {
-  const { outboxState, channelState, unhandledAction } = params;
-  return {
-    ...adjudicatorKnown(params),
-    type: CHANNEL_INITIALIZED,
-    stage: WALLET_INITIALIZED,
-    outboxState,
-    channelState,
-    unhandledAction,
-  };
-}
-
-export type InitializedState =
-  | WaitingForChannelInitialization
-  | InitializingChannel
-  | ChannelInitialized;
+export type InitializedState = Initialized;

--- a/packages/wallet/src/redux/initializing/__tests__/initializing.test.ts
+++ b/packages/wallet/src/redux/initializing/__tests__/initializing.test.ts
@@ -3,7 +3,7 @@ import { initializingReducer } from '../reducer';
 import * as states from '../../state';
 import * as actions from '../../actions';
 
-const defaults = { uid: 'uid', outboxState: {} };
+const defaults = { ...states.emptyState, uid: 'uid' };
 
 describe('when in WaitForLogin', () => {
   const state = states.waitForLogin();
@@ -25,8 +25,8 @@ describe('when in WaitForAdjudicator', () => {
     const action = actions.adjudicatorKnown('address', 'network_id');
     const updatedState = initializingReducer(state, action);
 
-    it('transitions to WAIT_FOR_ADJUDICATOR', async () => {
-      expect(updatedState.type).toEqual(states.WAITING_FOR_CHANNEL_INITIALIZATION);
+    it('transitions to WALLET_INITIALIZED', async () => {
+      expect(updatedState.type).toEqual(states.WALLET_INITIALIZED);
     });
   });
 });

--- a/packages/wallet/src/redux/initializing/reducer.ts
+++ b/packages/wallet/src/redux/initializing/reducer.ts
@@ -7,11 +7,12 @@ import {
   WaitForLogin,
   WaitForAdjudicator,
 } from './state';
-import { waitingForChannelInitialization, InitializedState } from '../state';
+import { InitializedState } from '../state';
 
 import { WalletAction, LOGGED_IN, ADJUDICATOR_KNOWN } from '../actions';
 import { unreachable } from '../../utils/reducer-utils';
 import { initializationSuccess } from 'magmo-wallet-client/lib/wallet-events';
+import { initialized } from '../initialized/state';
 
 export const initializingReducer = (
   state: InitializingState,
@@ -50,7 +51,7 @@ const waitForAdjudicatorReducer = (
   switch (action.type) {
     case ADJUDICATOR_KNOWN:
       const { adjudicator, networkId } = action;
-      return waitingForChannelInitialization({
+      return initialized({
         ...state,
         outboxState: { messageOutbox: initializationSuccess() },
         adjudicator,

--- a/packages/wallet/src/redux/initializing/state.ts
+++ b/packages/wallet/src/redux/initializing/state.ts
@@ -1,5 +1,4 @@
-import { SharedWalletState, base, LoggedIn, loggedIn } from '../shared/state';
-import { waitForFundingRequest } from '../fundingState/state';
+import { SharedWalletState, base, LoggedIn, loggedIn, emptyState } from '../shared/state';
 
 export const INITIALIZING = 'INITIALIZING';
 
@@ -11,12 +10,11 @@ export interface WaitForLogin extends SharedWalletState {
   type: typeof WAIT_FOR_LOGIN;
   stage: typeof INITIALIZING;
 }
-export function waitForLogin<T extends SharedWalletState>(params = {} as T): WaitForLogin {
+export function waitForLogin(): WaitForLogin {
   return {
     type: WAIT_FOR_LOGIN,
     stage: INITIALIZING,
-    fundingState: waitForFundingRequest(),
-    ...base(params),
+    ...emptyState,
   };
 }
 

--- a/packages/wallet/src/redux/sagas/saga-manager.ts
+++ b/packages/wallet/src/redux/sagas/saga-manager.ts
@@ -6,12 +6,13 @@ import { transactionSender } from './transaction-sender';
 import { adjudicatorWatcher } from './adjudicator-watcher';
 import { blockMiningWatcher } from './block-mining-watcher';
 
-import { WalletState, CHANNEL_INITIALIZED, WAIT_FOR_ADJUDICATOR } from '../state';
+import { WalletState, WAIT_FOR_ADJUDICATOR } from '../state';
 import { getProvider } from '../../utils/contract-utils';
 
 import { displaySender } from './display-sender';
 import { ganacheMiner } from './ganache-miner';
 import { adjudicatorLoader } from './adjudicator-loader';
+import { WALLET_INITIALIZED } from '../initialized/state';
 
 export function* sagaManager(): IterableIterator<any> {
   let adjudicatorWatcherProcess;
@@ -36,7 +37,8 @@ export function* sagaManager(): IterableIterator<any> {
     }
 
     // if have adjudicator, make sure that the adjudicator watcher is running
-    if (state.type === CHANNEL_INITIALIZED) {
+    if (state.type === WALLET_INITIALIZED) {
+      throw new Error('TODO: Correctly use the channel state');
       if ('channelId' in state.channelState) {
         if (!adjudicatorWatcherProcess) {
           const provider = yield getProvider();

--- a/packages/wallet/src/redux/shared/state.ts
+++ b/packages/wallet/src/redux/shared/state.ts
@@ -1,5 +1,5 @@
 import { OutboxState } from '../outbox/state';
-import { FundingState } from '../fundingState/state';
+import { FundingState, waitForFundingRequest } from '../fundingState/state';
 import { ChannelState } from '../channelState/state';
 
 export interface StateWithSideEffects<T> {
@@ -8,15 +8,15 @@ export interface StateWithSideEffects<T> {
 }
 
 export interface SharedWalletState {
-  channelState: { [channelId: string]: ChannelState };
-  fundingState: { [channelId: string]: FundingState };
+  channelState: ChannelState;
+  fundingState: FundingState;
   outboxState: OutboxState;
 }
 
 export const emptyState: SharedWalletState = {
   outboxState: {},
-  fundingState: {},
-  channelState: {},
+  fundingState: waitForFundingRequest(),
+  channelState: { initializedChannels: {}, initializingChannels: {} },
 };
 
 export interface LoggedIn extends SharedWalletState {

--- a/packages/wallet/src/redux/shared/state.ts
+++ b/packages/wallet/src/redux/shared/state.ts
@@ -1,7 +1,6 @@
-import { WalletAction } from '../actions';
-import { SharedChannelState } from '../channelState/shared/state';
 import { OutboxState } from '../outbox/state';
 import { FundingState } from '../fundingState/state';
+import { ChannelState } from '../channelState/state';
 
 export interface StateWithSideEffects<T> {
   state: T;
@@ -9,11 +8,16 @@ export interface StateWithSideEffects<T> {
 }
 
 export interface SharedWalletState {
-  channelState?: SharedChannelState;
-  fundingState?: FundingState;
+  channelState: { [channelId: string]: ChannelState };
+  fundingState: { [channelId: string]: FundingState };
   outboxState: OutboxState;
-  unhandledAction?: WalletAction;
 }
+
+export const emptyState: SharedWalletState = {
+  outboxState: {},
+  fundingState: {},
+  channelState: {},
+};
 
 export interface LoggedIn extends SharedWalletState {
   uid: string;
@@ -39,6 +43,6 @@ export function loggedIn<T extends LoggedIn>(params: T): LoggedIn {
 }
 
 export function adjudicatorKnown<T extends AdjudicatorKnown>(params: T): AdjudicatorKnown {
-  const { networkId, adjudicator } = params;
-  return { ...loggedIn(params), networkId, adjudicator };
+  const { networkId, adjudicator, channelState } = params;
+  return { ...loggedIn(params), networkId, adjudicator, channelState };
 }

--- a/packages/wallet/src/redux/state.ts
+++ b/packages/wallet/src/redux/state.ts
@@ -1,10 +1,10 @@
-import { SharedWalletState } from './shared/state';
+import { SharedWalletState, emptyState } from './shared/state';
 import { InitializingState } from './initializing/state';
 import { InitializedState } from './initialized/state';
 
 export * from './initialized/state';
 export * from './initializing/state';
 
-export { SharedWalletState };
+export { SharedWalletState, emptyState };
 
 export type WalletState = InitializingState | InitializedState;

--- a/packages/wallet/src/utils/reducer-utils.ts
+++ b/packages/wallet/src/utils/reducer-utils.ts
@@ -40,9 +40,6 @@ export type ReducersMapObject<S = any, A extends WalletAction = WalletAction> = 
   [K in keyof S]: ReducerWithSideEffects<S[K], A>
 };
 
-// interface HasOutboxState {
-//   outboxState: OutboxState;
-// }
 export type ReducerWithSideEffects<Tree, A extends WalletAction = WalletAction> = (
   state: Tree,
   action: A,

--- a/packages/wallet/src/utils/reducer-utils.ts
+++ b/packages/wallet/src/utils/reducer-utils.ts
@@ -1,5 +1,5 @@
 import { Commitment } from 'fmg-core';
-import { ChannelState } from '../redux/channelState/state';
+import { ChannelStatus } from '../redux/channelState/state';
 import { channelID } from 'fmg-core/lib/channel';
 import { applySideEffects } from '../redux/outbox';
 import { OutboxState } from 'src/redux/outbox/state';
@@ -9,7 +9,7 @@ export function unreachable(x: never) {
   return x;
 }
 
-export const validTransition = (fromState: ChannelState, toCommitment: Commitment) => {
+export const validTransition = (fromState: ChannelStatus, toCommitment: Commitment) => {
   // todo: check the game rules
 
   if (!('turnNum' in fromState)) {
@@ -29,7 +29,7 @@ export const validTransition = (fromState: ChannelState, toCommitment: Commitmen
   );
 };
 
-export const ourTurn = (state: ChannelState) => {
+export const ourTurn = (state: ChannelStatus) => {
   if (!('turnNum' in state)) {
     return false;
   }

--- a/packages/wallet/src/utils/state-utils.ts
+++ b/packages/wallet/src/utils/state-utils.ts
@@ -1,4 +1,4 @@
-import { ChannelState } from '../redux/channelState/state';
+import { ChannelStatus } from '../redux/channelState/state';
 import {
   OWN_COMMITMENT_RECEIVED,
   OPPONENT_COMMITMENT_RECEIVED,
@@ -14,7 +14,7 @@ import {
 import { signCommitment, validCommitmentSignature } from './signing-utils';
 
 export function handleSignatureAndValidationMessages(
-  state: ChannelState,
+  state: ChannelStatus,
   action: WalletAction,
 ): WalletEvent | undefined {
   switch (action.type) {


### PR DESCRIPTION
This changes the definition of `isDepositing` to consider the case where a `FUNDING_RECEIVED_EVENT` is dispatched which indicates that the channel is funded, before the `TRANSACTION_CONFIRMED` action is dispatched, indicating that the deposit was successful.


edit: I messed up the git history, so putting this on pause for the moment.