### PR TITLE
Update Wallet Messages to have a process and channelId

### DIFF
--- a/packages/magmo-wallet-client/src/index.ts
+++ b/packages/magmo-wallet-client/src/index.ts
@@ -7,3 +7,4 @@ export * from './wallet-events';
 
 export * from './wallet-functions';
 export { WalletEventListener } from './wallet-event-listener';
+export * from './wallet-types';

--- a/packages/magmo-wallet-client/src/wallet-events.ts
+++ b/packages/magmo-wallet-client/src/wallet-events.ts
@@ -1,4 +1,5 @@
 import { Commitment } from 'fmg-core';
+import { WalletProcess, WalletMessage } from './wallet-types';
 
 // TODO: We should limit WalletEvent/WalletEventTypes to the bare minimum of events we expect the app to handle. Some of these can be pruned.
 // Events that we handle for the user (HideWallet,ShowWallet, ValidateSuccess, etc..) should be removed from WalletEvent/WalletEventTypes
@@ -281,10 +282,10 @@ export const MESSAGE_RELAY_REQUESTED = 'WALLET.MESSAGING.MESSAGE_RELAY_REQUESTED
 /**
  * @ignore
  */
-export const messageRelayRequested = (to: string, data: any) => ({
+export const messageRelayRequested = (to: string, message: WalletMessage) => ({
   type: MESSAGE_RELAY_REQUESTED as typeof MESSAGE_RELAY_REQUESTED,
   to,
-  data,
+  message,
 });
 
 /**

--- a/packages/magmo-wallet-client/src/wallet-events.ts
+++ b/packages/magmo-wallet-client/src/wallet-events.ts
@@ -1,5 +1,5 @@
 import { Commitment } from 'fmg-core';
-import { WalletMessage } from './wallet-types';
+import { WalletMessagePayload } from './wallet-types';
 
 // TODO: We should limit WalletEvent/WalletEventTypes to the bare minimum of events we expect the app to handle. Some of these can be pruned.
 // Events that we handle for the user (HideWallet,ShowWallet, ValidateSuccess, etc..) should be removed from WalletEvent/WalletEventTypes
@@ -282,11 +282,11 @@ export const MESSAGE_RELAY_REQUESTED = 'WALLET.MESSAGING.MESSAGE_RELAY_REQUESTED
 /**
  * @ignore
  */
-export const messageRelayRequested = (to: string, message: WalletMessage) => ({
-  type: MESSAGE_RELAY_REQUESTED as typeof MESSAGE_RELAY_REQUESTED,
-  to,
-  message,
-});
+export const messageRelayRequested = (to: string, messagePayload: WalletMessagePayload) => ({
+         type: MESSAGE_RELAY_REQUESTED as typeof MESSAGE_RELAY_REQUESTED,
+         to,
+         messagePayload,
+       });
 
 /**
  * The event emitted when the wallet requests a message be relayed to the opponent's wallet.

--- a/packages/magmo-wallet-client/src/wallet-events.ts
+++ b/packages/magmo-wallet-client/src/wallet-events.ts
@@ -283,10 +283,10 @@ export const MESSAGE_RELAY_REQUESTED = 'WALLET.MESSAGING.MESSAGE_RELAY_REQUESTED
  * @ignore
  */
 export const messageRelayRequested = (to: string, messagePayload: WalletMessagePayload) => ({
-         type: MESSAGE_RELAY_REQUESTED as typeof MESSAGE_RELAY_REQUESTED,
-         to,
-         messagePayload,
-       });
+  type: MESSAGE_RELAY_REQUESTED as typeof MESSAGE_RELAY_REQUESTED,
+  to,
+  messagePayload,
+});
 
 /**
  * The event emitted when the wallet requests a message be relayed to the opponent's wallet.

--- a/packages/magmo-wallet-client/src/wallet-events.ts
+++ b/packages/magmo-wallet-client/src/wallet-events.ts
@@ -293,29 +293,6 @@ export const messageRelayRequested = (to: string, data: string) => ({
 export type MessageRelayRequested = ReturnType<typeof messageRelayRequested>;
 
 /**
- * The type of event when a commitment relay to the opponent's wallet is requested.
- */
-export const COMMITMENT_RELAY_REQUESTED = 'WALLET.MESSAGING.COMMITMENT_RELAY_REQUESTED';
-/**
- * @ignore
- */
-export const commitmentRelayRequested = (
-  to: string,
-  commitment: Commitment,
-  signature: string,
-) => ({
-  type: COMMITMENT_RELAY_REQUESTED as typeof COMMITMENT_RELAY_REQUESTED,
-  to,
-  commitment,
-  signature,
-});
-
-/**
- * The event emitted when the wallet requests a commitment be relayed to the opponent's wallet.
- */
-export type CommitmentRelayRequested = ReturnType<typeof commitmentRelayRequested>;
-
-/**
  * The type for events where a challenge position is received from the wallet.
  */
 export const CHALLENGE_COMMITMENT_RECEIVED = 'WALLET.MESSAGING.CHALLENGE_COMMITMENT_RECEIVED';
@@ -384,7 +361,6 @@ export type WalletEventType =
   | typeof CHALLENGE_REJECTED
   | typeof CHALLENGE_RESPONSE_REQUESTED
   | typeof CLOSE_SUCCESS
-  | typeof COMMITMENT_RELAY_REQUESTED
   | typeof CONCLUDE_FAILURE
   | typeof CONCLUDE_SUCCESS
   | typeof FUNDING_FAILURE

--- a/packages/magmo-wallet-client/src/wallet-events.ts
+++ b/packages/magmo-wallet-client/src/wallet-events.ts
@@ -281,7 +281,7 @@ export const MESSAGE_RELAY_REQUESTED = 'WALLET.MESSAGING.MESSAGE_RELAY_REQUESTED
 /**
  * @ignore
  */
