### PR TITLE
Remove relayCommitment

### DIFF
--- a/packages/magmo-wallet-client/src/wallet-events.ts
+++ b/packages/magmo-wallet-client/src/wallet-events.ts
@@ -293,29 +293,6 @@ export const messageRelayRequested = (to: string, data: string) => ({
 export type MessageRelayRequested = ReturnType<typeof messageRelayRequested>;
 
 /**
- * The type of event when a commitment relay to the opponent's wallet is requested.
- */
-export const COMMITMENT_RELAY_REQUESTED = 'WALLET.MESSAGING.COMMITMENT_RELAY_REQUESTED';
-/**
- * @ignore
- */
-export const commitmentRelayRequested = (
-  to: string,
-  commitment: Commitment,
-  signature: string,
-) => ({
-  type: COMMITMENT_RELAY_REQUESTED as typeof COMMITMENT_RELAY_REQUESTED,
-  to,
-  commitment,
-  signature,
-});
-
-/**
- * The event emitted when the wallet requests a commitment be relayed to the opponent's wallet.
- */
-export type CommitmentRelayRequested = ReturnType<typeof commitmentRelayRequested>;
-
-/**
  * The type for events where a challenge position is received from the wallet.
  */
 export const CHALLENGE_COMMITMENT_RECEIVED = 'WALLET.MESSAGING.CHALLENGE_COMMITMENT_RECEIVED';
@@ -384,7 +361,6 @@ export type WalletEventType =
   | typeof CHALLENGE_REJECTED
   | typeof CHALLENGE_RESPONSE_REQUESTED
   | typeof CLOSE_SUCCESS
-  | typeof COMMITMENT_RELAY_REQUESTED
   | typeof CONCLUDE_FAILURE
   | typeof CONCLUDE_SUCCESS
   | typeof FUNDING_FAILURE

--- a/packages/magmo-wallet-client/src/wallet-events.ts
+++ b/packages/magmo-wallet-client/src/wallet-events.ts
@@ -281,7 +281,7 @@ export const MESSAGE_RELAY_REQUESTED = 'WALLET.MESSAGING.MESSAGE_RELAY_REQUESTED
 /**
  * @ignore
  */
-export const messageRelayRequested = (to: string, data: string) => ({
+export const messageRelayRequested = (to: string, data: any) => ({
   type: MESSAGE_RELAY_REQUESTED as typeof MESSAGE_RELAY_REQUESTED,
   to,
   data,
@@ -386,7 +386,6 @@ export type WalletEvent =
   | ChallengeResponseRequested
   | ChannelInitializationSuccess
   | CloseSuccess
-  | CommitmentRelayRequested
   | ConcludeFailure
   | ConcludeSuccess
   | FundingFailure

--- a/packages/magmo-wallet-client/src/wallet-functions.ts
+++ b/packages/magmo-wallet-client/src/wallet-functions.ts
@@ -189,7 +189,7 @@ export async function signCommitment(iFrameId: string, commitment: Commitment): 
  * @param iFrameId The id of the embedded wallet iframe.
  * @param data The message to send to the wallet that was received from the opponent's wallet.
  */
-export function relayMessage(iFrameId: string, data: string) {
+export function relayMessage(iFrameId: string, data) {
   const iFrame = document.getElementById(iFrameId) as HTMLIFrameElement;
   const message = receiveMessage(data);
   iFrame.contentWindow.postMessage(message, '*');

--- a/packages/magmo-wallet-client/src/wallet-functions.ts
+++ b/packages/magmo-wallet-client/src/wallet-functions.ts
@@ -19,7 +19,6 @@ import {
   receiveMessage,
   createChallenge,
   respondToChallenge,
-  receiveCommitment,
   initializeChannelRequest,
 } from './wallet-instructions';
 import { Commitment } from 'fmg-core';
@@ -183,19 +182,6 @@ export async function signCommitment(iFrameId: string, commitment: Commitment): 
 
   iFrame.contentWindow.postMessage(message, '*');
   return signPromise;
-}
-
-/**
- * Relays a commitment to the wallet, from the opponent's wallet.
- * Used, for example, when the opponent's wallet is funding a channel through a ledger channel.
- * @param iFrameId The id of the embedded wallet iframe.
- * @param commitment The commitment to send to the wallet that was received from the opponent's wallet.
- * @param signature The signature that was received from the opponent's wallet.
- */
-export function relayCommitment(iFrameId: string, commitment: Commitment, signature: string) {
-  const iFrame = document.getElementById(iFrameId) as HTMLIFrameElement;
-  const message = receiveCommitment(commitment, signature);
-  iFrame.contentWindow.postMessage(message, '*');
 }
 
 /**

--- a/packages/magmo-wallet-client/src/wallet-instructions.ts
+++ b/packages/magmo-wallet-client/src/wallet-instructions.ts
@@ -111,17 +111,6 @@ export const receiveMessage = (data: string) => ({
 });
 export type ReceiveMessage = ReturnType<typeof receiveMessage>;
 
-// Called when a "wallet commitment" is received from the opponent.
-// By "wallet commitment" we mean a commitment that was created directly from the opponent's
-// wallet meant for wallet-to-wallet communication (e.g. commitments used to set up a ledger channel)
-export const RECEIVE_COMMITMENT = 'WALLET.MESSAGING.RECEIVE_COMMITMENT';
-export const receiveCommitment = (commitment: Commitment, signature: string) => ({
-  type: RECEIVE_COMMITMENT,
-  commitment,
-  signature,
-});
-export type ReceiveCommitment = ReturnType<typeof receiveCommitment>;
-
 // Requests
 // ========
 export type RequestAction =

--- a/packages/magmo-wallet-client/src/wallet-instructions.ts
+++ b/packages/magmo-wallet-client/src/wallet-instructions.ts
@@ -105,7 +105,7 @@ export type ConcludeChannelRequest = ReturnType<typeof concludeChannelRequest>;
 // wallet meant for wallet-to-wallet communication (e.g. communicating the address of the
 // adjudicator).
 export const RECEIVE_MESSAGE = 'WALLET.MESSAGING.RECEIVE_MESSAGE';
-export const receiveMessage = (data: string) => ({
+export const receiveMessage = data => ({
   type: RECEIVE_MESSAGE,
   data,
 });

--- a/packages/wallet/src/redux/actions.ts
+++ b/packages/wallet/src/redux/actions.ts
@@ -1,6 +1,7 @@
 import * as internal from './internal/actions';
 import * as channel from './channelState/actions';
 import * as funding from './fundingState/actions';
+import { Commitment } from 'fmg-core';
 
 export const LOGGED_IN = 'WALLET.LOGGED_IN';
 export const loggedIn = (uid: string) => ({
@@ -111,12 +112,36 @@ export const retryTransaction = (channelId: string) => ({
 });
 export type RetryTransaction = ReturnType<typeof retryTransaction>;
 
+export type Message = 'FundingDeclined';
+export const MESSAGE_RECEIVED = 'WALLET.COMMON.MESSAGE_RECEIVED';
+export const messageReceived = (channelId: string, data: Message) => ({
+  type: MESSAGE_RECEIVED as typeof MESSAGE_RECEIVED,
+  channelId,
+  data,
+});
+export type MessageReceived = ReturnType<typeof messageReceived>;
+
+export const COMMITMENT_RECEIVED = 'WALLET.COMMON.COMMITMENT_RECEIVED';
+export const commitmentReceived = (
+  channelId: string,
+  commitment: Commitment,
+  signature: string,
+) => ({
+  type: COMMITMENT_RECEIVED as typeof COMMITMENT_RECEIVED,
+  channelId,
+  commitment,
+  signature,
+});
+export type CommitmentReceived = ReturnType<typeof commitmentReceived>;
+
 export type CommonAction =
   | TransactionConfirmed
   | TransactionSentToMetamask
   | TransactionSubmissionFailed
   | TransactionSubmitted
-  | RetryTransaction;
+  | RetryTransaction
+  | MessageReceived
+  | CommitmentReceived;
 
 export function isCommonAction(action: WalletAction): action is CommonAction {
   return action.type.match('WALLET.COMMON') ? true : false;

--- a/packages/wallet/src/redux/channelState/actions.ts
+++ b/packages/wallet/src/redux/channelState/actions.ts
@@ -34,14 +34,6 @@ export const opponentCommitmentReceived = (commitment: Commitment, signature: st
 });
 export type OpponentCommitmentReceived = ReturnType<typeof opponentCommitmentReceived>;
 
-export const COMMITMENT_RECEIVED = 'WALLET.CHANNEL.COMMITMENT_RECEIVED';
-export const commitmentReceived = (commitment: Commitment, signature: string) => ({
-  type: COMMITMENT_RECEIVED as typeof COMMITMENT_RECEIVED,
-  commitment,
-  signature,
-});
-export type CommitmentReceived = ReturnType<typeof commitmentReceived>;
-
 export const FUNDING_REQUESTED = 'WALLET.CHANNEL.FUNDING_REQUESTED';
 export const fundingRequested = () => ({
   type: FUNDING_REQUESTED as typeof FUNDING_REQUESTED,
@@ -247,13 +239,6 @@ export const approveClose = (withdrawAddress: string) => ({
 });
 export type ApproveClose = ReturnType<typeof approveClose>;
 
-export const MESSAGE_RECEIVED = 'WALLET.CHANNEL.MESSAGE_RECEIVED';
-export const messageReceived = (data: 'FundingDeclined') => ({
-  type: MESSAGE_RECEIVED as typeof MESSAGE_RECEIVED,
-  data,
-});
-export type MessageReceived = ReturnType<typeof messageReceived>;
-
 export type ChannelAction =  // TODO: Some of these actions probably also belong in a FundingAction type
   | ApproveClose
   | ChallengeAcknowledged
@@ -269,7 +254,6 @@ export type ChannelAction =  // TODO: Some of these actions probably also belong
   | ChannelInitialized
   | ClosedOnChainAcknowledged
   | CloseSuccessAcknowledged
-  | CommitmentReceived
   | ConcludeApproved
   | concludedEvent
   | ConcludeRejected
@@ -279,7 +263,6 @@ export type ChannelAction =  // TODO: Some of these actions probably also belong
   | FundingRejected
   | FundingRequested
   | FundingSuccessAcknowledged
-  | MessageReceived
   | OpponentCommitmentReceived
   | OwnCommitmentReceived
   | PostFundSetupReceived

--- a/packages/wallet/src/redux/channelState/closing/__tests__/closing.test.ts
+++ b/packages/wallet/src/redux/channelState/closing/__tests__/closing.test.ts
@@ -108,7 +108,8 @@ describe('start in WaitForOpponentConclude', () => {
     Object.defineProperty(SigningUtil, 'validCommitmentSignature', { value: validateMock });
     Object.defineProperty(ReducerUtil, 'validTransition', { value: validateMock });
 
-    const action = actions.channel.commitmentReceived(
+    const action = actions.commitmentReceived(
+      channelId,
       ('commitment' as unknown) as Commitment,
       '0x0',
     );

--- a/packages/wallet/src/redux/channelState/closing/reducer.ts
+++ b/packages/wallet/src/redux/channelState/closing/reducer.ts
@@ -271,7 +271,7 @@ const waitForOpponentConclude = (
   action: WalletAction,
 ): StateWithSideEffects<channelStates.ChannelStatus> => {
   switch (action.type) {
-    case actions.channel.COMMITMENT_RECEIVED:
+    case actions.COMMITMENT_RECEIVED:
       const { commitment, signature } = action;
 
       const opponentAddress = state.participants[1 - state.ourIndex];

--- a/packages/wallet/src/redux/channelState/funding/__tests__/funding.test.ts
+++ b/packages/wallet/src/redux/channelState/funding/__tests__/funding.test.ts
@@ -131,7 +131,7 @@ describe('start in WaitForFundingApproval', () => {
   describe('incoming action: Funding declined message received', () => {
     const testDefaults = { ...defaultsA, ...justReceivedPreFundSetupB };
     const state = states.approveFunding(testDefaults);
-    const action = actions.channel.messageReceived('FundingDeclined');
+    const action = actions.messageReceived(channelId, 'FundingDeclined');
     const updatedState = fundingReducer(state, action);
     itTransitionsToChannelStateType(states.ACKNOWLEDGE_FUNDING_DECLINED, updatedState);
     itIncreasesTurnNumBy(0, state, updatedState);
@@ -160,7 +160,7 @@ describe('start in WaitForFundingAndPostFundSetup', () => {
 
   describe('incoming action: Funding declined message received', () => {
     const state = startingState('A');
-    const action = actions.channel.messageReceived('FundingDeclined');
+    const action = actions.messageReceived(channelId, 'FundingDeclined');
     const updatedState = fundingReducer(state, action);
 
     itTransitionsToChannelStateType(states.ACKNOWLEDGE_FUNDING_DECLINED, updatedState);
@@ -180,8 +180,7 @@ describe('start in WaitForFundingAndPostFundSetup', () => {
     const state = startingState('A');
     const validateMock = jest.fn().mockReturnValue(true);
     Object.defineProperty(SigningUtil, 'validCommitmentSignature', { value: validateMock });
-
-    const action = actions.channel.commitmentReceived(postFundCommitment1, '0x0');
+    const action = actions.commitmentReceived(channelId, postFundCommitment1, MOCK_SIGNATURE);
     const updatedState = fundingReducer(state, action);
 
     itTransitionsToChannelStateType(states.WAIT_FOR_FUNDING_AND_POST_FUND_SETUP, updatedState);
@@ -194,7 +193,7 @@ describe('start in WaitForFundingAndPostFundSetup', () => {
     const validateMock = jest.fn().mockReturnValue(true);
     Object.defineProperty(SigningUtil, 'validCommitmentSignature', { value: validateMock });
 
-    const action = actions.channel.commitmentReceived(postFundCommitment1, '0x0');
+    const action = actions.commitmentReceived(channelId, postFundCommitment1, MOCK_SIGNATURE);
     const updatedState = fundingReducer(state, action);
 
     itTransitionsToChannelStateType(states.WAIT_FOR_FUNDING_CONFIRMATION, updatedState);
@@ -244,7 +243,7 @@ describe('start in AWaitForPostFundSetup', () => {
 
     const testDefaults = { ...defaultsA, ...justReceivedPostFundSetupA };
     const state = states.aWaitForPostFundSetup({ ...testDefaults });
-    const action = actions.channel.commitmentReceived(postFundCommitment2, MOCK_SIGNATURE);
+    const action = actions.commitmentReceived(channelId, postFundCommitment2, MOCK_SIGNATURE);
     const updatedState = fundingReducer(state, action);
 
     itTransitionsToChannelStateType(states.ACKNOWLEDGE_FUNDING_SUCCESS, updatedState);
@@ -259,7 +258,7 @@ describe('start in BWaitForPostFundSetup', () => {
     const state = states.bWaitForPostFundSetup(testDefaults);
     const validateMock = jest.fn().mockReturnValue(true);
     Object.defineProperty(SigningUtil, 'validSignature', { value: validateMock });
-    const action = actions.channel.commitmentReceived(postFundCommitment1, MOCK_SIGNATURE);
+    const action = actions.commitmentReceived(channelId, postFundCommitment1, MOCK_SIGNATURE);
     const updatedState = fundingReducer(state, action);
 
     itTransitionsToChannelStateType(states.ACKNOWLEDGE_FUNDING_SUCCESS, updatedState);

--- a/packages/wallet/src/redux/channelState/funding/reducer.ts
+++ b/packages/wallet/src/redux/channelState/funding/reducer.ts
@@ -1,6 +1,11 @@
 import * as states from '../state';
 import * as actions from '../actions';
-import { internal, TRANSACTION_CONFIRMED } from '../../actions';
+import {
+  internal,
+  TRANSACTION_CONFIRMED,
+  MESSAGE_RECEIVED,
+  COMMITMENT_RECEIVED,
+} from '../../actions';
 import {
   messageRelayRequested,
   fundingSuccess,
@@ -97,8 +102,8 @@ const approveFundingReducer = (
           displayOutbox: hideWallet(),
         },
       };
-    case actions.MESSAGE_RECEIVED:
-      if (action.data && action.data === 'FundingDeclined') {
+    case MESSAGE_RECEIVED:
+      if (action.data === 'FundingDeclined') {
         return { state: states.acknowledgeFundingDeclined(state) };
       } else {
         return { state };
@@ -115,7 +120,7 @@ const waitForFundingAndPostFundSetupReducer = (
   action: actions.ChannelAction | internal.InternalAction,
 ): StateWithSideEffects<states.OpenedState> => {
   switch (action.type) {
-    case actions.MESSAGE_RECEIVED:
+    case MESSAGE_RECEIVED:
       if (action.data === 'FundingDeclined') {
         return {
           state: states.acknowledgeFundingDeclined({ ...state }),
@@ -123,7 +128,7 @@ const waitForFundingAndPostFundSetupReducer = (
       } else {
         return { state };
       }
-    case actions.COMMITMENT_RECEIVED:
+    case COMMITMENT_RECEIVED:
       const { commitment, signature } = action;
       if (!validTransitionToPostFundState(state, commitment, signature)) {
         return { state };
@@ -207,7 +212,7 @@ const aWaitForPostFundSetupReducer = (
   action: actions.ChannelAction | internal.InternalAction,
 ): StateWithSideEffects<states.OpenedState> => {
   switch (action.type) {
-    case actions.COMMITMENT_RECEIVED:
+    case COMMITMENT_RECEIVED:
       const { commitment: postFundState, signature } = action;
       if (!validTransitionToPostFundState(state, postFundState, signature)) {
         return { state };
@@ -231,7 +236,7 @@ const bWaitForPostFundSetupReducer = (
   action: actions.ChannelAction | internal.InternalAction,
 ): StateWithSideEffects<states.OpenedState> => {
   switch (action.type) {
-    case actions.COMMITMENT_RECEIVED:
+    case COMMITMENT_RECEIVED:
       const { commitment, signature } = action;
       if (!validTransitionToPostFundState(state, commitment, signature)) {
         return { state };

--- a/packages/wallet/src/redux/channelState/reducer.ts
+++ b/packages/wallet/src/redux/channelState/reducer.ts
@@ -21,7 +21,7 @@ import { CommitmentType } from 'fmg-core';
 import { StateWithSideEffects } from '../utils';
 import { ethers } from 'ethers';
 import { channelID } from 'fmg-core/lib/channel';
-import { WalletAction } from '../actions';
+import { WalletAction, COMMITMENT_RECEIVED } from '../actions';
 
 export const channelStateReducer: ReducerWithSideEffects<states.ChannelState> = (
   state: states.ChannelState,
@@ -179,7 +179,7 @@ const receivedValidOpponentConclusionRequest = (
   if (state.stage !== states.FUNDING && state.stage !== states.RUNNING) {
     return null;
   }
-  if (action.type !== actions.COMMITMENT_RECEIVED) {
+  if (action.type !== COMMITMENT_RECEIVED) {
     return null;
   }
 

--- a/packages/wallet/src/redux/sagas/message-listener.ts
+++ b/packages/wallet/src/redux/sagas/message-listener.ts
@@ -38,10 +38,12 @@ export function* messageListener() {
         yield put(actions.channel.opponentCommitmentReceived(action.commitment, action.signature));
         break;
       case incoming.RECEIVE_MESSAGE:
-        yield put(actions.channel.messageReceived(action.data));
-        break;
-      case incoming.RECEIVE_COMMITMENT:
-        yield put(actions.channel.commitmentReceived(action.commitment, action.signature));
+        const { data, channelId } = action;
+        if ('commitment' in data) {
+          yield put(actions.commitmentReceived(channelId, data.commitment, data.signature));
+        } else {
+          yield put(actions.messageReceived(channelId, data));
+        }
         break;
       case incoming.RESPOND_TO_CHALLENGE:
         yield put(actions.channel.challengeCommitmentReceived(action.commitment));


### PR DESCRIPTION
In preparation for messages that belong to a particular process, this PR removes the `relayCommitment` wallet function.

In the wallet, the `message-listener` peeks at the shape of the `data` and dispatches either `messageReceived` or `commitmentReceived`.

The next step would be to place an identifier on the message to indicate that it belongs to the `indirect-funding` "process" or "module", whatever that gets called.