### PR TITLE
Transition to Finalized instead of WaitForChannel

### DIFF
--- a/packages/wallet/src/containers/closing.tsx
+++ b/packages/wallet/src/containers/closing.tsx
@@ -17,6 +17,7 @@ import SelectAddress from '../components/withdrawing/select-address';
 import { ClosingStep } from '../components/closing/closing-step';
 import EtherscanLink from '../components/etherscan-link';
 import { WalletProcedure } from '../redux/types';
+import Todo from '../components/todo';
 
 interface Props {
   state: states.ClosingState;
@@ -122,6 +123,8 @@ class ClosingContainer extends PureComponent<Props> {
             retryAction={() => retryTransaction(state.channelId, WalletProcedure.Closing)}
           />
         );
+      case states.FINALIZED:
+        return <Todo stateType={state.type} />;
       default:
         return unreachable(state);
     }

--- a/packages/wallet/src/redux/channel-state/closing/__tests__/closing.test.ts
+++ b/packages/wallet/src/redux/channel-state/closing/__tests__/closing.test.ts
@@ -232,7 +232,7 @@ describe('start in AcknowledgCloseSuccess', () => {
 
     const action = actions.channel.closeSuccessAcknowledged();
     const updatedState = closingReducer(state, action);
-    itTransitionsToChannelStateType(states.WAIT_FOR_CHANNEL, updatedState);
+    itTransitionsToChannelStateType(states.FINALIZED, updatedState);
     itSendsThisMessage(updatedState, outgoing.CLOSE_SUCCESS);
   });
 });

--- a/packages/wallet/src/redux/channel-state/closing/reducer.ts
+++ b/packages/wallet/src/redux/channel-state/closing/reducer.ts
@@ -49,6 +49,8 @@ export const closingReducer = (
       return acknowledgeConcludeReducer(state, action);
     case channelStates.CLOSE_TRANSACTION_FAILED:
       return closeTransactionFailedReducer(state, action);
+    case channelStates.FINALIZED:
+      return { state };
     default:
       return unreachable(state);
   }

