### PR TITLE
channelState funding reducer for both ledger and application channels 

### DIFF
--- a/packages/wallet/src/__stories__/index.tsx
+++ b/packages/wallet/src/__stories__/index.tsx
@@ -89,7 +89,9 @@ const initializedWalletState = walletStates.initialized({
   unhandledAction: undefined,
   outboxState: EMPTY_OUTBOX_STATE,
   channelState: {
-    initializedChannels: { [channelId]: channelStates.approveFunding({ ...playerADefaults }) },
+    initializedChannels: {
+      [channelId]: channelStates.waitForFundingRequest({ ...playerADefaults }),
+    },
     initializingChannels: {},
   },
   networkId: 4,
@@ -164,7 +166,6 @@ function addStoriesFromCollection(collection, chapter, renderer = channelStateRe
 }
 
 const WalletScreensFundingPlayerA = {
-  ApproveFunding: { channelState: channelStates.approveFunding(playerADefaults) },
   WaitForTransactionSent: {
     channelState: channelStates.waitForFundingAndPostFundSetup(playerADefaults),
     fundingState: fundingStates.depositing.waitForTransactionSent(defaultFundingState),
@@ -188,9 +189,6 @@ const WalletScreensFundingPlayerA = {
     fundingState: fundingStates.waitForFundingConfirmed(defaultFundingState),
   },
   WaitForPostFundSetup: { channelState: channelStates.aWaitForPostFundSetup(playerADefaults) },
-  AcknowledgeFundingSuccess: {
-    channelState: channelStates.acknowledgeFundingSuccess(playerADefaults),
-  },
 };
 addStoriesFromCollection(
   WalletScreensFundingPlayerA,
@@ -199,7 +197,6 @@ addStoriesFromCollection(
 );
 
 const WalletScreensFundingPlayerB = {
-  ApproveFunding: { channelState: channelStates.approveFunding(playerBDefaults) },
   NotSafeToDeposit: {
     channelState: channelStates.waitForFundingAndPostFundSetup(playerBDefaults),
     fundingState: fundingStates.notSafeToDeposit(defaultFundingState),
@@ -221,9 +218,6 @@ const WalletScreensFundingPlayerB = {
     fundingState: fundingStates.waitForFundingConfirmed(defaultFundingState),
   },
   WaitForPostFundSetup: { channelState: channelStates.aWaitForPostFundSetup(playerBDefaults) },
-  AcknowledgeFundingSuccess: {
-    channelState: channelStates.acknowledgeFundingSuccess(playerBDefaults),
-  },
 };
 addStoriesFromCollection(
   WalletScreensFundingPlayerB,
@@ -233,7 +227,6 @@ addStoriesFromCollection(
 
 // Against bot, who sends funding too early:
 const WalletScreensFundingPlayerAPart2 = {
-  ApproveFunding: { channelState: channelStates.approveFunding(playerADefaults) },
   WaitForTransactionSent: {
     channelState: channelStates.waitForFundingConfirmation(playerADefaults),
     fundingState: fundingStates.depositing.waitForTransactionSent(defaultFundingState),
@@ -255,9 +248,6 @@ const WalletScreensFundingPlayerAPart2 = {
       ...playerADefaults,
     }),
     fundingState: fundingStates.waitForFundingConfirmed(defaultFundingState),
-  },
-  AcknowledgeFundingSuccess: {
-    channelState: channelStates.acknowledgeFundingSuccess(playerADefaults),
   },
 };
 addStoriesFromCollection(

--- a/packages/wallet/src/containers/Funding.tsx
+++ b/packages/wallet/src/containers/Funding.tsx
@@ -1,16 +1,12 @@
 import React from 'react';
 import { PureComponent } from 'react';
 import { connect } from 'react-redux';
-import { Button } from 'reactstrap';
 
 import * as channelStates from '../redux/channelState/state';
 import * as actions from '../redux/actions';
 
-import AcknowledgeX from '../components/AcknowledgeX';
 import { unreachable } from '../utils/reducer-utils';
-import ApproveFunding from '../components/funding/ApproveFunding';
 import DirectFunding from './DirectFunding';
-import { addHex } from '../utils/hex-utils';
 import { FundingStep, Step } from '../components/funding/FundingStep';
 import { WalletProcedure } from '../redux/types';
 
@@ -25,47 +21,17 @@ interface Props {
 
 class FundingContainer extends PureComponent<Props> {
   render() {
-    const {
-      state,
-      fundingApproved,
-      fundingRejected,
-      fundingSuccessAcknowledged,
-      fundingDeclinedAcknowledged,
-    } = this.props;
+    const { state } = this.props;
 
     switch (state.type) {
       case channelStates.WAIT_FOR_FUNDING_REQUEST:
         return null;
-      case channelStates.WAIT_FOR_FUNDING_APPROVAL:
-        return (
-          <ApproveFunding
-            fundingApproved={fundingApproved}
-            fundingRejected={fundingRejected}
-            requestedTotalFunds={state.lastCommitment.commitment.allocation.reduce(addHex)}
-            requestedYourContribution={state.lastCommitment.commitment.allocation[state.ourIndex]}
-          />
-        );
       case channelStates.WAIT_FOR_FUNDING_AND_POST_FUND_SETUP:
       case channelStates.WAIT_FOR_FUNDING_CONFIRMATION:
         return <DirectFunding channelId={state.channelId} />;
       case channelStates.A_WAIT_FOR_POST_FUND_SETUP:
       case channelStates.B_WAIT_FOR_POST_FUND_SETUP:
         return <FundingStep step={Step.CHANNEL_FUNDED}>Waiting for the other player</FundingStep>;
-      case channelStates.ACKNOWLEDGE_FUNDING_SUCCESS:
-        return (
-          <FundingStep step={Step.CHANNEL_FUNDED}>
-            <Button onClick={fundingSuccessAcknowledged}>{'Return to game'}</Button>
-          </FundingStep>
-        );
-      case channelStates.ACKNOWLEDGE_FUNDING_DECLINED:
-        return (
-          <AcknowledgeX
-            title="Funding declined!"
-            action={fundingDeclinedAcknowledged}
-            description="Your opponent has declined to fund the game."
-            actionTitle="Return to game"
-          />
-        );
       default:
         return unreachable(state);
     }

--- a/packages/wallet/src/redux/channelState/funding/__tests__/funding.test.ts
+++ b/packages/wallet/src/redux/channelState/funding/__tests__/funding.test.ts
@@ -233,10 +233,7 @@ describe('start in BWaitForPostFundSetup', () => {
     const updatedState = fundingReducer(state, action);
 
     itTransitionsToChannelStateType(states.WAIT_FOR_UPDATE, updatedState);
-    itSendsThisMessage(updatedState, [
-      outgoing.COMMITMENT_RELAY_REQUESTED,
-      outgoing.FUNDING_SUCCESS,
-    ]);
+    itSendsThisMessage(updatedState, [outgoing.MESSAGE_RELAY_REQUESTED, outgoing.FUNDING_SUCCESS]);
     itIncreasesTurnNumBy(2, state, updatedState);
   });
 });

--- a/packages/wallet/src/redux/channelState/funding/__tests__/funding.test.ts
+++ b/packages/wallet/src/redux/channelState/funding/__tests__/funding.test.ts
@@ -66,13 +66,6 @@ const justReceivedPostFundSetupA = {
   funded: true,
 };
 
-const justReceivedPostFundSetupB = {
-  penultimateCommitment: { commitment: postFundCommitment1, signature: MOCK_SIGNATURE },
-  lastCommitment: { commitment: postFundCommitment2, signature: MOCK_SIGNATURE },
-  turnNum: 3,
-  funded: true,
-};
-
 const playerDefaults = {
   A: defaultsA,
   B: defaultsB,
@@ -89,7 +82,7 @@ describe('start in WaitForFundingRequest', () => {
     const action = actions.channel.fundingRequested();
     const updatedState = fundingReducer(state, action);
 
-    itTransitionsToChannelStateType(states.WAIT_FOR_FUNDING_APPROVAL, updatedState);
+    itTransitionsToChannelStateType(states.WAIT_FOR_FUNDING_AND_POST_FUND_SETUP, updatedState);
     itIncreasesTurnNumBy(0, state, updatedState);
   });
 
@@ -101,52 +94,6 @@ describe('start in WaitForFundingRequest', () => {
     };
     const state = states.waitForFundingRequest(testDefaults);
     const action = actions.channel.fundingRequested();
-    const updatedState = fundingReducer(state, action);
-
-    itTransitionsToChannelStateType(states.WAIT_FOR_FUNDING_APPROVAL, updatedState);
-    itIncreasesTurnNumBy(0, state, updatedState);
-  });
-});
-
-describe('start in WaitForFundingApproval', () => {
-  describe('incoming action: funding approved', () => {
-    // player A scenario
-    const testDefaults = { ...defaultsA, ...justReceivedPreFundSetupB };
-    const state = states.approveFunding(testDefaults);
-    const action = actions.channel.fundingApproved();
-    const updatedState = fundingReducer(state, action);
-
-    itTransitionsToChannelStateType(states.WAIT_FOR_FUNDING_AND_POST_FUND_SETUP, updatedState);
-    itIncreasesTurnNumBy(0, state, updatedState);
-  });
-  describe('incoming action: funding rejected', () => {
-    const testDefaults = { ...defaultsA, ...justReceivedPreFundSetupB };
-    const state = states.approveFunding(testDefaults);
-    const action = actions.channel.fundingRejected();
-    const updatedState = fundingReducer(state, action);
-
-    itTransitionsToChannelStateType(states.WAIT_FOR_CHANNEL, updatedState);
-    itSendsThisMessage(updatedState, [outgoing.MESSAGE_RELAY_REQUESTED, outgoing.FUNDING_FAILURE]);
-  });
-
-  describe('incoming action: Funding declined message received', () => {
-    const testDefaults = { ...defaultsA, ...justReceivedPreFundSetupB };
-    const state = states.approveFunding(testDefaults);
-    const action = actions.messageReceived(
-      channelId,
-      WalletProcedure.DirectFunding,
-      'FundingDeclined',
-    );
-    const updatedState = fundingReducer(state, action);
-    itTransitionsToChannelStateType(states.ACKNOWLEDGE_FUNDING_DECLINED, updatedState);
-    itIncreasesTurnNumBy(0, state, updatedState);
-  });
-
-  describe('incoming action: funding approved', () => {
-    // player B scenario
-    const testDefaults = { ...defaultsB, ...justReceivedPreFundSetupB };
-    const state = states.approveFunding(testDefaults);
-    const action = actions.channel.fundingApproved();
     const updatedState = fundingReducer(state, action);
 
     itTransitionsToChannelStateType(states.WAIT_FOR_FUNDING_AND_POST_FUND_SETUP, updatedState);
@@ -163,22 +110,10 @@ describe('start in WaitForFundingAndPostFundSetup', () => {
     return states.waitForFundingAndPostFundSetup(params);
   }
 
-  describe('incoming action: Funding declined message received', () => {
+  describe('incoming action: INTERNAL.FUNDING_CONFIRMED', () => {
     const state = startingState('A');
-    const action = actions.messageReceived(
-      channelId,
-      WalletProcedure.DirectFunding,
-      'FundingDeclined',
-    );
-    const updatedState = fundingReducer(state, action);
 
-    itTransitionsToChannelStateType(states.ACKNOWLEDGE_FUNDING_DECLINED, updatedState);
-    itIncreasesTurnNumBy(0, state, updatedState);
-  });
-
-  describe('incoming action: INTERNAL.DIRECT_FUNDING_CONFIRMED', () => {
-    const state = startingState('A');
-    const action = actions.internal.directFundingConfirmed(channelId);
+    const action = actions.internal.fundingConfirmed(channelId);
     const updatedState = fundingReducer(state, action);
 
     itTransitionsToChannelStateType(states.A_WAIT_FOR_POST_FUND_SETUP, updatedState);
@@ -221,9 +156,9 @@ describe('start in WaitForFundingAndPostFundSetup', () => {
     itSendsNoMessage(updatedState);
   });
 
-  describe('incoming action: INTERNAL.DIRECT_FUNDING_CONFIRMED', () => {
+  describe('incoming action: INTERNAL.FUNDING_CONFIRMED', () => {
     const state = startingState('B');
-    const action = actions.internal.directFundingConfirmed(channelId);
+    const action = actions.internal.fundingConfirmed(channelId);
     const updatedState = fundingReducer(state, action);
 
     itTransitionsToChannelStateType(states.B_WAIT_FOR_POST_FUND_SETUP, updatedState);
@@ -232,14 +167,14 @@ describe('start in WaitForFundingAndPostFundSetup', () => {
 });
 
 describe('start in WaitForFundingConfirmation', () => {
-  describe('incoming action: INTERNAL.DIRECT_FUNDING_CONFIRMED', () => {
+  describe('incoming action: INTERNAL.FUNDING_CONFIRMED', () => {
     // As player B
     const validateMock = jest.fn().mockReturnValue(MOCK_SIGNATURE);
     Object.defineProperty(SigningUtil, 'signCommitment', { value: validateMock });
 
     const testData = { ...defaultsB, ...justReceivedPostFundSetupA };
     const state = states.waitForFundingConfirmation(testData);
-    const action = actions.internal.directFundingConfirmed(channelId);
+    const action = actions.internal.fundingConfirmed(channelId);
     const updatedState = fundingReducer(state, action);
 
     const sendCommitmentAction = outgoing.messageRelayRequested(
@@ -254,8 +189,8 @@ describe('start in WaitForFundingConfirmation', () => {
       },
     );
 
-    itTransitionsToChannelStateType(states.ACKNOWLEDGE_FUNDING_SUCCESS, updatedState);
-    itSendsThisMessage(updatedState, sendCommitmentAction);
+    itTransitionsToChannelStateType(states.WAIT_FOR_UPDATE, updatedState);
+    itSendsThisMessage(updatedState, [sendCommitmentAction, outgoing.FUNDING_SUCCESS]);
     itIncreasesTurnNumBy(1, state, updatedState);
   });
 });
@@ -276,8 +211,9 @@ describe('start in AWaitForPostFundSetup', () => {
     );
     const updatedState = fundingReducer(state, action);
 
-    itTransitionsToChannelStateType(states.ACKNOWLEDGE_FUNDING_SUCCESS, updatedState);
+    itTransitionsToChannelStateType(states.WAIT_FOR_UPDATE, updatedState);
     itIncreasesTurnNumBy(1, state, updatedState);
+    itSendsThisMessage(updatedState, outgoing.FUNDING_SUCCESS);
   });
 });
 
@@ -296,34 +232,11 @@ describe('start in BWaitForPostFundSetup', () => {
     );
     const updatedState = fundingReducer(state, action);
 
-    itTransitionsToChannelStateType(states.ACKNOWLEDGE_FUNDING_SUCCESS, updatedState);
-    itSendsThisMessage(updatedState, outgoing.MESSAGE_RELAY_REQUESTED);
+    itTransitionsToChannelStateType(states.WAIT_FOR_UPDATE, updatedState);
+    itSendsThisMessage(updatedState, [
+      outgoing.COMMITMENT_RELAY_REQUESTED,
+      outgoing.FUNDING_SUCCESS,
+    ]);
     itIncreasesTurnNumBy(2, state, updatedState);
-  });
-});
-
-describe('start in AcknowledgeFundingSuccess', () => {
-  describe('incoming action: FundingSuccessAcknowledged', () => {
-    // player A scenario
-    const testDefaults = { ...defaultsA, ...justReceivedPostFundSetupB };
-    const state = states.acknowledgeFundingSuccess(testDefaults);
-    const action = actions.channel.fundingSuccessAcknowledged();
-    const updatedState = fundingReducer(state, action);
-
-    itTransitionsToChannelStateType(states.WAIT_FOR_UPDATE, updatedState);
-    itSendsThisMessage(updatedState, outgoing.FUNDING_SUCCESS);
-    itIncreasesTurnNumBy(0, state, updatedState);
-  });
-
-  describe('incoming action: FundingSuccessAcknowledged', () => {
-    // player B scenario
-    const testDefaults = { ...defaultsB, ...justReceivedPostFundSetupB };
-    const state = states.acknowledgeFundingSuccess(testDefaults);
-    const action = actions.channel.fundingSuccessAcknowledged();
-    const updatedState = fundingReducer(state, action);
-
-    itTransitionsToChannelStateType(states.WAIT_FOR_UPDATE, updatedState);
-    itSendsThisMessage(updatedState, outgoing.FUNDING_SUCCESS);
-    itIncreasesTurnNumBy(0, state, updatedState);
   });
 });

--- a/packages/wallet/src/redux/channelState/funding/state.ts
+++ b/packages/wallet/src/redux/channelState/funding/state.ts
@@ -11,7 +11,6 @@ export const FUNDING = 'FUNDING';
 // STATE TYPES
 // Funding setup
 export const WAIT_FOR_FUNDING_REQUEST = 'CHANNEL.WAIT_FOR_FUNDING_REQUEST';
-export const WAIT_FOR_FUNDING_APPROVAL = 'CHANNEL.WAIT_FOR_FUNDING_APPROVAL';
 
 // Funding ongoing
 export const WAIT_FOR_FUNDING_AND_POST_FUND_SETUP = 'WAIT_FOR_FUNDING_AND_POST_FUND_SETUP';
@@ -19,17 +18,8 @@ export const WAIT_FOR_FUNDING_CONFIRMATION = 'WAIT_FOR_FUNDING_CONFIRMATION';
 export const A_WAIT_FOR_POST_FUND_SETUP = 'A_WAIT_FOR_POST_FUND_SETUP';
 export const B_WAIT_FOR_POST_FUND_SETUP = 'B_WAIT_FOR_POST_FUND_SETUP';
 
-// Possible end states
-export const ACKNOWLEDGE_FUNDING_SUCCESS = 'ACKNOWLEDGE_FUNDING_SUCCESS';
-export const ACKNOWLEDGE_FUNDING_DECLINED = 'ACKNOWLEDGE_FUNDING_DECLINED';
-
 export interface WaitForFundingRequest extends ChannelOpen {
   type: typeof WAIT_FOR_FUNDING_REQUEST;
-  stage: typeof FUNDING;
-}
-
-export interface WaitForFundingApproval extends ChannelOpen {
-  type: typeof WAIT_FOR_FUNDING_APPROVAL;
   stage: typeof FUNDING;
 }
 
@@ -53,27 +43,9 @@ export interface BWaitForPostFundSetup extends ChannelOpen {
   stage: typeof FUNDING;
 }
 
-export interface AcknowledgeFundingSuccess extends ChannelOpen {
-  type: typeof ACKNOWLEDGE_FUNDING_SUCCESS;
-  stage: typeof FUNDING;
-}
-
-export interface AcknowledgeFundingDeclined extends ChannelOpen {
-  type: typeof ACKNOWLEDGE_FUNDING_DECLINED;
-  stage: typeof FUNDING;
-}
-
 export function waitForFundingRequest<T extends ChannelOpen>(params: T): WaitForFundingRequest {
   return {
     type: WAIT_FOR_FUNDING_REQUEST,
-    stage: FUNDING,
-    ...channelOpen(params),
-  };
-}
-
-export function approveFunding<T extends ChannelOpen>(params: T): WaitForFundingApproval {
-  return {
-    type: WAIT_FOR_FUNDING_APPROVAL,
     stage: FUNDING,
     ...channelOpen(params),
   };
@@ -103,26 +75,11 @@ export function bWaitForPostFundSetup<T extends ChannelOpen>(params: T): BWaitFo
   return { type: B_WAIT_FOR_POST_FUND_SETUP, stage: FUNDING, ...channelOpen(params) };
 }
 
-export function acknowledgeFundingSuccess<T extends ChannelOpen>(
-  params: T,
-): AcknowledgeFundingSuccess {
-  return { type: ACKNOWLEDGE_FUNDING_SUCCESS, stage: FUNDING, ...channelOpen(params) };
-}
-
-export function acknowledgeFundingDeclined<T extends ChannelOpen>(
-  params: T,
-): AcknowledgeFundingDeclined {
-  return { type: ACKNOWLEDGE_FUNDING_DECLINED, stage: FUNDING, ...channelOpen(params) };
-}
-
 export type FundingState =
   | WaitForFundingRequest
-  | WaitForFundingApproval
   | WaitForFundingAndPostFundSetup
   | WaitForFundingConfirmation
   // ^^^ PlayerA should never let PlayerB get into this state, as it lets PlayerB move to the application phase
   // with no real value at stake, giving them a chance to take the real value that's backing PlayerA's stake.
   | AWaitForPostFundSetup
-  | BWaitForPostFundSetup
-  | AcknowledgeFundingSuccess // <-- at this point, a message might need to be sent
-  | AcknowledgeFundingDeclined;
+  | BWaitForPostFundSetup;

--- a/packages/wallet/src/redux/internal/actions.ts
+++ b/packages/wallet/src/redux/internal/actions.ts
@@ -17,15 +17,15 @@ export const directFundingRequested = (
 });
 export type DirectFundingRequested = ReturnType<typeof directFundingRequested>;
 
-export const DIRECT_FUNDING_CONFIRMED = 'WALLET.INTERNAL.CHANNEL.DIRECT_FUNDING_CONFIRMED';
-export const directFundingConfirmed = (channelId: string) => ({
-  type: DIRECT_FUNDING_CONFIRMED as typeof DIRECT_FUNDING_CONFIRMED,
+export const FUNDING_CONFIRMED = 'WALLET.INTERNAL.CHANNEL.FUNDING_CONFIRMED';
+export const fundingConfirmed = (channelId: string) => ({
+  type: FUNDING_CONFIRMED as typeof FUNDING_CONFIRMED,
   channelId,
 });
-export type DirectFundingConfirmed = ReturnType<typeof directFundingConfirmed>;
+export type fundingConfirmed = ReturnType<typeof fundingConfirmed>;
 
 export type InternalFundingAction = DirectFundingRequested;
-export type InternalChannelAction = DirectFundingConfirmed;
+export type InternalChannelAction = fundingConfirmed;
 
 export type InternalAction = InternalFundingAction | InternalChannelAction;
 

--- a/packages/wallet/src/redux/internal/actions.ts
+++ b/packages/wallet/src/redux/internal/actions.ts
@@ -22,10 +22,10 @@ export const fundingConfirmed = (channelId: string) => ({
   type: FUNDING_CONFIRMED as typeof FUNDING_CONFIRMED,
   channelId,
 });
-export type fundingConfirmed = ReturnType<typeof fundingConfirmed>;
+export type FundingConfirmed = ReturnType<typeof fundingConfirmed>;
 
 export type InternalFundingAction = DirectFundingRequested;
-export type InternalChannelAction = fundingConfirmed;
+export type InternalChannelAction = FundingConfirmed;
 
 export type InternalAction = InternalFundingAction | InternalChannelAction;
 


### PR DESCRIPTION
The vision is that `channelState` funding reducer is shared between application and ledger channels. At the moment, wallet display logic is part of the `FUNDING` stage. The proposal is that the `FUNDING` stage will no longer be responsible for display logic. The funding `procedure` (direct or indirect) will decide when user approval or action is needed **before** the funding stage is entered. Also, currently, user action is requested for acknowledgment of funding success or failure. Once again, the funding `procedure` will handle this.

At the moment, `DIRECT_FUNDING_CONFIRMED` action is part of the `FUNDING` stage reducer. The `FUNDING` stage will be agnostic of the type of funding that funds a channel.