### PR TITLE
Switch Message actions to use processId

### DIFF
--- a/packages/magmo-wallet-client/src/wallet-types.ts
+++ b/packages/magmo-wallet-client/src/wallet-types.ts
@@ -1,5 +1,5 @@
 export interface WalletMessagePayload {
-  channelId: string;
+  processId: string;
   procedure: string;
   data: any;
 }

--- a/packages/wallet/src/redux/actions.ts
+++ b/packages/wallet/src/redux/actions.ts
@@ -46,6 +46,7 @@ export const metamaskLoadError = () => ({
 export type MetamaskLoadError = ReturnType<typeof metamaskLoadError>;
 
 // Common Transaction Actions
+// TODO: These should be switched from channelId to processId
 // These actions are relevant to multiple branches of the wallet state tree
 export const TRANSACTION_SENT_TO_METAMASK = 'WALLET.COMMON.TRANSACTION_SENT_TO_METAMASK';
 export const transactionSentToMetamask = (channelId: string, procedure: WalletProcedure) => ({
@@ -112,9 +113,9 @@ export type RetryTransaction = ReturnType<typeof retryTransaction>;
 
 export type Message = 'FundingDeclined';
 export const MESSAGE_RECEIVED = 'WALLET.COMMON.MESSAGE_RECEIVED';
-export const messageReceived = (channelId: string, procedure: WalletProcedure, data: Message) => ({
+export const messageReceived = (processId: string, procedure: WalletProcedure, data: Message) => ({
   type: MESSAGE_RECEIVED as typeof MESSAGE_RECEIVED,
-  channelId,
+  processId,
   procedure,
   data,
 });
@@ -122,13 +123,13 @@ export type MessageReceived = ReturnType<typeof messageReceived>;
 
 export const COMMITMENT_RECEIVED = 'WALLET.COMMON.COMMITMENT_RECEIVED';
 export const commitmentReceived = (
-  channelId: string,
+  processId: string,
   procedure: WalletProcedure,
   commitment: Commitment,
   signature: string,
 ) => ({
   type: COMMITMENT_RECEIVED as typeof COMMITMENT_RECEIVED,
-  channelId,
+  processId,
   procedure,
   commitment,
   signature,

--- a/packages/wallet/src/redux/channel-state/closing/reducer.ts
+++ b/packages/wallet/src/redux/channel-state/closing/reducer.ts
@@ -369,7 +369,7 @@ const composeConcludePosition = (state: channelStates.ClosingState) => {
 
   const commitmentSignature = signCommitment(concludeCommitment, state.privateKey);
   const sendCommitmentAction = messageRelayRequested(state.participants[1 - state.ourIndex], {
-    channelId: state.channelId,
+    processId: state.channelId,
     procedure: WalletProcedure.DirectFunding,
     data: {
       concludeCommitment,

--- a/packages/wallet/src/redux/channel-state/funding/__tests__/funding.test.ts
+++ b/packages/wallet/src/redux/channel-state/funding/__tests__/funding.test.ts
@@ -150,7 +150,7 @@ describe('start in WaitForFundingConfirmation', () => {
     const sendCommitmentAction = outgoing.messageRelayRequested(
       state.participants[1 - state.ourIndex],
       {
-        channelId: state.channelId,
+        processId: state.channelId,
         procedure: WalletProcedure.DirectFunding,
         data: {
           commitment: postFundCommitment2,

--- a/packages/wallet/src/redux/channel-state/funding/reducer.ts
+++ b/packages/wallet/src/redux/channel-state/funding/reducer.ts
@@ -260,7 +260,7 @@ const composePostFundCommitment = (
   const commitmentSignature = signCommitment(postFundSetupCommitment, state.privateKey);
 
   const sendCommitmentAction = messageRelayRequested(state.participants[1 - state.ourIndex], {
-    channelId: state.channelId,
+    processId: state.channelId,
     procedure: WalletProcedure.DirectFunding,
     data: {
       commitment: postFundSetupCommitment,

--- a/packages/wallet/src/redux/indirect-funding/player-a/reducer.ts
+++ b/packages/wallet/src/redux/indirect-funding/player-a/reducer.ts
@@ -127,7 +127,11 @@ const waitForDirectFunding = (
   } else {
     let newState = updateDirectFundingStatus(state, action);
     if (directFundingIsComplete(newState, action.channelId)) {
-      newState = createAndSendPostFundCommitment(newState, action.channelId);
+      newState = createAndSendPostFundCommitment(
+        newState,
+        indirectFundingState.channelId,
+        indirectFundingState.ledgerId,
+      );
       newState.indirectFunding = states.waitForPostFundSetup1(indirectFundingState);
     }
     return newState;

--- a/packages/wallet/src/redux/indirect-funding/reducer-helpers.ts
+++ b/packages/wallet/src/redux/indirect-funding/reducer-helpers.ts
@@ -137,6 +137,7 @@ export const receiveOwnLedgerCommitment = (
 
 export const createAndSendPostFundCommitment = (
   state: walletStates.Initialized,
+  appChannelId: string,
   ledgerChannelId: string,
 ): walletStates.Initialized => {
   let newState = { ...state };
@@ -155,7 +156,7 @@ export const createAndSendPostFundCommitment = (
   newState.outboxState.messageOutbox = [
     createCommitmentMessageRelay(
       theirAddress,
-      ledgerChannelId,
+      appChannelId,
       postFundCommitment,
       commitmentSignature,
     ),
@@ -165,12 +166,12 @@ export const createAndSendPostFundCommitment = (
 
 export const createCommitmentMessageRelay = (
   to: string,
-  channelId: string,
+  processId: string,
   commitment: Commitment,
   signature: string,
 ) => {
   const payload = {
-    channelId,
+    processId,
     procedure: WalletProcedure.IndirectFunding,
     data: { commitment, signature },
   };

--- a/packages/wallet/src/redux/outbox/__tests__/reducer.test.ts
+++ b/packages/wallet/src/redux/outbox/__tests__/reducer.test.ts
@@ -10,12 +10,12 @@ const { channelId, mockTransactionOutboxItem } = scenarios;
 
 describe('when a side effect occured', () => {
   const sendFundingDeclinedActionA = outgoing.messageRelayRequested('0xa00', {
-    channelId: '0x0',
+    processId: '0x0',
     procedure: WalletProcedure.DirectFunding,
     data: 'FundingDeclined',
   });
   const sendFundingDeclinedActionB = outgoing.messageRelayRequested('0xb00', {
-    channelId: '0x0',
+    processId: '0x0',
     procedure: WalletProcedure.DirectFunding,
     data: 'FundingDeclined',
   });

--- a/packages/wallet/src/redux/sagas/message-listener.ts
+++ b/packages/wallet/src/redux/sagas/message-listener.ts
@@ -41,16 +41,16 @@ export function* messageListener() {
       case incoming.RECEIVE_MESSAGE:
         const {
           data,
-          channelId,
+          processId,
           procedure: incomingProcedure,
         } = (action as incoming.ReceiveMessage).messagePayload;
         const procedure = convertToWalletProcedure(incomingProcedure);
         if ('commitment' in data) {
           yield put(
-            actions.commitmentReceived(channelId, procedure, data.commitment, data.signature),
+            actions.commitmentReceived(processId, procedure, data.commitment, data.signature),
           );
         } else {
-          yield put(actions.messageReceived(channelId, procedure, data));
+          yield put(actions.messageReceived(processId, procedure, data));
         }
         break;
       case incoming.RESPOND_TO_CHALLENGE:


### PR DESCRIPTION
Switch `COMMITMENT_RECEIVED`/`MESSAGE_RECEIVED` to use `processId`.

This allows the `COMMITMENT_RECEIVED` action to be passed into the `channelStateReducer` and have it correctly deduce the channelId