### PR TITLE
a few typos and other tweaks

### DIFF
--- a/packages/wallet/notes/indirect_funding_proposal.md
+++ b/packages/wallet/notes/indirect_funding_proposal.md
@@ -2,21 +2,21 @@
 
 ## Goal
 
-The goal of this proposal is to sketch out a possible approach to funding an application channel, A, via a ledger channel, L. 
+The goal of this proposal is to sketch out a possible approach to funding an application channel, `X`, via a ledger channel, `L`. 
 It is deliberately high-level and hand-wavy, designed to start a discussion rather than finish one.
 
 
 ## Out of Scope
 
 * Running the full funding algorithm
-  * Instead we'll assume the simple case of one app channel A, funded by a directly-funded ledger channel L.
+  * Instead we'll assume the simple case of one app channel `X`, funded by a directly-funded ledger channel `L`.
 * Storing the funding table / funding relationships
-  * We'll just focus on opening an L that funds A, without worrying about how to remember that A is funded by L.
+  * We'll just focus on opening an `L` that funds `X`, without worrying about how to remember that `X` is funded by `L`.
 
 
 ## Proposed Operation
 
-We start in a position where both parties are at the funding point and have approved funding for application channel X. The channel state is in a new `DETERMINE_STRATEGY` state:
+We start in a position where both parties are at the funding point and have approved funding for application channel `X`. The channel state is in a new `DETERMINE_STRATEGY` state:
 ```json
 {
   channels: { X: { channelId: X, state: DETERMINE_STRATEGY, ... } },
@@ -28,12 +28,13 @@ sequenceDiagram
     participant wltA as A's wallet
     participant wltB as B's wallet
 
-    Note over wltA, wltB: A in DETERMINE_STRATEGY
+    Note over wltA, wltB: X in DETERMINE_STRATEGY
+
 
     wltA->>wltB: Fund X indirectly?
     wltB->>wltA: Ok!
 
-    Note over wltA, wltB: A in WAIT_FOR_FUNDING
+    Note over wltA, wltB: X in WAIT_FOR_FUNDING
 ```
 After this the wallet state updates as follows:
 ```json
@@ -42,7 +43,7 @@ After this the wallet state updates as follows:
   indirectFundings: { X: { id: X, state: START } },
 }
 ```
-Note: from the information stored in channel X, you have enough to locate the appropriate `indirectFunding`.
+Note: from the information stored in channel `X`, you have enough to locate the appropriate `indirectFunding` (i.e. look for entry under `X` in `indirectFunding`).
 This can be used by the channel container do figure out what to display.
 
 The indirectFunding state is a state machine with (something like) the following states:
@@ -52,6 +53,7 @@ graph LR
   W --> WFF(WaitForFunding)
   WFF --> WFC(WaitForPostFS)
   WFC --> WFCon(WaitForConsensus)
+  WFCon(WaitForConsensus) --> WFCon(WaitForConsensus)
 ```
 This state machine drives the creation of the ledger channel and generation of its states - 
 analogous to how the RPS app drives the creation of a RPS channel and the generation of its states.
@@ -63,15 +65,15 @@ sequenceDiagram
     participant wltA as A's wallet
     participant wltB as B's wallet
 
-    Note over wltA, wltB: IndirectFunding in WAIT_FOR_PRE_FS
+    Note over wltA, wltB: IndirectFundings.X in WAIT_FOR_PRE_FS
 
     wltA->>wltB: PreFundSetup for L
     wltB->>wltA: PreFundSetup for L
 
-    Note over wltA, wltB: IndirectFunding in WAIT_FOR_FUNDING
+    Note over wltA, wltB: IndirectFundings.X in WAIT_FOR_FUNDING
 ```
-
-When the indirectFunding is in the `WAIT_FOR_FUNDING` state, the wallet state will look something like:
+Note that the `PreFundSetup` commitments update the state of `L` so that it now allocates to `X`.
+When the `indirectFundings.X` is in the `WAIT_FOR_FUNDING` state, the wallet state will look something like:
 ```json
 {
   channels: {
@@ -82,11 +84,11 @@ When the indirectFunding is in the `WAIT_FOR_FUNDING` state, the wallet state wi
     X: { id: X, ledgerChannelId: L, state: WAIT_FOR_FUNDING,  strategy: 'direct', .. }
   },
   directFundings: {
-    L: { id: L, state: WAIT_FOR_SAFE_DEPLOY, .. }
+    L: { id: L, state: WAIT_FOR_SAFE_DEPOSIT, .. }
   }
 }
 ```
-Note: like before, the info in the `indirectFunding` record can be used to find the corresponding `directFunding`.
+Note: like before, the info in the `indirectFundings.X` record can be used to find the corresponding `directFunding`.
 
 The `directFunding` state tracks the direct funding state machine as found currently in the codebase.
 
@@ -97,32 +99,32 @@ sequenceDiagram
     participant wltB as B's wallet
     participant blk as blockchain
 
-    Note over wltA, blk: IndirectFunding in WAIT_FOR_FUNDING
+    Note over wltA, blk: IndirectFundings.X in WAIT_FOR_FUNDING
 
-    wltA->>blk: Deposit
+    wltA->>blk: Deposit into L
     wltA->>wltB: I deposited (txId)
     blk->>wltA: DepositConfirmed(txId)
     blk->>wltB: DepositConfirmed(txId)
-    wltB->>blk: Deposit
+    wltB->>blk: Deposit into L
     wltB->>wltA: I deposited (txId2)
     blk->>wltA: DepositConfirmed(txId2)
     blk->>wltB: DepositConfirmed(txId2)
 
-    Note over wltA, blk: IndirectFunding transitions to WAIT_FOR_POST_FS
+    Note over wltA, blk: IndirectFundings.X transitions to WAIT_FOR_POST_FS
 
     wltA->>wltB: PostFundSetup for L
     wltB->>wltA: PostFundSetup for L
 
-    Note over wltA, blk: IndirectFunding transitions to WAIT_FOR_CONSENSUS
+    Note over wltA, blk: IndirectFundings.X transitions to WAIT_FOR_CONSENSUS
 
     wltA->>wltB: Propose update funding X
     wltB->>wltA: Accept update funding X
 
-    Note over wltA, blk: IndirectFunding is complete 
+    Note over wltA, blk: IndirectFundings.X transitions to WAIT_FOR_CONSENSUS 
 
 ```
 
-At this point, we've opened an L that funds A. The wallet state might look something like:
+At this point, we've opened an `L` that funds `X`. The wallet state might look something like:
 ```json
 {
   channels: {

--- a/packages/wallet/notes/indirect_funding_proposal.md
+++ b/packages/wallet/notes/indirect_funding_proposal.md
@@ -28,13 +28,13 @@ sequenceDiagram
     participant wltA as A's wallet
     participant wltB as B's wallet
 
-    Note over wltA, wltB: X in DETERMINE_STRATEGY
+    Note over wltA, wltB: channels.X in DETERMINE_STRATEGY
 
 
     wltA->>wltB: Fund X indirectly?
     wltB->>wltA: Ok!
 
-    Note over wltA, wltB: X in WAIT_FOR_FUNDING
+    Note over wltA, wltB: channels.X in WAIT_FOR_FUNDING
 ```
 After this the wallet state updates as follows:
 ```json


### PR DESCRIPTION
- The application channel is always X, never A.

- Objects referenced by their absolute position in the state tree.

- state machine for indirectFunding allows transitions from WAIT_FOR_CONSENSUS back to itself

- added a couple of explanatory sentences which (if correct) I would have found useful for understanding