### PR TITLE
Deduce playerA from state type

### DIFF
--- a/packages/wallet/src/redux/indirect-funding/player-a/reducer.ts
+++ b/packages/wallet/src/redux/indirect-funding/player-a/reducer.ts
@@ -33,7 +33,7 @@ export function playerAReducer(
     return state;
   }
 
-  if (state.indirectFunding.player !== PlayerIndex.A) {
+  if (!states.isPlayerAState(state.indirectFunding)) {
     return state;
   }
 

--- a/packages/wallet/src/redux/indirect-funding/player-a/state.ts
+++ b/packages/wallet/src/redux/indirect-funding/player-a/state.ts
@@ -1,41 +1,36 @@
 import { Properties } from '../../utils';
-import { PlayerIndex } from '../../types';
+import { IndirectFundingState } from '../state';
 
-export const WAIT_FOR_APPROVAL = 'WAIT_FOR_APPROVAL';
+export const WAIT_FOR_APPROVAL = 'WAIT_FOR_APPROVAL_A';
 export const WAIT_FOR_PRE_FUND_SETUP_1 = 'WAIT_FOR_PRE_FUND_SETUP_1';
-export const WAIT_FOR_DIRECT_FUNDING = 'WAIT_FOR_DIRECT_FUNDING';
+export const WAIT_FOR_DIRECT_FUNDING = 'WAIT_FOR_DIRECT_FUNDING_A';
 export const WAIT_FOR_POST_FUND_SETUP_1 = 'WAIT_FOR_POST_FUND_SETUP_1';
 export const WAIT_FOR_LEDGER_UPDATE_1 = 'WAIT_FOR_LEDGER_UPDATE_1';
 
 export interface WaitForApproval {
   type: typeof WAIT_FOR_APPROVAL;
   channelId: string;
-  player: PlayerIndex.A;
 }
 
 export interface WaitForPreFundSetup1 {
   type: typeof WAIT_FOR_PRE_FUND_SETUP_1;
   channelId: string;
-  player: PlayerIndex.A;
   ledgerId: string;
 }
 
 export interface WaitForDirectFunding {
   type: typeof WAIT_FOR_DIRECT_FUNDING;
   channelId: string;
-  player: PlayerIndex.A;
   ledgerId: string;
 }
 export interface WaitForPostFundSetup1 {
   type: typeof WAIT_FOR_POST_FUND_SETUP_1;
   channelId: string;
-  player: PlayerIndex.A;
   ledgerId: string;
 }
 export interface WaitForLedgerUpdate1 {
   type: typeof WAIT_FOR_LEDGER_UPDATE_1;
   channelId: string;
-  player: PlayerIndex.A;
   ledgerId: string;
 }
 
@@ -49,33 +44,50 @@ export type PlayerAState =
 export function waitForApproval(params: Properties<WaitForApproval>): WaitForApproval {
   const { channelId } = params;
 
-  return { type: WAIT_FOR_APPROVAL, player: PlayerIndex.A, channelId };
+  return { type: WAIT_FOR_APPROVAL, channelId };
 }
 
 export function waitForPreFundSetup1(
   params: Properties<WaitForPreFundSetup1>,
 ): WaitForPreFundSetup1 {
   const { channelId, ledgerId } = params;
-  return { type: WAIT_FOR_PRE_FUND_SETUP_1, player: PlayerIndex.A, channelId, ledgerId };
+  return { type: WAIT_FOR_PRE_FUND_SETUP_1, channelId, ledgerId };
 }
 
 export function waitForDirectFunding(
   params: Properties<WaitForDirectFunding>,
 ): WaitForDirectFunding {
   const { channelId, ledgerId } = params;
-  return { type: WAIT_FOR_DIRECT_FUNDING, player: PlayerIndex.A, channelId, ledgerId };
+  return { type: WAIT_FOR_DIRECT_FUNDING, channelId, ledgerId };
 }
 
 export function waitForPostFundSetup1(
   params: Properties<WaitForPostFundSetup1>,
 ): WaitForPostFundSetup1 {
   const { channelId, ledgerId } = params;
-  return { type: WAIT_FOR_POST_FUND_SETUP_1, player: PlayerIndex.A, channelId, ledgerId };
+  return { type: WAIT_FOR_POST_FUND_SETUP_1, channelId, ledgerId };
 }
 
 export function waitForLedgerUpdate1(
   params: Properties<WaitForLedgerUpdate1>,
 ): WaitForLedgerUpdate1 {
   const { channelId, ledgerId } = params;
-  return { type: WAIT_FOR_LEDGER_UPDATE_1, player: PlayerIndex.A, channelId, ledgerId };
+  return { type: WAIT_FOR_LEDGER_UPDATE_1, channelId, ledgerId };
+}
+
+// -------
+// Helpers
+// -------
+
+export function isPlayerAState(state: IndirectFundingState): state is PlayerAState {
+  switch (state.type) {
+    case WAIT_FOR_APPROVAL:
+    case WAIT_FOR_LEDGER_UPDATE_1:
+    case WAIT_FOR_DIRECT_FUNDING:
+    case WAIT_FOR_POST_FUND_SETUP_1:
+    case WAIT_FOR_PRE_FUND_SETUP_1:
+      return true;
+    default:
+      return false;
+  }
 }

--- a/packages/wallet/src/redux/indirect-funding/player-a/state.ts
+++ b/packages/wallet/src/redux/indirect-funding/player-a/state.ts
@@ -7,31 +7,36 @@ export const WAIT_FOR_DIRECT_FUNDING = 'WAIT_FOR_DIRECT_FUNDING';
 export const WAIT_FOR_POST_FUND_SETUP_1 = 'WAIT_FOR_POST_FUND_SETUP_1';
 export const WAIT_FOR_LEDGER_UPDATE_1 = 'WAIT_FOR_LEDGER_UPDATE_1';
 
-interface BasePlayerAState {
+export interface WaitForApproval {
+  type: typeof WAIT_FOR_APPROVAL;
   channelId: string;
   player: PlayerIndex.A;
 }
 
-interface LedgerChannelExists extends BasePlayerAState {
+export interface WaitForPreFundSetup1 {
+  type: typeof WAIT_FOR_PRE_FUND_SETUP_1;
+  channelId: string;
+  player: PlayerIndex.A;
   ledgerId: string;
 }
 
-export interface WaitForApproval extends BasePlayerAState {
-  type: typeof WAIT_FOR_APPROVAL;
-}
-
-export interface WaitForPreFundSetup1 extends LedgerChannelExists {
-  type: typeof WAIT_FOR_PRE_FUND_SETUP_1;
-}
-
-export interface WaitForDirectFunding extends LedgerChannelExists {
+export interface WaitForDirectFunding {
   type: typeof WAIT_FOR_DIRECT_FUNDING;
+  channelId: string;
+  player: PlayerIndex.A;
+  ledgerId: string;
 }
-export interface WaitForPostFundSetup1 extends LedgerChannelExists {
+export interface WaitForPostFundSetup1 {
   type: typeof WAIT_FOR_POST_FUND_SETUP_1;
+  channelId: string;
+  player: PlayerIndex.A;
+  ledgerId: string;
 }
-export interface WaitForLedgerUpdate1 extends LedgerChannelExists {
+export interface WaitForLedgerUpdate1 {
   type: typeof WAIT_FOR_LEDGER_UPDATE_1;
+  channelId: string;
+  player: PlayerIndex.A;
+  ledgerId: string;
 }
 
 export type PlayerAState =

--- a/packages/wallet/src/redux/indirect-funding/player-b/state.ts
+++ b/packages/wallet/src/redux/indirect-funding/player-b/state.ts
@@ -1,37 +1,41 @@
 import { Properties } from '../../utils';
 import { PlayerIndex } from '../../types';
 
-export const WAIT_FOR_APPROVAL = 'WAIT_FOR_APPROVAL';
+export const WAIT_FOR_APPROVAL = 'WAIT_FOR_APPROVAL_B';
 export const WAIT_FOR_PRE_FUND_SETUP_0 = 'WAIT_FOR_PRE_FUND_SETUP_0';
-export const WAIT_FOR_DIRECT_FUNDING = 'WAIT_FOR_DIRECT_FUNDING';
+export const WAIT_FOR_DIRECT_FUNDING = 'WAIT_FOR_DIRECT_FUNDING_B';
 export const WAIT_FOR_POST_FUND_SETUP_0 = 'WAIT_FOR_POST_FUND_SETUP_0';
 export const WAIT_FOR_LEDGER_UPDATE_0 = 'WAIT_FOR_LEDGER_UPDATE_0';
 
-interface BasePlayerBState {
+export interface WaitForApproval {
+  type: typeof WAIT_FOR_APPROVAL;
   channelId: string;
   player: PlayerIndex.B;
 }
 
-interface LedgerChannelExists extends BasePlayerBState {
+export interface WaitForPreFundSetup0 {
+  type: typeof WAIT_FOR_PRE_FUND_SETUP_0;
+  channelId: string;
+  player: PlayerIndex.B;
+}
+
+export interface WaitForDirectFunding {
+  type: typeof WAIT_FOR_DIRECT_FUNDING;
+  channelId: string;
+  player: PlayerIndex.B;
   ledgerId: string;
 }
-
-export interface WaitForApproval extends BasePlayerBState {
-  type: typeof WAIT_FOR_APPROVAL;
-}
-
-export interface WaitForPreFundSetup0 extends BasePlayerBState {
-  type: typeof WAIT_FOR_PRE_FUND_SETUP_0;
-}
-
-export interface WaitForDirectFunding extends LedgerChannelExists {
-  type: typeof WAIT_FOR_DIRECT_FUNDING;
-}
-export interface WaitForPostFundSetup0 extends LedgerChannelExists {
+export interface WaitForPostFundSetup0 {
   type: typeof WAIT_FOR_POST_FUND_SETUP_0;
+  channelId: string;
+  player: PlayerIndex.B;
+  ledgerId: string;
 }
-export interface WaitForLedgerUpdate0 extends LedgerChannelExists {
+export interface WaitForLedgerUpdate0 {
   type: typeof WAIT_FOR_LEDGER_UPDATE_0;
+  channelId: string;
+  player: PlayerIndex.B;
+  ledgerId: string;
 }
 
 export type PlayerBState =

--- a/packages/wallet/src/redux/indirect-funding/player-b/state.ts
+++ b/packages/wallet/src/redux/indirect-funding/player-b/state.ts
@@ -1,5 +1,4 @@
 import { Properties } from '../../utils';
-import { PlayerIndex } from '../../types';
 
 export const WAIT_FOR_APPROVAL = 'WAIT_FOR_APPROVAL_B';
 export const WAIT_FOR_PRE_FUND_SETUP_0 = 'WAIT_FOR_PRE_FUND_SETUP_0';
@@ -10,31 +9,26 @@ export const WAIT_FOR_LEDGER_UPDATE_0 = 'WAIT_FOR_LEDGER_UPDATE_0';
 export interface WaitForApproval {
   type: typeof WAIT_FOR_APPROVAL;
   channelId: string;
-  player: PlayerIndex.B;
 }
 
 export interface WaitForPreFundSetup0 {
   type: typeof WAIT_FOR_PRE_FUND_SETUP_0;
   channelId: string;
-  player: PlayerIndex.B;
 }
 
 export interface WaitForDirectFunding {
   type: typeof WAIT_FOR_DIRECT_FUNDING;
   channelId: string;
-  player: PlayerIndex.B;
   ledgerId: string;
 }
 export interface WaitForPostFundSetup0 {
   type: typeof WAIT_FOR_POST_FUND_SETUP_0;
   channelId: string;
-  player: PlayerIndex.B;
   ledgerId: string;
 }
 export interface WaitForLedgerUpdate0 {
   type: typeof WAIT_FOR_LEDGER_UPDATE_0;
   channelId: string;
-  player: PlayerIndex.B;
   ledgerId: string;
 }
 
@@ -47,34 +41,33 @@ export type PlayerBState =
 
 export function waitForApproval(params: Properties<WaitForApproval>): WaitForApproval {
   const { channelId } = params;
-
-  return { type: WAIT_FOR_APPROVAL, player: PlayerIndex.B, channelId };
+  return { type: WAIT_FOR_APPROVAL, channelId };
 }
 
 export function waitForPreFundSetup0(
   params: Properties<WaitForPreFundSetup0>,
 ): WaitForPreFundSetup0 {
   const { channelId } = params;
-  return { type: WAIT_FOR_PRE_FUND_SETUP_0, player: PlayerIndex.B, channelId };
+  return { type: WAIT_FOR_PRE_FUND_SETUP_0, channelId };
 }
 
 export function waitForDirectFunding(
   params: Properties<WaitForDirectFunding>,
 ): WaitForDirectFunding {
   const { channelId, ledgerId } = params;
-  return { type: WAIT_FOR_DIRECT_FUNDING, player: PlayerIndex.B, channelId, ledgerId };
+  return { type: WAIT_FOR_DIRECT_FUNDING, channelId, ledgerId };
 }
 
 export function waitForPostFundSetup0(
   params: Properties<WaitForPostFundSetup0>,
 ): WaitForPostFundSetup0 {
   const { channelId, ledgerId } = params;
-  return { type: WAIT_FOR_POST_FUND_SETUP_0, player: PlayerIndex.B, channelId, ledgerId };
+  return { type: WAIT_FOR_POST_FUND_SETUP_0, channelId, ledgerId };
 }
 
 export function waitForLedgerUpdate0(
   params: Properties<WaitForLedgerUpdate0>,
 ): WaitForLedgerUpdate0 {
   const { channelId, ledgerId } = params;
-  return { type: WAIT_FOR_LEDGER_UPDATE_0, player: PlayerIndex.B, channelId, ledgerId };
+  return { type: WAIT_FOR_LEDGER_UPDATE_0, channelId, ledgerId };
 }

--- a/packages/wallet/src/redux/indirect-funding/reducer.ts
+++ b/packages/wallet/src/redux/indirect-funding/reducer.ts
@@ -17,14 +17,10 @@ export const indirectFundingReducer = (
     return state;
   }
 
-  switch (state.indirectFunding.player) {
-    case PlayerIndex.A:
-      return playerAReducer(state, action);
-    case PlayerIndex.B:
-      return playerBReducer(state, action);
-
-    default:
-      return unreachable(state.indirectFunding);
+  if (indirectFundingState.isPlayerAState(state.indirectFunding)) {
+    return playerAReducer(state, action);
+  } else {
+    return playerBReducer(state, action);
   }
 };
 

--- a/packages/wallet/src/redux/indirect-funding/state.ts
+++ b/packages/wallet/src/redux/indirect-funding/state.ts
@@ -4,3 +4,5 @@ import * as playerB from './player-b/state';
 export { playerA, playerB };
 
 export type IndirectFundingState = playerA.PlayerAState | playerB.PlayerBState;
+
+export const isPlayerAState = playerA.isPlayerAState;


### PR DESCRIPTION
This is an alternative to putting the `player` explicitly on the state. It means that the transitions become fully defined by the `type` alone instead of the `(player, type)` pair, which seems like a nice property. (The developer does have to be careful to avoid name collisions on types though, but that's already the case.)

Interested to hear thoughts on this.