### PR TITLE
channelState reducer: removing wait for funding request

### DIFF
--- a/packages/wallet/src/__stories__/index.tsx
+++ b/packages/wallet/src/__stories__/index.tsx
@@ -90,7 +90,7 @@ const initializedWalletState = walletStates.initialized({
   outboxState: EMPTY_OUTBOX_STATE,
   channelState: {
     initializedChannels: {
-      [channelId]: channelStates.waitForFundingRequest({ ...playerADefaults }),
+      [channelId]: channelStates.waitForFundingAndPostFundSetup({ ...playerADefaults }),
     },
     initializingChannels: {},
   },

--- a/packages/wallet/src/containers/Funding.tsx
+++ b/packages/wallet/src/containers/Funding.tsx
@@ -24,8 +24,6 @@ class FundingContainer extends PureComponent<Props> {
     const { state } = this.props;
 
     switch (state.type) {
-      case channelStates.WAIT_FOR_FUNDING_REQUEST:
-        return null;
       case channelStates.WAIT_FOR_FUNDING_AND_POST_FUND_SETUP:
       case channelStates.WAIT_FOR_FUNDING_CONFIRMATION:
         return <DirectFunding channelId={state.channelId} />;

--- a/packages/wallet/src/redux/channel-state/funding/__tests__/funding.test.ts
+++ b/packages/wallet/src/redux/channel-state/funding/__tests__/funding.test.ts
@@ -71,36 +71,6 @@ const playerDefaults = {
   B: defaultsB,
 };
 
-describe('start in WaitForFundingRequest', () => {
-  describe('action taken: funding requested', () => {
-    // player A scenario
-    const testDefaults = {
-      ...defaultsA,
-      ...justReceivedPreFundSetupB,
-    };
-    const state = states.waitForFundingRequest(testDefaults);
-    const action = actions.channel.fundingRequested();
-    const updatedState = fundingReducer(state, action);
-
-    itTransitionsToChannelStateType(states.WAIT_FOR_FUNDING_AND_POST_FUND_SETUP, updatedState);
-    itIncreasesTurnNumBy(0, state, updatedState);
-  });
-
-  describe('action taken: funding requested', () => {
-    // player B scenario
-    const testDefaults = {
-      ...defaultsB,
-      ...justReceivedPreFundSetupB,
-    };
-    const state = states.waitForFundingRequest(testDefaults);
-    const action = actions.channel.fundingRequested();
-    const updatedState = fundingReducer(state, action);
-
-    itTransitionsToChannelStateType(states.WAIT_FOR_FUNDING_AND_POST_FUND_SETUP, updatedState);
-    itIncreasesTurnNumBy(0, state, updatedState);
-  });
-});
-
 describe('start in WaitForFundingAndPostFundSetup', () => {
   function startingState(player: 'A' | 'B') {
     const params = {

--- a/packages/wallet/src/redux/channel-state/funding/reducer.ts
+++ b/packages/wallet/src/redux/channel-state/funding/reducer.ts
@@ -28,10 +28,6 @@ export const fundingReducer = (
   }
 
   switch (state.type) {
-    // Setup funding process
-    case states.WAIT_FOR_FUNDING_REQUEST:
-      return waitForFundingRequestReducer(state, action);
-
     // Funding is ongoing
     case states.WAIT_FOR_FUNDING_AND_POST_FUND_SETUP:
       return waitForFundingAndPostFundSetupReducer(state, action);
@@ -45,20 +41,6 @@ export const fundingReducer = (
     //
     default:
       return unreachable(state);
-  }
-};
-
-const waitForFundingRequestReducer = (
-  state: states.WaitForFundingRequest,
-  action: actions.ChannelAction | internal.InternalAction,
-): StateWithSideEffects<states.OpenedState> => {
-  switch (action.type) {
-    case actions.FUNDING_REQUESTED:
-      return {
-        state: states.waitForFundingAndPostFundSetup({ ...state }),
-      };
-    default:
-      return { state };
   }
 };
 

--- a/packages/wallet/src/redux/channel-state/funding/state.ts
+++ b/packages/wallet/src/redux/channel-state/funding/state.ts
@@ -9,19 +9,10 @@ import { channelOpen, ChannelOpen } from '../shared/state';
 export const FUNDING = 'FUNDING';
 
 // STATE TYPES
-// Funding setup
-export const WAIT_FOR_FUNDING_REQUEST = 'CHANNEL.WAIT_FOR_FUNDING_REQUEST';
-
-// Funding ongoing
 export const WAIT_FOR_FUNDING_AND_POST_FUND_SETUP = 'WAIT_FOR_FUNDING_AND_POST_FUND_SETUP';
 export const WAIT_FOR_FUNDING_CONFIRMATION = 'WAIT_FOR_FUNDING_CONFIRMATION';
 export const A_WAIT_FOR_POST_FUND_SETUP = 'A_WAIT_FOR_POST_FUND_SETUP';
 export const B_WAIT_FOR_POST_FUND_SETUP = 'B_WAIT_FOR_POST_FUND_SETUP';
-
-export interface WaitForFundingRequest extends ChannelOpen {
-  type: typeof WAIT_FOR_FUNDING_REQUEST;
-  stage: typeof FUNDING;
-}
 
 export interface WaitForFundingAndPostFundSetup extends ChannelOpen {
   type: typeof WAIT_FOR_FUNDING_AND_POST_FUND_SETUP;
@@ -41,14 +32,6 @@ export interface AWaitForPostFundSetup extends ChannelOpen {
 export interface BWaitForPostFundSetup extends ChannelOpen {
   type: typeof B_WAIT_FOR_POST_FUND_SETUP;
   stage: typeof FUNDING;
-}
-
-export function waitForFundingRequest<T extends ChannelOpen>(params: T): WaitForFundingRequest {
-  return {
-    type: WAIT_FOR_FUNDING_REQUEST,
-    stage: FUNDING,
-    ...channelOpen(params),
-  };
 }
 
 export function waitForFundingAndPostFundSetup<T extends ChannelOpen>(
@@ -76,7 +59,6 @@ export function bWaitForPostFundSetup<T extends ChannelOpen>(params: T): BWaitFo
 }
 
 export type FundingState =
-  | WaitForFundingRequest
   | WaitForFundingAndPostFundSetup
   | WaitForFundingConfirmation
   // ^^^ PlayerA should never let PlayerB get into this state, as it lets PlayerB move to the application phase

--- a/packages/wallet/src/redux/channel-state/opening/__tests__/opening.test.ts
+++ b/packages/wallet/src/redux/channel-state/opening/__tests__/opening.test.ts
@@ -104,7 +104,7 @@ describe('when in WaitForPreFundSetup', () => {
     const action = actions.channel.ownCommitmentReceived(preFundCommitment2);
     const updatedState = openingReducer(state, action);
 
-    itTransitionsToChannelStateType(states.WAIT_FOR_FUNDING_REQUEST, updatedState);
+    itTransitionsToChannelStateType(states.WAIT_FOR_FUNDING_AND_POST_FUND_SETUP, updatedState);
   });
 
   describe('when an opponent sends a PreFundSetupB', () => {
@@ -116,7 +116,7 @@ describe('when in WaitForPreFundSetup', () => {
     const action = actions.channel.opponentCommitmentReceived(preFundCommitment2, 'sig');
     const updatedState = openingReducer(state, action);
 
-    itTransitionsToChannelStateType(states.WAIT_FOR_FUNDING_REQUEST, updatedState);
+    itTransitionsToChannelStateType(states.WAIT_FOR_FUNDING_AND_POST_FUND_SETUP, updatedState);
   });
 
   describe('when an opponent sends a PreFundSetupB but the signature is bad', () => {

--- a/packages/wallet/src/redux/channel-state/opening/reducer.ts
+++ b/packages/wallet/src/redux/channel-state/opening/reducer.ts
@@ -151,7 +151,7 @@ const waitForPreFundSetupReducer = (
   state: channelStates.WaitForPreFundSetup,
   action: actions.WalletAction,
 ): StateWithSideEffects<
-  channelStates.WaitForPreFundSetup | channelStates.WaitForFundingRequest
+  channelStates.WaitForPreFundSetup | channelStates.WaitForFundingAndPostFundSetup
 > => {
   switch (action.type) {
     case actions.channel.OWN_COMMITMENT_RECEIVED:
@@ -179,7 +179,7 @@ const waitForPreFundSetupReducer = (
 
       // if so, unpack its contents into the state
       return {
-        state: channelStates.waitForFundingRequest({
+        state: channelStates.waitForFundingAndPostFundSetup({
           ...state,
           turnNum: 1,
           lastCommitment: { commitment: ownCommitment, signature },
@@ -221,7 +221,7 @@ const waitForPreFundSetupReducer = (
 
       // if so, unpack its contents into the state
       return {
-        state: channelStates.waitForFundingRequest({
+        state: channelStates.waitForFundingAndPostFundSetup({
           ...state,
           turnNum: 1,
           lastCommitment: { commitment: action.commitment, signature: action.signature },


### PR DESCRIPTION
The `channelState` reducer now transitions from the opening stage directly to the `WAIT_FOR_FUNDING_AND_POST_FUND_SETUP` state. This is further fallout from the idea that `channelState` tracks only the state of a channel and nothing related to user approvals/acknowledgements or wallet display. 