--- a/packages/wallet/src/redux/channel-state/closing/reducer.ts
+++ b/packages/wallet/src/redux/channel-state/closing/reducer.ts
@@ -334,7 +334,7 @@ const acknowledgeCloseSuccessReducer = (
   switch (action.type) {
     case actions.channel.CLOSE_SUCCESS_ACKNOWLEDGED:
       return {
-        state: channelStates.waitForChannel({
+        state: channelStates.finalized({
           ...state,
         }),
         sideEffects: { messageOutbox: closeSuccess(), displayOutbox: hideWallet() },
@@ -351,7 +351,7 @@ const acknowledgeClosedOnChainReducer = (
   switch (action.type) {
     case actions.channel.CLOSED_ON_CHAIN_ACKNOWLEDGED:
       return {
-        state: channelStates.waitForChannel({ ...state }),
+        state: channelStates.finalized({ ...state }),
         sideEffects: { messageOutbox: closeSuccess() },
       };
     default:

--- a/packages/wallet/src/redux/channel-state/closing/state.ts
+++ b/packages/wallet/src/redux/channel-state/closing/state.ts
@@ -1,5 +1,5 @@
 import { ChannelOpen, channelOpen, UserAddressExists, userAddressExists } from '../shared/state';
-import { TransactionExists, Properties } from '../../utils';
+import { TransactionExists, Properties as Props } from '../../utils';
 
 // stage
 export const CLOSING = 'CLOSING';
@@ -77,42 +77,44 @@ export interface Finalized extends ChannelOpen {
   stage: typeof CLOSING;
 }
 
-export function approveConclude<T extends ChannelOpen>(params: T): ApproveConclude {
+export function approveConclude(params: Props<ApproveConclude>): ApproveConclude {
   return { type: APPROVE_CONCLUDE, stage: CLOSING, ...channelOpen(params) };
 }
-export function approveCloseOnChain<T extends ChannelOpen>(params: T): ApproveCloseOnChain {
+export function approveCloseOnChain(params: Props<ApproveCloseOnChain>): ApproveCloseOnChain {
   return { type: APPROVE_CLOSE_ON_CHAIN, stage: CLOSING, ...channelOpen(params) };
 }
 
-export function waitForOpponentConclude<T extends ChannelOpen>(params: T): WaitForOpponentConclude {
+export function waitForOpponentConclude(
+  params: Props<WaitForOpponentConclude>,
+): WaitForOpponentConclude {
   return { type: WAIT_FOR_OPPONENT_CONCLUDE, stage: CLOSING, ...channelOpen(params) };
 }
 
-export function acknowledgeCloseSuccess<T extends ChannelOpen>(params: T): AcknowledgeCloseSuccess {
+export function acknowledgeCloseSuccess(
+  params: Props<AcknowledgeCloseSuccess>,
+): AcknowledgeCloseSuccess {
   return { type: ACKNOWLEDGE_CLOSE_SUCCESS, stage: CLOSING, ...channelOpen(params) };
 }
 
-export function acknowledgeClosedOnChain<T extends ChannelOpen>(
-  params: T,
+export function acknowledgeClosedOnChain(
+  params: Props<AcknowledgeClosedOnChain>,
 ): AcknowledgeClosedOnChain {
   return { type: ACKNOWLEDGE_CLOSED_ON_CHAIN, stage: CLOSING, ...channelOpen(params) };
 }
 
-export function waitForCloseInitiation<T extends UserAddressExists>(
-  params: T,
+export function waitForCloseInitiation(
+  params: Props<WaitForCloseInitiation>,
 ): WaitForCloseInitiation {
   return { type: WAIT_FOR_CLOSE_INITIATION, stage: CLOSING, ...userAddressExists(params) };
 }
 
-export function waitForCloseSubmission<T extends UserAddressExists>(
-  params: T,
+export function waitForCloseSubmission(
+  params: Props<WaitForCloseSubmission>,
 ): WaitForCloseSubmission {
   return { type: WAIT_FOR_CLOSE_SUBMISSION, stage: CLOSING, ...userAddressExists(params) };
 }
 
-export function waitForCloseConfirmed<T extends ChannelOpen & TransactionExists>(
-  params: T,
-): WaitForCloseConfirmed {
+export function waitForCloseConfirmed(params: Props<WaitForCloseConfirmed>): WaitForCloseConfirmed {
   return {
     type: WAIT_FOR_CLOSE_CONFIRMED,
     stage: CLOSING,
@@ -121,17 +123,17 @@ export function waitForCloseConfirmed<T extends ChannelOpen & TransactionExists>
   };
 }
 
-export function acknowledgeConclude<T extends ChannelOpen>(params: T): AcknowledgeConclude {
+export function acknowledgeConclude(params: Props<AcknowledgeConclude>): AcknowledgeConclude {
   return { type: ACKNOWLEDGE_CONCLUDE, stage: CLOSING, ...channelOpen(params) };
 }
 
-export function closeTransactionFailed<T extends UserAddressExists>(
-  params: T,
+export function closeTransactionFailed(
+  params: Props<CloseTransactionFailed>,
 ): CloseTransactionFailed {
   return { type: CLOSE_TRANSACTION_FAILED, stage: CLOSING, ...userAddressExists(params) };
 }
 
-export function finalized(params: Properties<Finalized>): Finalized {
+export function finalized(params: Props<Finalized>): Finalized {
   return { type: FINALIZED, stage: CLOSING, ...channelOpen(params) };
 }
 

--- a/packages/wallet/src/redux/channel-state/closing/state.ts
+++ b/packages/wallet/src/redux/channel-state/closing/state.ts
@@ -1,5 +1,5 @@
 import { ChannelOpen, channelOpen, UserAddressExists, userAddressExists } from '../shared/state';
-import { TransactionExists } from '../../utils';
+import { TransactionExists, Properties } from '../../utils';
 
 // stage
 export const CLOSING = 'CLOSING';
@@ -15,6 +15,8 @@ export const WAIT_FOR_CLOSE_SUBMISSION = 'WAIT_FOR_CLOSE_SUBMISSION';
 export const WAIT_FOR_CLOSE_CONFIRMED = 'WAIT_FOR_CLOSE_CONFIRMED';
 export const ACKNOWLEDGE_CONCLUDE = 'ACKNOWLEDGE_CONCLUDE';
 export const CLOSE_TRANSACTION_FAILED = 'CLOSE_TRANSACTION_FAILED';
+
+export const FINALIZED = 'FINALIZED'; // when the outcome has been finalized in the adjudicator
 
 export interface CloseTransactionFailed extends UserAddressExists {
   type: typeof CLOSE_TRANSACTION_FAILED;
@@ -67,6 +69,11 @@ export interface WaitForCloseInitiation extends UserAddressExists {
 
 export interface WaitForCloseSubmission extends UserAddressExists {
   type: typeof WAIT_FOR_CLOSE_SUBMISSION;
+  stage: typeof CLOSING;
+}
+
+export interface Finalized extends ChannelOpen {
+  type: typeof FINALIZED;
   stage: typeof CLOSING;
 }
 
@@ -124,6 +131,10 @@ export function closeTransactionFailed<T extends UserAddressExists>(
   return { type: CLOSE_TRANSACTION_FAILED, stage: CLOSING, ...userAddressExists(params) };
 }
 
+export function finalized(params: Properties<Finalized>): Finalized {
+  return { type: FINALIZED, stage: CLOSING, ...channelOpen(params) };
+}
+
 export type ClosingState =
   | ApproveConclude
   | WaitForOpponentConclude
@@ -134,4 +145,5 @@ export type ClosingState =
   | WaitForCloseSubmission
   | WaitForCloseConfirmed
   | AcknowledgeConclude
-  | CloseTransactionFailed;
+  | CloseTransactionFailed
+  | Finalized;

--- a/packages/wallet/src/redux/channel-state/withdrawing/__tests__/withdrawing.test.ts
+++ b/packages/wallet/src/redux/channel-state/withdrawing/__tests__/withdrawing.test.ts
@@ -122,6 +122,6 @@ describe('when in AcknowledgeWithdrawalSuccess', () => {
     const action = actions.channel.withdrawalSuccessAcknowledged();
     const updatedState = withdrawingReducer(state, action);
 
-    itTransitionsToChannelStateType(states.WAIT_FOR_CHANNEL, updatedState);
+    itTransitionsToChannelStateType(states.FINALIZED, updatedState);
   });
 });

--- a/packages/wallet/src/redux/channel-state/withdrawing/reducer.ts
+++ b/packages/wallet/src/redux/channel-state/withdrawing/reducer.ts
@@ -158,7 +158,7 @@ const acknowledgeWithdrawalSuccessReducer = (
     case actions.channel.WITHDRAWAL_SUCCESS_ACKNOWLEDGED:
       // TODO: We shouldn't be sending out a close success in the withdrawal reducer
       return {
-        state: states.waitForChannel({
+        state: states.finalized({
           ...state,
         }),
         sideEffects: { messageOutbox: closeSuccess(), displayOutbox: hideWallet() },


### PR DESCRIPTION
I am working to remove the `WaitForChannel` channel state, which we no-longer need now we have initializing channels. The `WaitForChannel` state is the only `ChannelStatus` without a channel id, which is a barrier when trying to write utilities that act on channels.