### PR TITLE
Remove actionOutbox

### DIFF
--- a/packages/wallet/src/redux/__tests__/coordinator.test.ts
+++ b/packages/wallet/src/redux/__tests__/coordinator.test.ts
@@ -56,7 +56,7 @@ const justReceivedPreFundSetupB = {
 };
 
 describe('when a fundingReceivedEvent caused a channel to be funded', () => {
-  it('updates the corresponding channel state', () => {
+  it.skip('updates the corresponding channel state', () => {
     const channelState: channelStates.ChannelState = {
       initializingChannels: {},
       initializedChannels: {

--- a/packages/wallet/src/redux/__tests__/coordinator.test.ts
+++ b/packages/wallet/src/redux/__tests__/coordinator.test.ts
@@ -1,0 +1,89 @@
+import * as scenarios from './test-scenarios';
+import * as states from '../state';
+import * as channelStates from '../channelState/state';
+import * as fundingStates from '../fundingState/state';
+import * as actions from '../actions';
+import { addHex } from '../../utils/hex-utils';
+import { coordinator } from '../initialized/reducer';
+
+const {
+  asAddress,
+  asPrivateKey,
+  channelNonce,
+  libraryAddress,
+  participants,
+  preFundCommitment1,
+  preFundCommitment2,
+  channelId,
+  twoThree,
+} = scenarios;
+
+const defaults = {
+  address: asAddress,
+  adjudicator: 'adj-address',
+  channelId,
+  channelNonce,
+  libraryAddress,
+  networkId: 3,
+  participants,
+  uid: 'uid',
+  transactionHash: '0x0',
+  funded: false,
+};
+const channelDefaults = {
+  ...defaults,
+  ourIndex: 0,
+  privateKey: asPrivateKey,
+};
+
+const YOUR_DEPOSIT_A = twoThree[0];
+const TOTAL_REQUIRED = twoThree.reduce(addHex);
+const fundingDefaults: fundingStates.DirectFundingStatus = {
+  fundingType: fundingStates.DIRECT_FUNDING,
+  requestedTotalFunds: TOTAL_REQUIRED,
+  requestedYourContribution: YOUR_DEPOSIT_A,
+  channelId,
+  ourIndex: 0,
+  safeToDepositLevel: '0x',
+  channelFundingStatus: fundingStates.NOT_SAFE_TO_DEPOSIT,
+};
+
+const MOCK_SIGNATURE = 'signature';
+const justReceivedPreFundSetupB = {
+  penultimateCommitment: { commitment: preFundCommitment1, signature: MOCK_SIGNATURE },
+  lastCommitment: { commitment: preFundCommitment2, signature: MOCK_SIGNATURE },
+  turnNum: 1,
+};
+
+describe('when a fundingReceivedEvent caused a channel to be funded', () => {
+  it('updates the corresponding channel state', () => {
+    const channelState: channelStates.ChannelState = {
+      initializingChannels: {},
+      initializedChannels: {
+        [channelId]: channelStates.waitForFundingAndPostFundSetup({
+          ...channelDefaults,
+          ...justReceivedPreFundSetupB,
+        }),
+      },
+    };
+
+    const fundingState: fundingStates.FundingState = {
+      ...fundingStates.EMPTY_FUNDING_STATE,
+      directFunding: {
+        [channelId]: fundingStates.notSafeToDeposit(fundingDefaults),
+      },
+    };
+
+    const state = states.initialized({
+      ...states.emptyState,
+      ...defaults,
+      channelState,
+      fundingState,
+    });
+
+    const action = actions.funding.fundingReceivedEvent(channelId, TOTAL_REQUIRED, TOTAL_REQUIRED);
+    const updatedState = coordinator(state, action);
+    const updatedChannel = states.getChannelStatus(updatedState, channelId);
+    expect(updatedChannel.type).toEqual(channelStates.A_WAIT_FOR_POST_FUND_SETUP);
+  });
+});

--- a/packages/wallet/src/redux/__tests__/coordinator.test.ts
+++ b/packages/wallet/src/redux/__tests__/coordinator.test.ts
@@ -4,7 +4,7 @@ import * as channelStates from '../channelState/state';
 import * as fundingStates from '../fundingState/state';
 import * as actions from '../actions';
 import { addHex } from '../../utils/hex-utils';
-import { coordinator } from '../initialized/reducer';
+import { walletReducer } from '../reducer';
 
 const {
   asAddress,
@@ -82,7 +82,7 @@ describe('when a fundingReceivedEvent caused a channel to be funded', () => {
     });
 
     const action = actions.funding.fundingReceivedEvent(channelId, TOTAL_REQUIRED, TOTAL_REQUIRED);
-    const updatedState = coordinator(state, action);
+    const updatedState = walletReducer(state, action);
     const updatedChannel = states.getChannelStatus(updatedState, channelId);
     expect(updatedChannel.type).toEqual(channelStates.A_WAIT_FOR_POST_FUND_SETUP);
   });

--- a/packages/wallet/src/redux/__tests__/helpers.ts
+++ b/packages/wallet/src/redux/__tests__/helpers.ts
@@ -141,31 +141,6 @@ export const itIncreasesTurnNumBy = (
   });
 };
 
-export const itDispatchesThisAction = (action, state: StateWithSideEffects<any>) => {
-  if (action.type) {
-    it(`dispatches ${action.type}`, () => {
-      // The actionOutbox should only dispatch internal actions
-      // We were passed the whole action
-      expect(action.type).toMatch('WALLET.INTERNAL');
-      expectSideEffect('actionOutbox', state, action);
-    });
-  } else {
-    it(`dispatches ${action}`, () => {
-      // We were just passed the type
-      expect(action).toMatch('WALLET.INTERNAL');
-      expectSideEffect('actionOutbox', state, action);
-    });
-  }
-};
-
-export const itDispatchesNoAction = (state: StateWithSideEffects<any>) => {
-  it(`dispatches no action`, () => {
-    if (state.sideEffects) {
-      expectSideEffect('actionOutbox', state, undefined);
-    }
-  });
-};
-
 export function itChangesDepositStatusTo(status: string, state) {
   it(`changes depositStatus to ${status} `, () => {
     expect(state.state.depositStatus).toEqual(status);

--- a/packages/wallet/src/redux/__tests__/initialized.test.ts
+++ b/packages/wallet/src/redux/__tests__/initialized.test.ts
@@ -1,14 +1,8 @@
 import { walletReducer } from '../reducer';
 
-import * as states from '../state';
-import * as fundingStates from '../fundingState/state';
-import * as actions from '../actions';
-import * as outgoing from 'magmo-wallet-client/lib/wallet-events';
-import * as scenarios from './test-scenarios';
-import { waitForUpdate } from '../channelState/state';
-import { EMPTY_OUTBOX_STATE } from '../outbox/state';
-
-const { channelId } = scenarios;
+import * as states from './../state';
+import * as fundingStates from './../fundingState/state';
+import * as actions from './../actions';
 
 const defaults = {
   ...states.emptyState,
@@ -39,58 +33,4 @@ describe.skip('when a funding related action arrives', () => {
   it('applies the funding state reducer', async () => {
     expect(updatedState.fundingState).toEqual(fundingStates.FUNDING_NOT_STARTED);
   });
-});
-
-describe('When the channel reducer declares a side effect', () => {
-  const {
-    bsAddress,
-    bsPrivateKey,
-    gameCommitment1,
-    gameCommitment2,
-    channelNonce,
-    channel,
-  } = scenarios;
-  const walletParams = {
-    ...states.emptyState,
-    uid: 'uid',
-    adjudicator: 'adj-address',
-    networkId: 2132,
-  };
-
-  const channelParams = {
-    participants: channel.participants as [string, string],
-    libraryAddress: channel.channelType,
-    channelId,
-    channelNonce,
-    lastCommitment: { commitment: gameCommitment1, signature: 'sig' },
-    penultimateCommitment: { commitment: gameCommitment2, signature: 'sig' },
-    turnNum: gameCommitment2.turnNum,
-    challengeExpiry: new Date(),
-    funded: false,
-  };
-
-  const bParams = { address: bsAddress, ourIndex: 1, privateKey: bsPrivateKey };
-  const bDefaults = { ...channelParams, ...bParams };
-
-  const state = states.initialized({
-    ...walletParams,
-    channelState: {
-      initializedChannels: { [channelId]: waitForUpdate(bDefaults) },
-      initializingChannels: {},
-      activeAppChannelId: channelId,
-    },
-    outboxState: {
-      ...EMPTY_OUTBOX_STATE,
-      actionOutbox: [actions.internal.directFundingConfirmed('channelId')],
-    },
-  });
-
-  const action = actions.channel.challengeRequested();
-
-  const updatedState = walletReducer(state, action);
-
-  expect(updatedState.outboxState.messageOutbox![0].type).toEqual(outgoing.CHALLENGE_REJECTED);
-  expect(updatedState.outboxState!.actionOutbox![0].type).toEqual(
-    actions.internal.DIRECT_FUNDING_CONFIRMED,
-  );
 });

--- a/packages/wallet/src/redux/channelState/funding/__tests__/funding.test.ts
+++ b/packages/wallet/src/redux/channelState/funding/__tests__/funding.test.ts
@@ -8,14 +8,10 @@ import {
   itTransitionsToChannelStateType,
   itIncreasesTurnNumBy,
   itSendsThisMessage,
-  itDispatchesThisAction,
-  itDispatchesNoAction,
   itSendsNoMessage,
 } from '../../../__tests__/helpers';
 import * as outgoing from 'magmo-wallet-client/lib/wallet-events';
 import * as SigningUtil from '../../../../utils/signing-utils';
-import { addHex } from '../../../../utils/hex-utils';
-
 const {
   asAddress,
   asPrivateKey,
@@ -28,7 +24,6 @@ const {
   postFundCommitment1,
   postFundCommitment2,
   channelId,
-  twoThree,
 } = scenarios;
 
 const defaults = {
@@ -121,16 +116,6 @@ describe('start in WaitForFundingApproval', () => {
     const updatedState = fundingReducer(state, action);
 
     itTransitionsToChannelStateType(states.WAIT_FOR_FUNDING_AND_POST_FUND_SETUP, updatedState);
-    itDispatchesThisAction(
-      actions.internal.directFundingRequested(
-        channelId,
-        '0x00',
-        twoThree.reduce(addHex),
-        twoThree[0],
-        0,
-      ),
-      updatedState,
-    );
     itIncreasesTurnNumBy(0, state, updatedState);
   });
   describe('incoming action: funding rejected', () => {
@@ -140,7 +125,6 @@ describe('start in WaitForFundingApproval', () => {
     const updatedState = fundingReducer(state, action);
 
     itTransitionsToChannelStateType(states.WAIT_FOR_CHANNEL, updatedState);
-    itDispatchesNoAction(updatedState);
     itSendsThisMessage(updatedState, [outgoing.MESSAGE_RELAY_REQUESTED, outgoing.FUNDING_FAILURE]);
   });
 
@@ -150,7 +134,6 @@ describe('start in WaitForFundingApproval', () => {
     const action = actions.channel.messageReceived('FundingDeclined');
     const updatedState = fundingReducer(state, action);
     itTransitionsToChannelStateType(states.ACKNOWLEDGE_FUNDING_DECLINED, updatedState);
-    itDispatchesNoAction(updatedState);
     itIncreasesTurnNumBy(0, state, updatedState);
   });
 
@@ -162,16 +145,6 @@ describe('start in WaitForFundingApproval', () => {
     const updatedState = fundingReducer(state, action);
 
     itTransitionsToChannelStateType(states.WAIT_FOR_FUNDING_AND_POST_FUND_SETUP, updatedState);
-    itDispatchesThisAction(
-      actions.internal.directFundingRequested(
-        channelId,
-        twoThree[0],
-        twoThree.reduce(addHex),
-        twoThree[1],
-        1,
-      ),
-      updatedState,
-    );
     itIncreasesTurnNumBy(0, state, updatedState);
   });
 });

--- a/packages/wallet/src/redux/channelState/funding/reducer.ts
+++ b/packages/wallet/src/redux/channelState/funding/reducer.ts
@@ -1,5 +1,4 @@
 import * as states from '../state';
-import { addHex } from '../../../utils/hex-utils';
 import * as actions from '../actions';
 import { internal, TRANSACTION_CONFIRMED } from '../../actions';
 import {
@@ -82,23 +81,8 @@ const approveFundingReducer = (
 ): StateWithSideEffects<states.OpenedState | states.WaitForChannel> => {
   switch (action.type) {
     case actions.FUNDING_APPROVED:
-      const totalFundingRequired = state.lastCommitment.commitment.allocation.reduce(addHex);
-      const safeToDepositLevel =
-        state.ourIndex === 0
-          ? '0x00'
-          : state.lastCommitment.commitment.allocation.slice(0, state.ourIndex).reduce(addHex);
-      const ourDeposit = state.lastCommitment.commitment.allocation[state.ourIndex];
       return {
         state: states.waitForFundingAndPostFundSetup(state),
-        sideEffects: {
-          actionOutbox: internal.directFundingRequested(
-            state.channelId,
-            safeToDepositLevel,
-            totalFundingRequired,
-            ourDeposit,
-            state.ourIndex,
-          ),
-        },
       };
     case actions.FUNDING_REJECTED:
       const relayFundingDeclinedMessage = messageRelayRequested(

--- a/packages/wallet/src/redux/fundingState/directFunding/__tests__/directFunding.test.ts
+++ b/packages/wallet/src/redux/fundingState/directFunding/__tests__/directFunding.test.ts
@@ -8,8 +8,6 @@ import * as scenarios from '../../../__tests__/test-scenarios';
 import {
   itChangesChannelFundingStatusTo,
   itChangesDepositStatusTo,
-  itDispatchesThisAction,
-  itDispatchesNoAction,
 } from '../../../__tests__/helpers';
 import { addHex } from '../../../../utils/hex-utils';
 
@@ -51,7 +49,6 @@ describe(startingIn('any state'), () => {
         );
         const updatedState = directFundingStatusReducer(state, action);
         itChangesChannelFundingStatusTo(states.CHANNEL_FUNDED, updatedState);
-        itDispatchesThisAction(actions.internal.DIRECT_FUNDING_CONFIRMED, updatedState);
       });
       describe('when the channel is still not funded', () => {
         const state = states.notSafeToDeposit(defaultsForB);
@@ -62,7 +59,6 @@ describe(startingIn('any state'), () => {
         );
         const updatedState = directFundingStatusReducer(state, action);
         itChangesChannelFundingStatusTo(states.NOT_SAFE_TO_DEPOSIT, updatedState);
-        itDispatchesNoAction(updatedState);
       });
     });
 
@@ -71,7 +67,6 @@ describe(startingIn('any state'), () => {
       const action = actions.funding.fundingReceivedEvent('0xf00', TOTAL_REQUIRED, TOTAL_REQUIRED);
       const updatedState = directFundingStatusReducer(state, action);
       itChangesChannelFundingStatusTo(states.NOT_SAFE_TO_DEPOSIT, updatedState);
-      itDispatchesNoAction(updatedState);
     });
   });
 });
@@ -114,7 +109,6 @@ describe(startingIn(states.SAFE_TO_DEPOSIT), () => {
       const updatedState = directFundingStatusReducer(state, action);
 
       itChangesChannelFundingStatusTo(states.CHANNEL_FUNDED, updatedState);
-      itDispatchesThisAction(actions.internal.DIRECT_FUNDING_CONFIRMED, updatedState);
     });
 
     describe('when it is still not fully funded', () => {
@@ -123,8 +117,6 @@ describe(startingIn(states.SAFE_TO_DEPOSIT), () => {
       const updatedState = directFundingStatusReducer(state, action);
 
       itChangesChannelFundingStatusTo(states.SAFE_TO_DEPOSIT, updatedState);
-      itDispatchesNoAction(updatedState);
-      // itSendsNoMessage(updatedState);
     });
 
     describe('when it is for the wrong channel', () => {
@@ -133,8 +125,6 @@ describe(startingIn(states.SAFE_TO_DEPOSIT), () => {
       const updatedState = directFundingStatusReducer(state, action);
 
       itChangesChannelFundingStatusTo(states.SAFE_TO_DEPOSIT, updatedState);
-      itDispatchesNoAction(updatedState);
-      // itSendsNoMessage(updatedState);
     });
   });
 });

--- a/packages/wallet/src/redux/fundingState/directFunding/reducer.ts
+++ b/packages/wallet/src/redux/fundingState/directFunding/reducer.ts
@@ -23,7 +23,6 @@ export const directFundingStatusReducer = (
     if (bigNumberify(action.totalForDestination).gte(state.requestedTotalFunds)) {
       return {
         state: states.channelFunded(state),
-        sideEffects: { actionOutbox: actions.internal.directFundingConfirmed(state.channelId) },
       };
     }
   }
@@ -88,7 +87,6 @@ const waitForFundingConfirmationReducer = (
       ) {
         return {
           state: states.channelFunded(state),
-          sideEffects: { actionOutbox: actions.internal.directFundingConfirmed(state.channelId) },
         };
       } else {
         return { state };

--- a/packages/wallet/src/redux/outbox/__tests__/reducer.test.ts
+++ b/packages/wallet/src/redux/outbox/__tests__/reducer.test.ts
@@ -11,15 +11,10 @@ describe('when a side effect occured', () => {
   const sendFundingDeclinedActionA = outgoing.messageRelayRequested('0xa00', 'FundingDeclined');
   const sendFundingDeclinedActionB = outgoing.messageRelayRequested('0xb00', 'FundingDeclined');
   const displayOutbox = [outgoing.hideWallet(), outgoing.showWallet()];
-  const actionOutbox = [
-    actions.internal.directFundingConfirmed(channelId),
-    actions.internal.directFundingConfirmed(channelId),
-  ];
   const transactionOutbox = [mockTransactionOutboxItem, mockTransactionOutboxItem];
   const messageOutbox = [sendFundingDeclinedActionA, sendFundingDeclinedActionB];
   const state: OutboxState = {
     displayOutbox,
-    actionOutbox,
     transactionOutbox,
     messageOutbox,
   };
@@ -40,11 +35,5 @@ describe('when a side effect occured', () => {
     const action = actions.transactionSentToMetamask(channelId);
     const updatedState = clearOutbox(state, action);
     expect(updatedState.transactionOutbox).toMatchObject(transactionOutbox.slice(1));
-  });
-
-  it('clears the first element of the actionOutbox', () => {
-    const action = state.actionOutbox[0];
-    const updatedState = clearOutbox(state, action);
-    expect(updatedState.actionOutbox).toMatchObject(actionOutbox.slice(1));
   });
 });

--- a/packages/wallet/src/redux/outbox/reducer.ts
+++ b/packages/wallet/src/redux/outbox/reducer.ts
@@ -13,10 +13,6 @@ export function clearOutbox(state: OutboxState, action: actions.WalletAction): O
     // TODO: Should this be a channel message?
     nextOutbox.transactionOutbox = nextOutbox.transactionOutbox.slice(1);
   }
-  if (action.type.match('WALLET.INTERNAL')) {
-    // For the moment, only one action should ever be put in the actionOutbox,
-    // so it's always safe to clear it.
-    nextOutbox.actionOutbox = nextOutbox.actionOutbox.slice(1);
-  }
+
   return nextOutbox;
 }

--- a/packages/wallet/src/redux/outbox/state.ts
+++ b/packages/wallet/src/redux/outbox/state.ts
@@ -1,12 +1,10 @@
 import { TransactionRequest } from 'ethers/providers';
 import { WalletEvent, DisplayAction } from 'magmo-wallet-client';
-import { internal } from '../actions';
 
 export const EMPTY_OUTBOX_STATE: OutboxState = {
   displayOutbox: [],
   messageOutbox: [],
   transactionOutbox: [],
-  actionOutbox: [],
 };
 
 export interface TransactionOutboxItem {
@@ -17,7 +15,6 @@ export interface OutboxState {
   displayOutbox: DisplayAction[];
   messageOutbox: WalletEvent[];
   transactionOutbox: TransactionOutboxItem[];
-  actionOutbox: internal.InternalAction[];
 }
 
 export type SideEffects = {

--- a/packages/wallet/src/redux/sagas/saga-manager.ts
+++ b/packages/wallet/src/redux/sagas/saga-manager.ts
@@ -1,4 +1,4 @@
-import { select, take, fork, actionChannel, put, cancel } from 'redux-saga/effects';
+import { select, take, fork, actionChannel, cancel } from 'redux-saga/effects';
 
 import { messageListener } from './message-listener';
 import { messageSender } from './message-sender';
@@ -91,10 +91,6 @@ export function* sagaManager(): IterableIterator<any> {
     if (outboxState.transactionOutbox.length) {
       const { transactionRequest, channelId } = outboxState.transactionOutbox[0];
       yield transactionSender(transactionRequest, channelId);
-    }
-
-    if (outboxState.actionOutbox.length) {
-      yield put(outboxState.actionOutbox[0]);
     }
   }
 }

--- a/packages/wallet/src/redux/state.ts
+++ b/packages/wallet/src/redux/state.ts
@@ -1,6 +1,6 @@
 import { OutboxState, EMPTY_OUTBOX_STATE } from './outbox/state';
 import { FundingState, EMPTY_FUNDING_STATE } from './fundingState/state';
-import { ChannelState } from './channelState/state';
+import { ChannelState, ChannelStatus } from './channelState/state';
 import { Properties } from './utils';
 
 export type WalletState = WaitForLogin | WaitForAdjudicator | MetaMaskError | Initialized;
@@ -82,4 +82,8 @@ export function initialized(params: Properties<Initialized>): Initialized {
     networkId,
     adjudicator,
   };
+}
+
+export function getChannelStatus(state: WalletState, channelId: string): ChannelStatus {
+  return state.channelState.initializedChannels[channelId];
 }

--- a/packages/wallet/src/redux/state.ts
+++ b/packages/wallet/src/redux/state.ts
@@ -1,7 +1,14 @@
+<<<<<<< HEAD
 import { OutboxState, EMPTY_OUTBOX_STATE } from './outbox/state';
 import { FundingState, EMPTY_FUNDING_STATE } from './fundingState/state';
 import { ChannelState } from './channelState/state';
 import { Properties } from './utils';
+=======
+import { SharedWalletState, emptyState } from './shared/state';
+import { InitializingState } from './initializing/state';
+import { InitializedState } from './initialized/state';
+import { ChannelStatus } from './channelState/state';
+>>>>>>> Add getChannelStatus selector
 
 export type WalletState = WaitForLogin | WaitForAdjudicator | MetaMaskError | Initialized;
 
@@ -13,6 +20,7 @@ export const METAMASK_ERROR = 'INITIALIZING.METAMASK_ERROR';
 export const WAIT_FOR_ADJUDICATOR = 'INITIALIZING.WAIT_FOR_ADJUDICATOR';
 export const WALLET_INITIALIZED = 'WALLET.INITIALIZED';
 
+<<<<<<< HEAD
 // ------
 // States
 // ------
@@ -82,4 +90,10 @@ export function initialized(params: Properties<Initialized>): Initialized {
     networkId,
     adjudicator,
   };
+=======
+export type WalletState = InitializingState | InitializedState;
+
+export function getChannelStatus(state: WalletState, channelId: string): ChannelStatus {
+  return state.channelState.initializedChannels[channelId];
+>>>>>>> Add getChannelStatus selector
 }

--- a/packages/wallet/src/redux/state.ts
+++ b/packages/wallet/src/redux/state.ts
@@ -1,14 +1,7 @@
-<<<<<<< HEAD
 import { OutboxState, EMPTY_OUTBOX_STATE } from './outbox/state';
 import { FundingState, EMPTY_FUNDING_STATE } from './fundingState/state';
 import { ChannelState } from './channelState/state';
 import { Properties } from './utils';
-=======
-import { SharedWalletState, emptyState } from './shared/state';
-import { InitializingState } from './initializing/state';
-import { InitializedState } from './initialized/state';
-import { ChannelStatus } from './channelState/state';
->>>>>>> Add getChannelStatus selector
 
 export type WalletState = WaitForLogin | WaitForAdjudicator | MetaMaskError | Initialized;
 
@@ -20,7 +13,6 @@ export const METAMASK_ERROR = 'INITIALIZING.METAMASK_ERROR';
 export const WAIT_FOR_ADJUDICATOR = 'INITIALIZING.WAIT_FOR_ADJUDICATOR';
 export const WALLET_INITIALIZED = 'WALLET.INITIALIZED';
 
-<<<<<<< HEAD
 // ------
 // States
 // ------
@@ -90,10 +82,4 @@ export function initialized(params: Properties<Initialized>): Initialized {
     networkId,
     adjudicator,
   };
-=======
-export type WalletState = InitializingState | InitializedState;
-
-export function getChannelStatus(state: WalletState, channelId: string): ChannelStatus {
-  return state.channelState.initializedChannels[channelId];
->>>>>>> Add getChannelStatus selector
 }


### PR DESCRIPTION
To get wallet development started again, we need to figure out how to coordinate state updates in the wallet.

This PR removes the `actionOutbox`, cutting the existing communication between branches of the redux state.

This communication needs to be replaced with a "coordinator" that responds to, eg., a `FUNDING_RECEIVED_EVENT` which completely funds a channel by updating both the funding state (based on the action) and the channel state (based on the updated funding state).

There is one failing test, though to cover the existing wallet requirements, more tests are needed. The initialized reducer needs to be rewritten to make this test pass.

Proposed implementations of the coordinators can be based on this branch.