-export const messageRelayRequested = (to: string, data: string) => ({
+export const messageRelayRequested = (to: string, data: any) => ({
   type: MESSAGE_RELAY_REQUESTED as typeof MESSAGE_RELAY_REQUESTED,
   to,
   data,
@@ -386,7 +386,6 @@ export type WalletEvent =
   | ChallengeResponseRequested
   | ChannelInitializationSuccess
   | CloseSuccess
-  | CommitmentRelayRequested
   | ConcludeFailure
   | ConcludeSuccess
   | FundingFailure

--- a/packages/magmo-wallet-client/src/wallet-events.ts
+++ b/packages/magmo-wallet-client/src/wallet-events.ts
@@ -1,5 +1,5 @@
 import { Commitment } from 'fmg-core';
-import { WalletProcess, WalletMessage } from './wallet-types';
+import { WalletMessage } from './wallet-types';
 
 // TODO: We should limit WalletEvent/WalletEventTypes to the bare minimum of events we expect the app to handle. Some of these can be pruned.
 // Events that we handle for the user (HideWallet,ShowWallet, ValidateSuccess, etc..) should be removed from WalletEvent/WalletEventTypes

--- a/packages/magmo-wallet-client/src/wallet-functions.ts
+++ b/packages/magmo-wallet-client/src/wallet-functions.ts
@@ -184,12 +184,13 @@ export async function signCommitment(iFrameId: string, commitment: Commitment): 
   return signPromise;
 }
 
+export const;
 /**
  * Relays a message to the wallet, from the opponent's wallet.
  * @param iFrameId The id of the embedded wallet iframe.
  * @param data The message to send to the wallet that was received from the opponent's wallet.
  */
-export function relayMessage(iFrameId: string, data) {
+export function relayMessage(iFrameId: string, channelId: string, process: WalletProcess, data) {
   const iFrame = document.getElementById(iFrameId) as HTMLIFrameElement;
   const message = receiveMessage(data);
   iFrame.contentWindow.postMessage(message, '*');

--- a/packages/magmo-wallet-client/src/wallet-functions.ts
+++ b/packages/magmo-wallet-client/src/wallet-functions.ts
@@ -189,7 +189,7 @@ export async function signCommitment(iFrameId: string, commitment: Commitment): 
  * @param iFrameId The id of the embedded wallet iframe.
  * @param data The message to send to the wallet that was received from the opponent's wallet.
  */
-export function relayMessage(iFrameId: string, data: string) {
+export function relayMessage(iFrameId: string, data) {
   const iFrame = document.getElementById(iFrameId) as HTMLIFrameElement;
   const message = receiveMessage(data);
   iFrame.contentWindow.postMessage(message, '*');

--- a/packages/magmo-wallet-client/src/wallet-functions.ts
+++ b/packages/magmo-wallet-client/src/wallet-functions.ts
@@ -19,7 +19,6 @@ import {
   receiveMessage,
   createChallenge,
   respondToChallenge,
-  receiveCommitment,
   initializeChannelRequest,
 } from './wallet-instructions';
 import { Commitment } from 'fmg-core';
@@ -183,19 +182,6 @@ export async function signCommitment(iFrameId: string, commitment: Commitment): 
 
   iFrame.contentWindow.postMessage(message, '*');
   return signPromise;
-}
-
-/**
- * Relays a commitment to the wallet, from the opponent's wallet.
- * Used, for example, when the opponent's wallet is funding a channel through a ledger channel.
- * @param iFrameId The id of the embedded wallet iframe.
- * @param commitment The commitment to send to the wallet that was received from the opponent's wallet.
- * @param signature The signature that was received from the opponent's wallet.
- */
-export function relayCommitment(iFrameId: string, commitment: Commitment, signature: string) {
-  const iFrame = document.getElementById(iFrameId) as HTMLIFrameElement;
-  const message = receiveCommitment(commitment, signature);
-  iFrame.contentWindow.postMessage(message, '*');
 }
 
 /**

--- a/packages/magmo-wallet-client/src/wallet-functions.ts
+++ b/packages/magmo-wallet-client/src/wallet-functions.ts
@@ -22,7 +22,7 @@ import {
   initializeChannelRequest,
 } from './wallet-instructions';
 import { Commitment } from 'fmg-core';
-import { WalletMessage } from './wallet-types';
+import { WalletMessagePayload } from './wallet-types';
 
 /**
  * Creates an iframe element for the wallet to be embedded in the page. The wallet iframe will hide itself and only show when interaction with the wallet is necessary.
@@ -190,9 +190,9 @@ export async function signCommitment(iFrameId: string, commitment: Commitment): 
  * @param iFrameId The id of the embedded wallet iframe.
  * @param walletMessage The message to send to the wallet that was received from the opponent's wallet.
  */
-export function relayMessage(iFrameId: string, walletMessage: WalletMessage) {
+export function relayMessage(iFrameId: string, messagePayload: WalletMessagePayload) {
   const iFrame = document.getElementById(iFrameId) as HTMLIFrameElement;
-  const message = receiveMessage(walletMessage);
+  const message = receiveMessage(messagePayload);
   iFrame.contentWindow.postMessage(message, '*');
 }
 

--- a/packages/magmo-wallet-client/src/wallet-functions.ts
+++ b/packages/magmo-wallet-client/src/wallet-functions.ts
@@ -22,6 +22,7 @@ import {
   initializeChannelRequest,
 } from './wallet-instructions';
 import { Commitment } from 'fmg-core';
+import { WalletMessage } from './wallet-types';
 
 /**
  * Creates an iframe element for the wallet to be embedded in the page. The wallet iframe will hide itself and only show when interaction with the wallet is necessary.
@@ -184,15 +185,14 @@ export async function signCommitment(iFrameId: string, commitment: Commitment): 
   return signPromise;
 }
 
-export const;
 /**
  * Relays a message to the wallet, from the opponent's wallet.
  * @param iFrameId The id of the embedded wallet iframe.
- * @param data The message to send to the wallet that was received from the opponent's wallet.
+ * @param walletMessage The message to send to the wallet that was received from the opponent's wallet.
  */
-export function relayMessage(iFrameId: string, channelId: string, process: WalletProcess, data) {
+export function relayMessage(iFrameId: string, walletMessage: WalletMessage) {
   const iFrame = document.getElementById(iFrameId) as HTMLIFrameElement;
-  const message = receiveMessage(data);
+  const message = receiveMessage(walletMessage);
   iFrame.contentWindow.postMessage(message, '*');
 }
 

--- a/packages/magmo-wallet-client/src/wallet-instructions.ts
+++ b/packages/magmo-wallet-client/src/wallet-instructions.ts
@@ -111,17 +111,6 @@ export const receiveMessage = (data: string) => ({
 });
 export type ReceiveMessage = ReturnType<typeof receiveMessage>;
 
-// Called when a "wallet commitment" is received from the opponent.
-// By "wallet commitment" we mean a commitment that was created directly from the opponent's
-// wallet meant for wallet-to-wallet communication (e.g. commitments used to set up a ledger channel)
-export const RECEIVE_COMMITMENT = 'WALLET.MESSAGING.RECEIVE_COMMITMENT';
-export const receiveCommitment = (commitment: Commitment, signature: string) => ({
-  type: RECEIVE_COMMITMENT,
-  commitment,
-  signature,
-});
-export type ReceiveCommitment = ReturnType<typeof receiveCommitment>;
-
 // Requests
 // ========
 export type RequestAction =

--- a/packages/magmo-wallet-client/src/wallet-instructions.ts
+++ b/packages/magmo-wallet-client/src/wallet-instructions.ts
@@ -105,7 +105,7 @@ export type ConcludeChannelRequest = ReturnType<typeof concludeChannelRequest>;
 // wallet meant for wallet-to-wallet communication (e.g. communicating the address of the
 // adjudicator).
 export const RECEIVE_MESSAGE = 'WALLET.MESSAGING.RECEIVE_MESSAGE';
-export const receiveMessage = (data: string) => ({
+export const receiveMessage = data => ({
   type: RECEIVE_MESSAGE,
   data,
 });

--- a/packages/magmo-wallet-client/src/wallet-instructions.ts
+++ b/packages/magmo-wallet-client/src/wallet-instructions.ts
@@ -1,4 +1,5 @@
 import { Commitment } from 'fmg-core';
+import { WalletProcess, WalletMessage } from './wallet-types';
 
 export enum PlayerIndex {
   'A' = 0,
@@ -105,9 +106,9 @@ export type ConcludeChannelRequest = ReturnType<typeof concludeChannelRequest>;
 // wallet meant for wallet-to-wallet communication (e.g. communicating the address of the
 // adjudicator).
 export const RECEIVE_MESSAGE = 'WALLET.MESSAGING.RECEIVE_MESSAGE';
-export const receiveMessage = data => ({
+export const receiveMessage = (message: WalletMessage) => ({
   type: RECEIVE_MESSAGE,
-  data,
+  message,
 });
 export type ReceiveMessage = ReturnType<typeof receiveMessage>;
 

--- a/packages/magmo-wallet-client/src/wallet-instructions.ts
+++ b/packages/magmo-wallet-client/src/wallet-instructions.ts
@@ -1,5 +1,5 @@
 import { Commitment } from 'fmg-core';
-import { WalletProcess, WalletMessage } from './wallet-types';
+import { WalletMessage } from './wallet-types';
 
 export enum PlayerIndex {
   'A' = 0,

--- a/packages/magmo-wallet-client/src/wallet-instructions.ts
+++ b/packages/magmo-wallet-client/src/wallet-instructions.ts
@@ -1,5 +1,5 @@
 import { Commitment } from 'fmg-core';
-import { WalletMessage } from './wallet-types';
+import { WalletMessagePayload } from './wallet-types';
 
 export enum PlayerIndex {
   'A' = 0,
@@ -106,9 +106,9 @@ export type ConcludeChannelRequest = ReturnType<typeof concludeChannelRequest>;
 // wallet meant for wallet-to-wallet communication (e.g. communicating the address of the
 // adjudicator).
 export const RECEIVE_MESSAGE = 'WALLET.MESSAGING.RECEIVE_MESSAGE';
-export const receiveMessage = (message: WalletMessage) => ({
+export const receiveMessage = (messagePayload: WalletMessagePayload) => ({
   type: RECEIVE_MESSAGE,
-  message,
+  messagePayload,
 });
 export type ReceiveMessage = ReturnType<typeof receiveMessage>;
 

--- a/packages/magmo-wallet-client/src/wallet-types.ts
+++ b/packages/magmo-wallet-client/src/wallet-types.ts
@@ -1,4 +1,4 @@
-export interface WalletMessage {
+export interface WalletMessagePayload {
   channelId: string;
   procedure: string;
   data: any;

--- a/packages/magmo-wallet-client/src/wallet-types.ts
+++ b/packages/magmo-wallet-client/src/wallet-types.ts
@@ -1,0 +1,5 @@
+export interface WalletMessage {
+  channelId: string;
+  procedure: string;
+  data: any;
+}

--- a/packages/rps/src/redux/message-service/saga.ts
+++ b/packages/rps/src/redux/message-service/saga.ts
@@ -40,7 +40,7 @@ interface AppMessage {
 }
 
 interface WalletMessage {
-  message: any;
+  payload: any;
   queue: Queue.WALLET;
   userName?: string;
 }
@@ -52,12 +52,12 @@ export function* sendWalletMessageSaga() {
   while (true) {
     const messageRelayRequest: MessageRelayRequested = yield take(sendMessageChannel);
 
-    const { message: messageFromWallet, to } = messageRelayRequest;
-    const messageToSend: WalletMessage = { message: messageFromWallet, queue: Queue.WALLET };
+    const { messagePayload, to } = messageRelayRequest;
+    const messageToSend: WalletMessage = { payload: messagePayload, queue: Queue.WALLET };
 
     if (process.env.NODE_ENV === 'development' && to === process.env.SERVER_WALLET_ADDRESS) {
       try {
-        const response = yield call(postData, { ...messageFromWallet });
+        const response = yield call(postData, { ...messagePayload });
 
         // Since the response is returned straight away, we have to relay the commitment
         // immediately
@@ -184,8 +184,8 @@ function* receiveFromFirebaseSaga(address) {
         throw new Error('Invalid game message received: signature missing');
       }
     } else {
-      if ('message' in value) {
-        Wallet.relayMessage(WALLET_IFRAME_ID, value.message);
+      if ('payload' in value) {
+        Wallet.relayMessage(WALLET_IFRAME_ID, value.payload);
       } else {
         throw new Error('Invalid wallet message received: message missing');
       }

--- a/packages/rps/src/redux/message-service/saga.ts
+++ b/packages/rps/src/redux/message-service/saga.ts
@@ -5,7 +5,7 @@ import { reduxSagaFirebase } from '../../gateways/firebase';
 import { Player } from '../../core';
 import * as gameActions from '../game/actions';
 import * as appActions from '../global/actions';
-import { MessageState, WalletMessage } from './state';
+import { MessageState, WalletRequest } from './state';
 import * as gameStates from '../game/state';
 import { getMessageState, getGameState } from '../store';
 import * as Wallet from 'magmo-wallet-client';
@@ -13,6 +13,7 @@ import { WALLET_IFRAME_ID } from '../../constants';
 import { channelID } from 'fmg-core/lib/channel';
 import { asCoreCommitment, fromCoreCommitment } from '../../core/rps-commitment';
 import { Commitment } from 'fmg-core';
+import { MessageRelayRequested } from 'magmo-wallet-client';
 
 export enum Queue {
   WALLET = 'WALLET',
@@ -31,83 +32,44 @@ export default function* messageSaga() {
   yield fork(exitGameSaga);
 }
 
-interface CommitmentMessage {
-  data: Commitment;
+interface AppCommunication {
+  commitment: Commitment;
   signature: string;
-  queue: Queue;
+  queue: Queue.GAME_ENGINE;
   userName?: string;
 }
 
-interface NonCommitmentMessage {
-  data: string;
+interface WalletCommunication {
+  message: any;
   queue: Queue.WALLET;
   userName?: string;
 }
 
-type Message = CommitmentMessage | NonCommitmentMessage;
+type Communication = AppCommunication | WalletCommunication;
 
 export function* sendWalletMessageSaga() {
-  const sendMessageChannel = createWalletEventChannel([
-    Wallet.COMMITMENT_RELAY_REQUESTED,
-    Wallet.MESSAGE_RELAY_REQUESTED,
-  ]);
+  const sendMessageChannel = createWalletEventChannel([Wallet.MESSAGE_RELAY_REQUESTED]);
   while (true) {
-    const messageRequest = yield take(sendMessageChannel);
-    const queue = Queue.WALLET;
+    const messageRelayRequest: MessageRelayRequested = yield take(sendMessageChannel);
 
-    switch (messageRequest.type) {
-      case Wallet.COMMITMENT_RELAY_REQUESTED: {
-        const { commitment, to, signature } = messageRequest;
-        const message: CommitmentMessage = { data: commitment, queue, signature };
+    const { message, to } = messageRelayRequest;
+    const messageToSend: WalletCommunication = { message, queue: Queue.WALLET };
 
-        if (
-          process.env.NODE_ENV === 'development' &&
-          commitment.channel.participants[1] === process.env.SERVER_WALLET_ADDRESS
-        ) {
-          const response = yield call(postData, { ...message, commitment });
-          const { commitment: theirCommitment, signature: theirSignature } = response;
+    if (process.env.NODE_ENV === 'development' && to === process.env.SERVER_WALLET_ADDRESS) {
+      try {
+        const response = yield call(postData, { ...message });
 
-          // Since the response is returned straight away, we have to relay the commitment
-          // immediately
-          relayToWallet({
-            commitment: theirCommitment,
-            signature: theirSignature,
-            type: 'Commitment',
-          });
-        } else {
-          yield call(reduxSagaFirebase.database.create, `/messages/${to.toLowerCase()}`, message);
-        }
-        break;
+        // Since the response is returned straight away, we have to relay the commitment
+        // immediately
+        Wallet.relayMessage(WALLET_IFRAME_ID, response.data);
+      } catch (err) {
+        console.error(err);
       }
-      case Wallet.MESSAGE_RELAY_REQUESTED: {
-        const { data, to } = messageRequest;
-        const message: NonCommitmentMessage = { data, queue };
-
-        if (process.env.NODE_ENV === 'development' && to === process.env.SERVER_WALLET_ADDRESS) {
-          try {
-            const response = yield call(postData, { ...message });
-            const { commitment: theirCommitment, signature: theirSignature } = response;
-
-            // Since the response is returned straight away, we have to relay the commitment
-            // immediately
-            relayToWallet({
-              commitment: theirCommitment,
-              signature: theirSignature,
-              type: 'Commitment',
-            });
-          } catch (err) {
-            console.error(err);
-          }
-        } else {
-          yield call(reduxSagaFirebase.database.create, `/messages/${to.toLowerCase()}`, message);
-        }
-        yield call(reduxSagaFirebase.database.create, `/messages/${to.toLowerCase()}`, message);
-        break;
-      }
-
-      default:
-        break;
+    } else {
+      yield call(reduxSagaFirebase.database.create, `/messages/${to.toLowerCase()}`, messageToSend);
     }
+    yield call(reduxSagaFirebase.database.create, `/messages/${to.toLowerCase()}`, messageToSend);
+    break;
   }
 }
 
@@ -144,7 +106,7 @@ export function* sendMessagesSaga() {
       const commitment = messageState.opponentOutbox.commitment;
       const signature = yield signMessage(commitment);
       const userName = gameState.name !== gameStates.StateName.NoName ? gameState.myName : '';
-      const message: CommitmentMessage = { data: commitment, queue, signature, userName };
+      const message: AppCommunication = { commitment, queue, signature, userName };
       const { opponentAddress } = messageState.opponentOutbox;
 
       if (
@@ -152,13 +114,13 @@ export function* sendMessagesSaga() {
         commitment.channel.participants[1] === process.env.SERVER_WALLET_ADDRESS
       ) {
         // To ease local development, we bypass firebase and make http requests directly against the local server
-        const response = yield call(postData, { ...message, commitment: message.data });
+        const response = yield call(postData, { ...message, commitment: message.commitment });
         yield put(gameActions.messageSent());
 
         // Since the response is returned straight away, we have to receive the commitment immediately
         const { commitment: theirCommitment, signature: theirSignature } = response;
         yield receiveCommitmentSaga({
-          data: theirCommitment,
+          commitment: theirCommitment,
           signature: theirSignature,
           queue: Queue.GAME_ENGINE,
           userName: 'Neo Bot',
@@ -211,7 +173,7 @@ function* receiveFromFirebaseSaga(address) {
 
   while (true) {
     const message = yield take(channel);
-    const value: Message = message.value;
+    const value: Communication = message.value;
 
     const key = message.snapshot.key;
     const { queue } = value;
@@ -222,12 +184,13 @@ function* receiveFromFirebaseSaga(address) {
         throw new Error('Invalid game message received: signature missing');
       }
     } else {
-      if ('signature' in value) {
-        relayToWallet({ ...value, commitment: value.data, type: 'Commitment' });
+      if ('message' in value) {
+        Wallet.relayMessage(WALLET_IFRAME_ID, value.message);
       } else {
-        relayToWallet({ ...value, type: 'Message' });
+        throw new Error('Invalid wallet message received: message missing');
       }
     }
+
     yield call(reduxSagaFirebase.database.delete, `/messages/${address}/${key}`);
   }
 }
@@ -248,7 +211,7 @@ function createWalletEventChannel(walletEventTypes: Wallet.WalletEventType[]) {
   });
 }
 
-function* handleWalletMessage(walletMessage: WalletMessage, state: gameStates.PlayingState) {
+function* handleWalletMessage(walletMessage: WalletRequest, state: gameStates.PlayingState) {
   const { channel, player, allocation: balances, destination: participants } = state;
   const channelId = channelID(channel);
 
@@ -362,23 +325,8 @@ function* receiveChallengePositionFromWalletSaga() {
   }
 }
 
-function relayToWallet(
-  message:
-    | { data: string; type: 'Message' }
-    | { commitment: Commitment; signature: string; type: 'Commitment' },
-) {
-  switch (message.type) {
-    case 'Message':
-      Wallet.relayMessage(WALLET_IFRAME_ID, message.data);
-      return;
-    case 'Commitment':
-      const { commitment, signature } = message;
-      Wallet.relayCommitment(WALLET_IFRAME_ID, commitment, signature);
-  }
-}
-
-function* receiveCommitmentSaga(message: CommitmentMessage) {
-  const { data, signature, userName } = message;
+function* receiveCommitmentSaga(message: AppCommunication) {
+  const { commitment: data, signature, userName } = message;
   const validMessage = yield validateMessage(data, signature);
   if (!validMessage) {
     // TODO: Handle this

--- a/packages/rps/src/redux/message-service/state.ts
+++ b/packages/rps/src/redux/message-service/state.ts
@@ -6,7 +6,7 @@ export interface OutgoingMessage {
   opponentAddress: Address;
   commitment: Commitment;
 }
-export interface WalletMessage {
+export interface WalletRequest {
   type:
     | 'FUNDING_REQUESTED'
     | 'RESPOND_TO_CHALLENGE'
@@ -17,7 +17,7 @@ export interface WalletMessage {
 }
 export interface MessageState {
   opponentOutbox?: OutgoingMessage;
-  walletOutbox?: WalletMessage;
+  walletOutbox?: WalletRequest;
   actionToRetry?: actions.CommitmentReceived;
 }
 

--- a/packages/wallet/src/redux/actions.ts
+++ b/packages/wallet/src/redux/actions.ts
@@ -3,7 +3,6 @@ import * as channel from './channelState/actions';
 import * as funding from './fundingState/actions';
 import { WalletProcedure } from './types';
 import { Commitment } from 'fmg-core';
-import { WalletProcess } from 'magmo-wallet-client';
 
 export const LOGGED_IN = 'WALLET.LOGGED_IN';
 export const loggedIn = (uid: string) => ({
@@ -132,10 +131,10 @@ export type RetryTransaction = ReturnType<typeof retryTransaction>;
 
 export type Message = 'FundingDeclined';
 export const MESSAGE_RECEIVED = 'WALLET.COMMON.MESSAGE_RECEIVED';
-export const messageReceived = (channelId: string, process: WalletProcess, data: Message) => ({
+export const messageReceived = (channelId: string, procedure: WalletProcedure, data: Message) => ({
   type: MESSAGE_RECEIVED as typeof MESSAGE_RECEIVED,
   channelId,
-  process,
+  procedure,
   data,
 });
 export type MessageReceived = ReturnType<typeof messageReceived>;
@@ -143,12 +142,13 @@ export type MessageReceived = ReturnType<typeof messageReceived>;
 export const COMMITMENT_RECEIVED = 'WALLET.COMMON.COMMITMENT_RECEIVED';
 export const commitmentReceived = (
   channelId: string,
-  process: WalletProcess,
+  procedure: WalletProcedure,
   commitment: Commitment,
   signature: string,
 ) => ({
   type: COMMITMENT_RECEIVED as typeof COMMITMENT_RECEIVED,
   channelId,
+  procedure,
   commitment,
   signature,
 });

--- a/packages/wallet/src/redux/actions.ts
+++ b/packages/wallet/src/redux/actions.ts
@@ -3,6 +3,7 @@ import * as channel from './channelState/actions';
 import * as funding from './fundingState/actions';
 import { WalletProcedure } from './types';
 import { Commitment } from 'fmg-core';
+import { WalletProcess } from 'magmo-wallet-client';
 
 export const LOGGED_IN = 'WALLET.LOGGED_IN';
 export const loggedIn = (uid: string) => ({
@@ -131,9 +132,10 @@ export type RetryTransaction = ReturnType<typeof retryTransaction>;
 
 export type Message = 'FundingDeclined';
 export const MESSAGE_RECEIVED = 'WALLET.COMMON.MESSAGE_RECEIVED';
-export const messageReceived = (channelId: string, data: Message) => ({
+export const messageReceived = (channelId: string, process: WalletProcess, data: Message) => ({
   type: MESSAGE_RECEIVED as typeof MESSAGE_RECEIVED,
   channelId,
+  process,
   data,
 });
 export type MessageReceived = ReturnType<typeof messageReceived>;
@@ -141,6 +143,7 @@ export type MessageReceived = ReturnType<typeof messageReceived>;
 export const COMMITMENT_RECEIVED = 'WALLET.COMMON.COMMITMENT_RECEIVED';
 export const commitmentReceived = (
   channelId: string,
+  process: WalletProcess,
   commitment: Commitment,
   signature: string,
 ) => ({

--- a/packages/wallet/src/redux/actions.ts
+++ b/packages/wallet/src/redux/actions.ts
@@ -2,6 +2,7 @@ import * as internal from './internal/actions';
 import * as channel from './channelState/actions';
 import * as funding from './fundingState/actions';
 import { WalletProcedure } from './types';
+import { Commitment } from 'fmg-core';
 
 export const LOGGED_IN = 'WALLET.LOGGED_IN';
 export const loggedIn = (uid: string) => ({
@@ -128,12 +129,36 @@ export const retryTransaction = (channelId: string, procedure: WalletProcedure) 
 });
 export type RetryTransaction = ReturnType<typeof retryTransaction>;
 
+export type Message = 'FundingDeclined';
+export const MESSAGE_RECEIVED = 'WALLET.COMMON.MESSAGE_RECEIVED';
+export const messageReceived = (channelId: string, data: Message) => ({
+  type: MESSAGE_RECEIVED as typeof MESSAGE_RECEIVED,
+  channelId,
+  data,
+});
+export type MessageReceived = ReturnType<typeof messageReceived>;
+
+export const COMMITMENT_RECEIVED = 'WALLET.COMMON.COMMITMENT_RECEIVED';
+export const commitmentReceived = (
+  channelId: string,
+  commitment: Commitment,
+  signature: string,
+) => ({
+  type: COMMITMENT_RECEIVED as typeof COMMITMENT_RECEIVED,
+  channelId,
+  commitment,
+  signature,
+});
+export type CommitmentReceived = ReturnType<typeof commitmentReceived>;
+
 export type CommonAction =
   | TransactionConfirmed
   | TransactionSentToMetamask
   | TransactionSubmissionFailed
   | TransactionSubmitted
-  | RetryTransaction;
+  | RetryTransaction
+  | MessageReceived
+  | CommitmentReceived;
 
 export function isCommonAction(action: WalletAction): action is CommonAction {
   return action.type.match('WALLET.COMMON') ? true : false;

--- a/packages/wallet/src/redux/channelState/actions.ts
+++ b/packages/wallet/src/redux/channelState/actions.ts
@@ -34,14 +34,6 @@ export const opponentCommitmentReceived = (commitment: Commitment, signature: st
 });
 export type OpponentCommitmentReceived = ReturnType<typeof opponentCommitmentReceived>;
 
-export const COMMITMENT_RECEIVED = 'WALLET.CHANNEL.COMMITMENT_RECEIVED';
-export const commitmentReceived = (commitment: Commitment, signature: string) => ({
-  type: COMMITMENT_RECEIVED as typeof COMMITMENT_RECEIVED,
-  commitment,
-  signature,
-});
-export type CommitmentReceived = ReturnType<typeof commitmentReceived>;
-
 export const FUNDING_REQUESTED = 'WALLET.CHANNEL.FUNDING_REQUESTED';
 export const fundingRequested = () => ({
   type: FUNDING_REQUESTED as typeof FUNDING_REQUESTED,
@@ -247,13 +239,6 @@ export const approveClose = (withdrawAddress: string) => ({
 });
 export type ApproveClose = ReturnType<typeof approveClose>;
 
-export const MESSAGE_RECEIVED = 'WALLET.CHANNEL.MESSAGE_RECEIVED';
-export const messageReceived = (data: 'FundingDeclined') => ({
-  type: MESSAGE_RECEIVED as typeof MESSAGE_RECEIVED,
-  data,
-});
-export type MessageReceived = ReturnType<typeof messageReceived>;
-
 export type ChannelAction =  // TODO: Some of these actions probably also belong in a FundingAction type
   | ApproveClose
   | ChallengeAcknowledged
@@ -269,7 +254,6 @@ export type ChannelAction =  // TODO: Some of these actions probably also belong
   | ChannelInitialized
   | ClosedOnChainAcknowledged
   | CloseSuccessAcknowledged
-  | CommitmentReceived
   | ConcludeApproved
   | concludedEvent
   | ConcludeRejected
@@ -279,7 +263,6 @@ export type ChannelAction =  // TODO: Some of these actions probably also belong
   | FundingRejected
   | FundingRequested
   | FundingSuccessAcknowledged
-  | MessageReceived
   | OpponentCommitmentReceived
   | OwnCommitmentReceived
   | PostFundSetupReceived

--- a/packages/wallet/src/redux/channelState/closing/__tests__/closing.test.ts
+++ b/packages/wallet/src/redux/channelState/closing/__tests__/closing.test.ts
@@ -109,7 +109,8 @@ describe('start in WaitForOpponentConclude', () => {
     Object.defineProperty(SigningUtil, 'validCommitmentSignature', { value: validateMock });
     Object.defineProperty(ReducerUtil, 'validTransition', { value: validateMock });
 
-    const action = actions.channel.commitmentReceived(
+    const action = actions.commitmentReceived(
+      channelId,
       ('commitment' as unknown) as Commitment,
       '0x0',
     );

--- a/packages/wallet/src/redux/channelState/closing/__tests__/closing.test.ts
+++ b/packages/wallet/src/redux/channelState/closing/__tests__/closing.test.ts
@@ -66,7 +66,7 @@ describe('start in AcknowledgeConclude', () => {
 
     const updatedState = closingReducer(state, action);
     itTransitionsToChannelStateType(states.APPROVE_CLOSE_ON_CHAIN, updatedState);
-    itSendsThisMessage(updatedState, outgoing.COMMITMENT_RELAY_REQUESTED);
+    itSendsThisMessage(updatedState, outgoing.MESSAGE_RELAY_REQUESTED);
   });
 });
 
@@ -111,6 +111,7 @@ describe('start in WaitForOpponentConclude', () => {
 
     const action = actions.commitmentReceived(
       channelId,
+      WalletProcedure.DirectFunding,
       ('commitment' as unknown) as Commitment,
       '0x0',
     );

--- a/packages/wallet/src/redux/channelState/closing/reducer.ts
+++ b/packages/wallet/src/redux/channelState/closing/reducer.ts
@@ -286,7 +286,7 @@ const waitForOpponentConclude = (
   action: WalletAction,
 ): StateWithSideEffects<channelStates.ChannelStatus> => {
   switch (action.type) {
-    case actions.channel.COMMITMENT_RECEIVED:
+    case actions.COMMITMENT_RECEIVED:
       const { commitment, signature } = action;
 
       const opponentAddress = state.participants[1 - state.ourIndex];

--- a/packages/wallet/src/redux/channelState/closing/reducer.ts
+++ b/packages/wallet/src/redux/channelState/closing/reducer.ts
@@ -9,11 +9,11 @@ import {
   validCommitmentSignature,
 } from '../../../utils/signing-utils';
 import {
-  commitmentRelayRequested,
   closeSuccess,
   concludeSuccess,
   concludeFailure,
   hideWallet,
+  messageRelayRequested,
 } from 'magmo-wallet-client/lib/wallet-events';
 import { CommitmentType, Commitment } from 'fmg-core';
 import {
@@ -368,10 +368,13 @@ const composeConcludePosition = (state: channelStates.ClosingState) => {
   };
 
   const commitmentSignature = signCommitment(concludeCommitment, state.privateKey);
-  const sendCommitmentAction = commitmentRelayRequested(
-    state.participants[1 - state.ourIndex],
-    concludeCommitment,
-    commitmentSignature,
-  );
+  const sendCommitmentAction = messageRelayRequested(state.participants[1 - state.ourIndex], {
+    channelId: state.channelId,
+    procedure: WalletProcedure.DirectFunding,
+    data: {
+      concludeCommitment,
+      commitmentSignature,
+    },
+  });
   return { concludeCommitment, positionSignature: commitmentSignature, sendCommitmentAction };
 };

--- a/packages/wallet/src/redux/channelState/funding/__tests__/funding.test.ts
+++ b/packages/wallet/src/redux/channelState/funding/__tests__/funding.test.ts
@@ -131,7 +131,7 @@ describe('start in WaitForFundingApproval', () => {
   describe('incoming action: Funding declined message received', () => {
     const testDefaults = { ...defaultsA, ...justReceivedPreFundSetupB };
     const state = states.approveFunding(testDefaults);
-    const action = actions.channel.messageReceived('FundingDeclined');
+    const action = actions.messageReceived(channelId, 'FundingDeclined');
     const updatedState = fundingReducer(state, action);
     itTransitionsToChannelStateType(states.ACKNOWLEDGE_FUNDING_DECLINED, updatedState);
     itIncreasesTurnNumBy(0, state, updatedState);
@@ -160,7 +160,7 @@ describe('start in WaitForFundingAndPostFundSetup', () => {
 
   describe('incoming action: Funding declined message received', () => {
     const state = startingState('A');
-    const action = actions.channel.messageReceived('FundingDeclined');
+    const action = actions.messageReceived(channelId, 'FundingDeclined');
     const updatedState = fundingReducer(state, action);
 
     itTransitionsToChannelStateType(states.ACKNOWLEDGE_FUNDING_DECLINED, updatedState);
@@ -180,8 +180,7 @@ describe('start in WaitForFundingAndPostFundSetup', () => {
     const state = startingState('A');
     const validateMock = jest.fn().mockReturnValue(true);
     Object.defineProperty(SigningUtil, 'validCommitmentSignature', { value: validateMock });
-
-    const action = actions.channel.commitmentReceived(postFundCommitment1, '0x0');
+    const action = actions.commitmentReceived(channelId, postFundCommitment1, MOCK_SIGNATURE);
     const updatedState = fundingReducer(state, action);
 
     itTransitionsToChannelStateType(states.WAIT_FOR_FUNDING_AND_POST_FUND_SETUP, updatedState);
@@ -194,7 +193,7 @@ describe('start in WaitForFundingAndPostFundSetup', () => {
     const validateMock = jest.fn().mockReturnValue(true);
     Object.defineProperty(SigningUtil, 'validCommitmentSignature', { value: validateMock });
 
-    const action = actions.channel.commitmentReceived(postFundCommitment1, '0x0');
+    const action = actions.commitmentReceived(channelId, postFundCommitment1, MOCK_SIGNATURE);
     const updatedState = fundingReducer(state, action);
 
     itTransitionsToChannelStateType(states.WAIT_FOR_FUNDING_CONFIRMATION, updatedState);
@@ -244,7 +243,7 @@ describe('start in AWaitForPostFundSetup', () => {
 
     const testDefaults = { ...defaultsA, ...justReceivedPostFundSetupA };
     const state = states.aWaitForPostFundSetup({ ...testDefaults });
-    const action = actions.channel.commitmentReceived(postFundCommitment2, MOCK_SIGNATURE);
+    const action = actions.commitmentReceived(channelId, postFundCommitment2, MOCK_SIGNATURE);
     const updatedState = fundingReducer(state, action);
 
     itTransitionsToChannelStateType(states.ACKNOWLEDGE_FUNDING_SUCCESS, updatedState);
@@ -259,7 +258,7 @@ describe('start in BWaitForPostFundSetup', () => {
     const state = states.bWaitForPostFundSetup(testDefaults);
     const validateMock = jest.fn().mockReturnValue(true);
     Object.defineProperty(SigningUtil, 'validSignature', { value: validateMock });
-    const action = actions.channel.commitmentReceived(postFundCommitment1, MOCK_SIGNATURE);
+    const action = actions.commitmentReceived(channelId, postFundCommitment1, MOCK_SIGNATURE);
     const updatedState = fundingReducer(state, action);
 
     itTransitionsToChannelStateType(states.ACKNOWLEDGE_FUNDING_SUCCESS, updatedState);

--- a/packages/wallet/src/redux/channelState/funding/__tests__/funding.test.ts
+++ b/packages/wallet/src/redux/channelState/funding/__tests__/funding.test.ts
@@ -131,7 +131,7 @@ describe('start in WaitForFundingApproval', () => {
   describe('incoming action: Funding declined message received', () => {
     const testDefaults = { ...defaultsA, ...justReceivedPreFundSetupB };
     const state = states.approveFunding(testDefaults);
-    const action = actions.messageReceived(channelId, 'FundingDeclined');
+    const action = actions.messageReceived(channelId, 'DirectFunding', 'FundingDeclined');
     const updatedState = fundingReducer(state, action);
     itTransitionsToChannelStateType(states.ACKNOWLEDGE_FUNDING_DECLINED, updatedState);
     itIncreasesTurnNumBy(0, state, updatedState);
@@ -160,7 +160,7 @@ describe('start in WaitForFundingAndPostFundSetup', () => {
 
   describe('incoming action: Funding declined message received', () => {
     const state = startingState('A');
-    const action = actions.messageReceived(channelId, 'FundingDeclined');
+    const action = actions.messageReceived(channelId, 'DirectFunding', 'FundingDeclined');
     const updatedState = fundingReducer(state, action);
 
     itTransitionsToChannelStateType(states.ACKNOWLEDGE_FUNDING_DECLINED, updatedState);
@@ -180,7 +180,12 @@ describe('start in WaitForFundingAndPostFundSetup', () => {
     const state = startingState('A');
     const validateMock = jest.fn().mockReturnValue(true);
     Object.defineProperty(SigningUtil, 'validCommitmentSignature', { value: validateMock });
-    const action = actions.commitmentReceived(channelId, postFundCommitment1, MOCK_SIGNATURE);
+    const action = actions.commitmentReceived(
+      channelId,
+      'DirectFunding',
+      postFundCommitment1,
+      MOCK_SIGNATURE,
+    );
     const updatedState = fundingReducer(state, action);
 
     itTransitionsToChannelStateType(states.WAIT_FOR_FUNDING_AND_POST_FUND_SETUP, updatedState);
@@ -193,7 +198,12 @@ describe('start in WaitForFundingAndPostFundSetup', () => {
     const validateMock = jest.fn().mockReturnValue(true);
     Object.defineProperty(SigningUtil, 'validCommitmentSignature', { value: validateMock });
 
-    const action = actions.commitmentReceived(channelId, postFundCommitment1, MOCK_SIGNATURE);
+    const action = actions.commitmentReceived(
+      channelId,
+      'DirectFunding',
+      postFundCommitment1,
+      MOCK_SIGNATURE,
+    );
     const updatedState = fundingReducer(state, action);
 
     itTransitionsToChannelStateType(states.WAIT_FOR_FUNDING_CONFIRMATION, updatedState);
@@ -223,10 +233,14 @@ describe('start in WaitForFundingConfirmation', () => {
     const action = actions.internal.directFundingConfirmed(channelId);
     const updatedState = fundingReducer(state, action);
 
-    const sendCommitmentAction = outgoing.commitmentRelayRequested(
+    const sendCommitmentAction = outgoing.messageRelayRequested(
       state.participants[1 - state.ourIndex],
-      postFundCommitment2,
-      MOCK_SIGNATURE,
+      state.channelId,
+      'DirectFunding',
+      {
+        commitment: postFundCommitment2,
+        signature: MOCK_SIGNATURE,
+      },
     );
 
     itTransitionsToChannelStateType(states.ACKNOWLEDGE_FUNDING_SUCCESS, updatedState);

--- a/packages/wallet/src/redux/channelState/funding/reducer.ts
+++ b/packages/wallet/src/redux/channelState/funding/reducer.ts
@@ -1,6 +1,11 @@
 import * as states from '../state';
 import * as actions from '../actions';
-import { internal, TRANSACTION_CONFIRMED } from '../../actions';
+import {
+  internal,
+  TRANSACTION_CONFIRMED,
+  MESSAGE_RECEIVED,
+  COMMITMENT_RECEIVED,
+} from '../../actions';
 import {
   messageRelayRequested,
   fundingSuccess,
@@ -97,8 +102,8 @@ const approveFundingReducer = (
           displayOutbox: hideWallet(),
         },
       };
-    case actions.MESSAGE_RECEIVED:
-      if (action.data && action.data === 'FundingDeclined') {
+    case MESSAGE_RECEIVED:
+      if (action.data === 'FundingDeclined') {
         return { state: states.acknowledgeFundingDeclined(state) };
       } else {
         return { state };
@@ -115,7 +120,7 @@ const waitForFundingAndPostFundSetupReducer = (
   action: actions.ChannelAction | internal.InternalAction,
 ): StateWithSideEffects<states.OpenedState> => {
   switch (action.type) {
-    case actions.MESSAGE_RECEIVED:
+    case MESSAGE_RECEIVED:
       if (action.data === 'FundingDeclined') {
         return {
           state: states.acknowledgeFundingDeclined({ ...state }),
@@ -123,7 +128,7 @@ const waitForFundingAndPostFundSetupReducer = (
       } else {
         return { state };
       }
-    case actions.COMMITMENT_RECEIVED:
+    case COMMITMENT_RECEIVED:
       const { commitment, signature } = action;
       if (!validTransitionToPostFundState(state, commitment, signature)) {
         return { state };
@@ -207,7 +212,7 @@ const aWaitForPostFundSetupReducer = (
   action: actions.ChannelAction | internal.InternalAction,
 ): StateWithSideEffects<states.OpenedState> => {
   switch (action.type) {
-    case actions.COMMITMENT_RECEIVED:
+    case COMMITMENT_RECEIVED:
       const { commitment: postFundState, signature } = action;
       if (!validTransitionToPostFundState(state, postFundState, signature)) {
         return { state };
@@ -231,7 +236,7 @@ const bWaitForPostFundSetupReducer = (
   action: actions.ChannelAction | internal.InternalAction,
 ): StateWithSideEffects<states.OpenedState> => {
   switch (action.type) {
-    case actions.COMMITMENT_RECEIVED:
+    case COMMITMENT_RECEIVED:
       const { commitment, signature } = action;
       if (!validTransitionToPostFundState(state, commitment, signature)) {
         return { state };

--- a/packages/wallet/src/redux/channelState/reducer.ts
+++ b/packages/wallet/src/redux/channelState/reducer.ts
@@ -21,7 +21,7 @@ import { CommitmentType } from 'fmg-core';
 import { StateWithSideEffects } from '../utils';
 import { ethers } from 'ethers';
 import { channelID } from 'fmg-core/lib/channel';
-import { WalletAction } from '../actions';
+import { WalletAction, COMMITMENT_RECEIVED } from '../actions';
 
 export const channelStateReducer: ReducerWithSideEffects<states.ChannelState> = (
   state: states.ChannelState,
@@ -179,7 +179,7 @@ const receivedValidOpponentConclusionRequest = (
   if (state.stage !== states.FUNDING && state.stage !== states.RUNNING) {
     return null;
   }
-  if (action.type !== actions.COMMITMENT_RECEIVED) {
+  if (action.type !== COMMITMENT_RECEIVED) {
     return null;
   }
 

--- a/packages/wallet/src/redux/outbox/__tests__/reducer.test.ts
+++ b/packages/wallet/src/redux/outbox/__tests__/reducer.test.ts
@@ -9,8 +9,16 @@ import { WalletProcedure } from '../../types';
 const { channelId, mockTransactionOutboxItem } = scenarios;
 
 describe('when a side effect occured', () => {
-  const sendFundingDeclinedActionA = outgoing.messageRelayRequested('0xa00', 'FundingDeclined');
-  const sendFundingDeclinedActionB = outgoing.messageRelayRequested('0xb00', 'FundingDeclined');
+  const sendFundingDeclinedActionA = outgoing.messageRelayRequested('0xa00', {
+    channelId: '0x0',
+    procedure: WalletProcedure.DirectFunding,
+    data: 'FundingDeclined',
+  });
+  const sendFundingDeclinedActionB = outgoing.messageRelayRequested('0xb00', {
+    channelId: '0x0',
+    procedure: WalletProcedure.DirectFunding,
+    data: 'FundingDeclined',
+  });
   const displayOutbox = [outgoing.hideWallet(), outgoing.showWallet()];
   const transactionOutbox = [mockTransactionOutboxItem, mockTransactionOutboxItem];
   const messageOutbox = [sendFundingDeclinedActionA, sendFundingDeclinedActionB];

--- a/packages/wallet/src/redux/sagas/message-listener.ts
+++ b/packages/wallet/src/redux/sagas/message-listener.ts
@@ -38,11 +38,13 @@ export function* messageListener() {
         yield put(actions.channel.opponentCommitmentReceived(action.commitment, action.signature));
         break;
       case incoming.RECEIVE_MESSAGE:
-        const { data, channelId } = action;
+        const { data, channelId, process } = action as incoming.ReceiveMessage;
         if ('commitment' in data) {
-          yield put(actions.commitmentReceived(channelId, data.commitment, data.signature));
+          yield put(
+            actions.commitmentReceived(channelId, process, data.commitment, data.signature),
+          );
         } else {
-          yield put(actions.messageReceived(channelId, data));
+          yield put(actions.messageReceived(channelId, process, data));
         }
         break;
       case incoming.RESPOND_TO_CHALLENGE:

--- a/packages/wallet/src/redux/sagas/message-listener.ts
+++ b/packages/wallet/src/redux/sagas/message-listener.ts
@@ -3,6 +3,7 @@ import * as incoming from 'magmo-wallet-client/lib/wallet-instructions';
 
 import * as actions from '../actions';
 import { eventChannel } from 'redux-saga';
+import { WalletProcedure } from '../types';
 
 export function* messageListener() {
   const postMessageEventChannel = eventChannel(emitter => {
@@ -38,13 +39,18 @@ export function* messageListener() {
         yield put(actions.channel.opponentCommitmentReceived(action.commitment, action.signature));
         break;
       case incoming.RECEIVE_MESSAGE:
-        const { data, channelId, process } = action as incoming.ReceiveMessage;
+        const {
+          data,
+          channelId,
+          procedure: incomingProcedure,
+        } = (action as incoming.ReceiveMessage).message;
+        const procedure = convertToWalletProcedure(incomingProcedure);
         if ('commitment' in data) {
           yield put(
-            actions.commitmentReceived(channelId, process, data.commitment, data.signature),
+            actions.commitmentReceived(channelId, procedure, data.commitment, data.signature),
           );
         } else {
-          yield put(actions.messageReceived(channelId, process, data));
+          yield put(actions.messageReceived(channelId, procedure, data));
         }
         break;
       case incoming.RESPOND_TO_CHALLENGE:
@@ -57,3 +63,13 @@ export function* messageListener() {
     }
   }
 }
+
+const convertToWalletProcedure = (procedure: string) => {
+  if (procedure === WalletProcedure.DirectFunding) {
+    return WalletProcedure.DirectFunding;
+  } else if (procedure === WalletProcedure.IndirectFunding) {
+    return WalletProcedure.IndirectFunding;
+  } else {
+    throw new Error(`Could not convert ${procedure} to a valid wallet procedure`);
+  }
+};

--- a/packages/wallet/src/redux/sagas/message-listener.ts
+++ b/packages/wallet/src/redux/sagas/message-listener.ts
@@ -43,7 +43,7 @@ export function* messageListener() {
           data,
           channelId,
           procedure: incomingProcedure,
-        } = (action as incoming.ReceiveMessage).message;
+        } = (action as incoming.ReceiveMessage).messagePayload;
         const procedure = convertToWalletProcedure(incomingProcedure);
         if ('commitment' in data) {
           yield put(

--- a/packages/wallet/src/redux/sagas/message-listener.ts
+++ b/packages/wallet/src/redux/sagas/message-listener.ts
@@ -38,10 +38,12 @@ export function* messageListener() {
         yield put(actions.channel.opponentCommitmentReceived(action.commitment, action.signature));
         break;
       case incoming.RECEIVE_MESSAGE:
-        yield put(actions.channel.messageReceived(action.data));
-        break;
-      case incoming.RECEIVE_COMMITMENT:
-        yield put(actions.channel.commitmentReceived(action.commitment, action.signature));
+        const { data, channelId } = action;
+        if ('commitment' in data) {
+          yield put(actions.commitmentReceived(channelId, data.commitment, data.signature));
+        } else {
+          yield put(actions.messageReceived(channelId, data));
+        }
         break;
       case incoming.RESPOND_TO_CHALLENGE:
         yield put(actions.channel.challengeCommitmentReceived(action.commitment));


### PR DESCRIPTION
This is based on Andrew's work in  #272  and my transaction  work in #270 .
- There is no longer separate methods for communicating commitments and messages to a wallet. There is only `relayWalletMessage` and `messageReceived`.
- Wallet messages now include `channelId` and `procedure`.
- Wallet messages are encapsulated in a `WalletMessage` object so the application can blindly relay the message without knowing the contents.
- `RPS` has been updated to the latest wallet messaging changes.
