### PR TITLE
Adjudicator Watcher now checks state for processes to alert

### DIFF
--- a/packages/wallet/src/__stories__/index.tsx
+++ b/packages/wallet/src/__stories__/index.tsx
@@ -74,6 +74,7 @@ const initializedWalletState = walletStates.initialized({
   adjudicator: '',
   uid: '',
   consensusLibrary: '0x0',
+  processStore: {},
 });
 
 // Want to return top level wallet state, not the channel state

--- a/packages/wallet/src/contract-tests/adjudicator-events.test.ts
+++ b/packages/wallet/src/contract-tests/adjudicator-events.test.ts
@@ -9,6 +9,7 @@ import {
   refuteChallenge,
   respondWithMove,
   getChannelId,
+  defaultDepositAmount,
 } from './test-utils';
 
 jest.setTimeout(60000);
@@ -21,6 +22,7 @@ describe('adjudicator listener', () => {
   const participantA = ethers.Wallet.createRandom();
   const participantB = ethers.Wallet.createRandom();
   let nonce = 5;
+  const processId = 'A process identifier';
   function getNextNonce() {
     return ++nonce;
   }
@@ -31,27 +33,59 @@ describe('adjudicator listener', () => {
     const channelId = await getChannelId(provider, getNextNonce(), participantA, participantB);
     await depositContract(provider, channelId);
   });
-  it('should handle a funds received event', async () => {
+
+  it('should not handle a event when no process has registered', async () => {
     const channelId = await getChannelId(provider, getNextNonce(), participantA, participantB);
-
     const sagaTester = new SagaTester({});
-    sagaTester.start(adjudicatorWatcher, channelId, provider);
-    await depositContract(provider, channelId);
-    await sagaTester.waitFor(actions.funding.FUNDING_RECEIVED_EVENT);
 
-    const action: actions.funding.FundingReceivedEvent = sagaTester.getLatestCalledAction();
-    expect(action.type).toEqual(actions.funding.FUNDING_RECEIVED_EVENT);
-    expect(action.channelId).toEqual(channelId);
-    expect(action.amount).toEqual('0x05');
-    expect(action.totalForDestination).toEqual('0x05');
+    sagaTester.start(adjudicatorWatcher, provider);
+    await depositContract(provider, channelId);
+
+    expect(sagaTester.numCalled(actions.FUNDING_RECEIVED_EVENT)).toEqual(0);
   });
 
-  it('should handle a challengeCreated event', async () => {
+  it('should not handle a event after a process unregisters', async () => {
+    const channelId = await getChannelId(provider, getNextNonce(), participantA, participantB);
+    const sagaTester = new SagaTester({});
+
+    sagaTester.start(adjudicatorWatcher, provider);
+    sagaTester.dispatch(actions.registerForAdjudicatorEvents(processId, channelId));
+    sagaTester.dispatch(actions.unregisterForAdjudicatorEvents(processId));
+
+    await depositContract(provider, channelId);
+
+    expect(sagaTester.numCalled(actions.FUNDING_RECEIVED_EVENT)).toEqual(0);
+  });
+
+  it('should handle a funds received event when registered for that channel', async () => {
+    const channelId = await getChannelId(provider, getNextNonce(), participantA, participantB);
+    const sagaTester = new SagaTester({});
+    sagaTester.start(adjudicatorWatcher, provider);
+    sagaTester.dispatch(actions.registerForAdjudicatorEvents(processId, channelId));
+
+    await depositContract(provider, channelId);
+    await sagaTester.waitFor(actions.FUNDING_RECEIVED_EVENT);
+
+    const action: actions.FundingReceivedEvent = sagaTester.getLatestCalledAction();
+    expect(action).toEqual(
+      actions.fundingReceivedEvent(
+        processId,
+        channelId,
+        defaultDepositAmount,
+        defaultDepositAmount,
+      ),
+    );
+  });
+
+  it('should handle a challengeCreated event when registered for that channel', async () => {
     const startTimestamp = Date.now();
     const channelNonce = getNextNonce();
     const channelId = await getChannelId(provider, channelNonce, participantA, participantB);
+
     const sagaTester = new SagaTester({});
-    sagaTester.start(adjudicatorWatcher, channelId, provider);
+    sagaTester.start(adjudicatorWatcher, provider);
+    sagaTester.dispatch(actions.registerForAdjudicatorEvents(processId, channelId));
+
     const challengeState = await createChallenge(
       provider,
 
@@ -59,63 +93,72 @@ describe('adjudicator listener', () => {
       participantA,
       participantB,
     );
-    await sagaTester.waitFor(actions.channel.CHALLENGE_CREATED_EVENT);
-    const action: actions.channel.ChallengeCreatedEvent = sagaTester.getLatestCalledAction();
 
+    await sagaTester.waitFor(actions.CHALLENGE_CREATED_EVENT);
+
+    const action: actions.ChallengeCreatedEvent = sagaTester.getLatestCalledAction();
     expect(action.finalizedAt * 1000).toBeGreaterThan(startTimestamp);
     expect(action.commitment).toEqual(challengeState);
   });
 
-  it('should handle a concluded event', async () => {
+  it('should handle a concluded event when registered for that channel', async () => {
     const channelNonce = getNextNonce();
     const channelId = await getChannelId(provider, channelNonce, participantA, participantB);
     const sagaTester = new SagaTester({});
-    sagaTester.start(adjudicatorWatcher, channelId, provider);
+
+    sagaTester.start(adjudicatorWatcher, provider);
+    sagaTester.dispatch(actions.registerForAdjudicatorEvents(processId, channelId));
+
     await concludeGame(provider, channelNonce, participantA, participantB);
-    await sagaTester.waitFor(actions.channel.CONCLUDED_EVENT);
-    const action: actions.channel.concludedEvent = sagaTester.getLatestCalledAction();
-    // TODO: We should check the channel ID
-    expect(action.channelId).toBeDefined();
+
+    await sagaTester.waitFor(actions.CONCLUDED_EVENT);
+    const action: actions.ConcludedEvent = sagaTester.getLatestCalledAction();
+
+    expect(action).toEqual(actions.concludedEvent(processId, channelId));
   });
 
-  it('should handle a refute event', async () => {
+  it('should handle a refute event when registered for that channel', async () => {
     const channelNonce = getNextNonce();
     const channelId = await getChannelId(provider, channelNonce, participantA, participantB);
     await createChallenge(provider, channelNonce, participantA, participantB);
 
     const sagaTester = new SagaTester({});
-    sagaTester.start(adjudicatorWatcher, channelId, provider);
+    sagaTester.start(adjudicatorWatcher, provider);
+    sagaTester.dispatch(actions.registerForAdjudicatorEvents(processId, channelId));
+
     const refuteCommitment = await refuteChallenge(
       provider,
-
       channelNonce,
       participantA,
       participantB,
     );
-    await sagaTester.waitFor(actions.channel.REFUTED_EVENT);
-    const action: actions.channel.RefutedEvent = sagaTester.getLatestCalledAction();
-    expect(action.type === actions.channel.REFUTED_EVENT);
-    expect(action.refuteCommitment).toEqual(refuteCommitment);
+
+    await sagaTester.waitFor(actions.REFUTED_EVENT);
+
+    const action: actions.RefutedEvent = sagaTester.getLatestCalledAction();
+    expect(action).toEqual(actions.refutedEvent(processId, channelId, refuteCommitment));
   });
 
-  it('should handle a respondWithMove event', async () => {
+  it('should handle a respondWithMove event when registered for that channel', async () => {
     const channelNonce = getNextNonce();
     const channelId = await getChannelId(provider, channelNonce, participantA, participantB);
 
     await createChallenge(provider, channelNonce, participantA, participantB);
 
     const sagaTester = new SagaTester({});
-    sagaTester.start(adjudicatorWatcher, channelId, provider);
-    const responseState = await respondWithMove(
-      provider,
+    sagaTester.start(adjudicatorWatcher, provider);
+    sagaTester.dispatch(actions.registerForAdjudicatorEvents(processId, channelId));
 
+    const responseCommitment = await respondWithMove(
+      provider,
       channelNonce,
       participantA,
       participantB,
     );
-    await sagaTester.waitFor(actions.channel.RESPOND_WITH_MOVE_EVENT);
-    const action: actions.channel.RespondWithMoveEvent = sagaTester.getLatestCalledAction();
-    expect(action.type === actions.channel.RESPOND_WITH_MOVE_EVENT);
-    expect(action.responseCommitment).toEqual(responseState);
+
+    await sagaTester.waitFor(actions.RESPOND_WITH_MOVE_EVENT);
+
+    const action: actions.RespondWithMoveEvent = sagaTester.getLatestCalledAction();
+    expect(action).toEqual(actions.respondWithMoveEvent(processId, channelId, responseCommitment));
   });
 });

--- a/packages/wallet/src/contract-tests/adjudicator-events.test.ts
+++ b/packages/wallet/src/contract-tests/adjudicator-events.test.ts
@@ -73,7 +73,7 @@ describe('adjudicator listener', () => {
     expect(sagaTester.numCalled(actions.FUNDING_RECEIVED_EVENT)).toEqual(0);
   });
 
-  it.only('should handle a funds received event when registered for that channel', async () => {
+  it('should handle a funds received event when registered for that channel', async () => {
     const channelId = await getChannelId(provider, getNextNonce(), participantA, participantB);
     const processId = ethers.Wallet.createRandom().address;
     const sagaTester = new SagaTester({

--- a/packages/wallet/src/contract-tests/adjudicator-events.test.ts
+++ b/packages/wallet/src/contract-tests/adjudicator-events.test.ts
@@ -58,6 +58,24 @@ describe('adjudicator listener', () => {
     expect(sagaTester.numCalled(actions.FUNDING_RECEIVED_EVENT)).toEqual(0);
   });
 
+  it('should ignore events for other channels', async () => {
+    const channelId = await getChannelId(provider, getNextNonce(), participantA, participantB);
+    const channelIdToIgnore = await getChannelId(
+      provider,
+      getNextNonce(),
+      participantA,
+      participantB,
+    );
+    const processId = ethers.Wallet.createRandom().address;
+    const sagaTester = new SagaTester({});
+
+    sagaTester.start(adjudicatorWatcher, provider);
+    sagaTester.dispatch(actions.registerForAdjudicatorEvents(processId, channelId));
+
+    await depositContract(provider, channelIdToIgnore);
+    expect(sagaTester.numCalled(actions.FUNDING_RECEIVED_EVENT)).toEqual(0);
+  });
+
   it('should handle a funds received event when registered for that channel', async () => {
     const channelId = await getChannelId(provider, getNextNonce(), participantA, participantB);
     const processId = ethers.Wallet.createRandom().address;

--- a/packages/wallet/src/contract-tests/adjudicator-events.test.ts
+++ b/packages/wallet/src/contract-tests/adjudicator-events.test.ts
@@ -22,7 +22,7 @@ describe('adjudicator listener', () => {
   const participantA = ethers.Wallet.createRandom();
   const participantB = ethers.Wallet.createRandom();
   let nonce = 5;
-  const processId = 'A process identifier';
+
   function getNextNonce() {
     return ++nonce;
   }
@@ -46,6 +46,7 @@ describe('adjudicator listener', () => {
 
   it('should not handle a event after a process unregisters', async () => {
     const channelId = await getChannelId(provider, getNextNonce(), participantA, participantB);
+    const processId = ethers.Wallet.createRandom().address;
     const sagaTester = new SagaTester({});
 
     sagaTester.start(adjudicatorWatcher, provider);
@@ -59,6 +60,7 @@ describe('adjudicator listener', () => {
 
   it('should handle a funds received event when registered for that channel', async () => {
     const channelId = await getChannelId(provider, getNextNonce(), participantA, participantB);
+    const processId = ethers.Wallet.createRandom().address;
     const sagaTester = new SagaTester({});
     sagaTester.start(adjudicatorWatcher, provider);
     sagaTester.dispatch(actions.registerForAdjudicatorEvents(processId, channelId));
@@ -81,6 +83,7 @@ describe('adjudicator listener', () => {
     const startTimestamp = Date.now();
     const channelNonce = getNextNonce();
     const channelId = await getChannelId(provider, channelNonce, participantA, participantB);
+    const processId = ethers.Wallet.createRandom().address;
 
     const sagaTester = new SagaTester({});
     sagaTester.start(adjudicatorWatcher, provider);
@@ -104,6 +107,7 @@ describe('adjudicator listener', () => {
   it('should handle a concluded event when registered for that channel', async () => {
     const channelNonce = getNextNonce();
     const channelId = await getChannelId(provider, channelNonce, participantA, participantB);
+    const processId = ethers.Wallet.createRandom().address;
     const sagaTester = new SagaTester({});
 
     sagaTester.start(adjudicatorWatcher, provider);
@@ -120,6 +124,7 @@ describe('adjudicator listener', () => {
   it('should handle a refute event when registered for that channel', async () => {
     const channelNonce = getNextNonce();
     const channelId = await getChannelId(provider, channelNonce, participantA, participantB);
+    const processId = ethers.Wallet.createRandom().address;
     await createChallenge(provider, channelNonce, participantA, participantB);
 
     const sagaTester = new SagaTester({});
@@ -142,6 +147,7 @@ describe('adjudicator listener', () => {
   it('should handle a respondWithMove event when registered for that channel', async () => {
     const channelNonce = getNextNonce();
     const channelId = await getChannelId(provider, channelNonce, participantA, participantB);
+    const processId = ethers.Wallet.createRandom().address;
 
     await createChallenge(provider, channelNonce, participantA, participantB);
 

--- a/packages/wallet/src/contract-tests/test-utils.ts
+++ b/packages/wallet/src/contract-tests/test-utils.ts
@@ -24,6 +24,8 @@ export const fourSix = [bigNumberify(4).toHexString(), bigNumberify(6).toHexStri
   string
 ];
 
+export const defaultDepositAmount = fiveFive[0];
+
 export async function getChannelId(provider, channelNonce, participantA, participantB) {
   const network = await provider.getNetwork();
   const networkId = network.chainId;
@@ -38,8 +40,9 @@ export async function getChannelId(provider, channelNonce, participantA, partici
 export async function depositContract(
   provider: ethers.providers.JsonRpcProvider,
   participant: string,
+  amount = defaultDepositAmount,
 ) {
-  const deployTransaction = createDepositTransaction(participant, '0x5');
+  const deployTransaction = createDepositTransaction(participant, amount);
   const transactionReceipt = await sendTransaction(provider, deployTransaction);
   await transactionReceipt.wait();
 }
@@ -61,7 +64,7 @@ export async function createChallenge(
 
   const fromCommitment: Commitment = {
     channel,
-    allocation: ['0x05', '0x05'],
+    allocation: fiveFive,
     destination: [participantA.address, participantB.address],
     turnNum: 5,
     commitmentType: CommitmentType.App,
@@ -71,7 +74,7 @@ export async function createChallenge(
 
   const toCommitment: Commitment = {
     channel,
-    allocation: ['0x05', '0x05'],
+    allocation: fiveFive,
     destination: [participantA.address, participantB.address],
     turnNum: 6,
     commitmentType: CommitmentType.App,
@@ -109,7 +112,7 @@ export async function concludeGame(
 
   const fromCommitment: Commitment = {
     channel,
-    allocation: ['0x05', '0x05'],
+    allocation: fiveFive,
     destination: [participantA.address, participantB.address],
     turnNum: 5,
     commitmentType: CommitmentType.Conclude,
@@ -119,7 +122,7 @@ export async function concludeGame(
 
   const toCommitment: Commitment = {
     channel,
-    allocation: ['0x05', '0x05'],
+    allocation: fiveFive,
     destination: [participantA.address, participantB.address],
     turnNum: 6,
     commitmentType: CommitmentType.Conclude,
@@ -157,7 +160,7 @@ export async function respondWithMove(
 
   const toCommitment: Commitment = {
     channel,
-    allocation: ['0x05', '0x05'],
+    allocation: fiveFive,
     destination: [participantA.address, participantB.address],
     turnNum: 7,
     commitmentType: CommitmentType.App,
@@ -190,7 +193,7 @@ export async function refuteChallenge(
 
   const toCommitment: Commitment = {
     channel,
-    allocation: ['0x05', '0x05'],
+    allocation: fiveFive,
     destination: [participantA.address, participantB.address],
     turnNum: 8,
     commitmentType: CommitmentType.App,

--- a/packages/wallet/src/redux/__tests__/initialized.test.ts
+++ b/packages/wallet/src/redux/__tests__/initialized.test.ts
@@ -9,6 +9,7 @@ const defaults = {
   adjudicator: 'adjudicator',
   networkId: 1,
   consensusLibrary: '0x0',
+  processStore: {},
 };
 
 const initializedState = states.initialized({ ...defaults });

--- a/packages/wallet/src/redux/__tests__/selectors.test.ts
+++ b/packages/wallet/src/redux/__tests__/selectors.test.ts
@@ -1,0 +1,51 @@
+import * as walletStates from '../state';
+import * as selectors from '../selectors';
+
+describe('getAdjudicatorWatcherProcessesForChannel', () => {
+  const createWatcherState = (
+    processIds: string[],
+    channelId?: string,
+  ): walletStates.Initialized => {
+    const processStore: walletStates.ProcessStore = {};
+    const channelsToMonitor = channelId ? [channelId] : [];
+    for (const processId of processIds) {
+      processStore[processId] = {
+        protocolState: {},
+        processId,
+        channelsToMonitor,
+      };
+    }
+    return walletStates.initialized({
+      ...walletStates.emptyState,
+      uid: '',
+      consensusLibrary: '',
+      networkId: 0,
+      adjudicator: '',
+      processStore,
+    });
+  };
+
+  it('should return an array of processIds that are registered for a channel', () => {
+    const processIds = ['p1', 'p2'];
+    const channelId = '0x0';
+    const state = createWatcherState(processIds, channelId);
+    expect(selectors.getAdjudicatorWatcherProcessesForChannel(state, '0x0')).toEqual(processIds);
+  });
+
+  it('should return an empty array when no processes are registered for the channel', () => {
+    const processIds = ['p1', 'p2'];
+    const channelId = '0x0';
+    const state = createWatcherState(processIds, channelId);
+    expect(selectors.getAdjudicatorWatcherProcessesForChannel(state, '0x1')).toEqual([]);
+  });
+
+  it('should return an empty array when the process store is empty', () => {
+    const state = createWatcherState([]);
+    expect(selectors.getAdjudicatorWatcherProcessesForChannel(state, '0x1')).toEqual([]);
+  });
+
+  it('should return an empty array when no channels are monitored', () => {
+    const state = createWatcherState(['p1', 'p2']);
+    expect(selectors.getAdjudicatorWatcherProcessesForChannel(state, '0x1')).toEqual([]);
+  });
+});

--- a/packages/wallet/src/redux/__tests__/test-scenarios.ts
+++ b/packages/wallet/src/redux/__tests__/test-scenarios.ts
@@ -31,6 +31,7 @@ export const initializedState: states.Initialized = {
   uid: 'uid',
   networkId: 3,
   consensusLibrary: '0x0',
+  processStore: {},
 };
 
 export const mockTransactionOutboxItem = {

--- a/packages/wallet/src/redux/actions.ts
+++ b/packages/wallet/src/redux/actions.ts
@@ -174,6 +174,7 @@ export type RefutedEvent = ReturnType<typeof refutedEvent>;
 
 export const RESPOND_WITH_MOVE_EVENT = 'WALLET.ADJUDICATOR.RESPOND_WITH_MOVE_EVENT';
 export const respondWithMoveEvent = (processId: string, channelId: string, responseCommitment) => ({
+  processId,
   channelId,
   responseCommitment,
   type: RESPOND_WITH_MOVE_EVENT as typeof RESPOND_WITH_MOVE_EVENT,
@@ -201,24 +202,6 @@ export type AdjudicatorEventAction =
   | RefutedEvent
   | RespondWithMoveEvent
   | FundingReceivedEvent;
-
-export const REGISTER_FOR_ADJUDICATOR_EVENTS = 'REGISTER_FOR_ADJUDICATOR_EVENTS';
-export const registerForAdjudicatorEvents = (processId: string, ...channelIds: string[]) => ({
-  type: REGISTER_FOR_ADJUDICATOR_EVENTS as typeof REGISTER_FOR_ADJUDICATOR_EVENTS,
-  processId,
-  channelIds,
-});
-export type RegisterForAdjudicatorEvents = ReturnType<typeof registerForAdjudicatorEvents>;
-export const UNREGISTER_FOR_ADJUDICATOR_EVENTS = 'UNREGISTER_FOR_ADJUDICATOR_EVENTS';
-export const unregisterForAdjudicatorEvents = (processId: string) => ({
-  type: UNREGISTER_FOR_ADJUDICATOR_EVENTS as typeof UNREGISTER_FOR_ADJUDICATOR_EVENTS,
-  processId,
-});
-export type UnregisterForAdjudicatorEvents = ReturnType<typeof unregisterForAdjudicatorEvents>;
-
-export type AdjudicatorRegisterAction =
-  | RegisterForAdjudicatorEvents
-  | UnregisterForAdjudicatorEvents;
 
 export type CommonAction =
   | TransactionConfirmed

--- a/packages/wallet/src/redux/actions.ts
+++ b/packages/wallet/src/redux/actions.ts
@@ -136,6 +136,90 @@ export const commitmentReceived = (
 });
 export type CommitmentReceived = ReturnType<typeof commitmentReceived>;
 
+export const CHALLENGE_CREATED_EVENT = 'WALLET.ADJUDICATOR.CHALLENGE_CREATED_EVENT';
+export const challengeCreatedEvent = (
+  processId: string,
+  channelId: string,
+  commitment: Commitment,
+  finalizedAt,
+) => ({
+  processId,
+  channelId,
+  commitment,
+  finalizedAt,
+  type: CHALLENGE_CREATED_EVENT as typeof CHALLENGE_CREATED_EVENT,
+});
+export type ChallengeCreatedEvent = ReturnType<typeof challengeCreatedEvent>;
+
+export const CONCLUDED_EVENT = 'WALLET.ADJUDICATOR.CONCLUDED_EVENT';
+export const concludedEvent = (processId: string, channelId: string) => ({
+  processId,
+  channelId,
+  type: CONCLUDED_EVENT as typeof CONCLUDED_EVENT,
+});
+export type ConcludedEvent = ReturnType<typeof concludedEvent>;
+
+export const REFUTED_EVENT = 'WALLET.ADJUDICATOR.REFUTED_EVENT';
+export const refutedEvent = (
+  processId: string,
+  channelId: string,
+  refuteCommitment: Commitment,
+) => ({
+  processId,
+  channelId,
+  refuteCommitment,
+  type: REFUTED_EVENT as typeof REFUTED_EVENT,
+});
+export type RefutedEvent = ReturnType<typeof refutedEvent>;
+
+export const RESPOND_WITH_MOVE_EVENT = 'WALLET.ADJUDICATOR.RESPOND_WITH_MOVE_EVENT';
+export const respondWithMoveEvent = (processId: string, channelId: string, responseCommitment) => ({
+  channelId,
+  responseCommitment,
+  type: RESPOND_WITH_MOVE_EVENT as typeof RESPOND_WITH_MOVE_EVENT,
+});
+export type RespondWithMoveEvent = ReturnType<typeof respondWithMoveEvent>;
+
+export const FUNDING_RECEIVED_EVENT = 'WALLET.ADJUDICATOR.FUNDING_RECEIVED_EVENT';
+export const fundingReceivedEvent = (
+  processId: string,
+  channelId: string,
+  amount: string,
+  totalForDestination: string,
+) => ({
+  processId,
+  channelId,
+  amount,
+  totalForDestination,
+  type: FUNDING_RECEIVED_EVENT as typeof FUNDING_RECEIVED_EVENT,
+});
+export type FundingReceivedEvent = ReturnType<typeof fundingReceivedEvent>;
+
+export type AdjudicatorEventAction =
+  | ChallengeCreatedEvent
+  | ConcludedEvent
+  | RefutedEvent
+  | RespondWithMoveEvent
+  | FundingReceivedEvent;
+
+export const REGISTER_FOR_ADJUDICATOR_EVENTS = 'REGISTER_FOR_ADJUDICATOR_EVENTS';
+export const registerForAdjudicatorEvents = (processId: string, ...channelIds: string[]) => ({
+  type: REGISTER_FOR_ADJUDICATOR_EVENTS as typeof REGISTER_FOR_ADJUDICATOR_EVENTS,
+  processId,
+  channelIds,
+});
+export type RegisterForAdjudicatorEvents = ReturnType<typeof registerForAdjudicatorEvents>;
+export const UNREGISTER_FOR_ADJUDICATOR_EVENTS = 'UNREGISTER_FOR_ADJUDICATOR_EVENTS';
+export const unregisterForAdjudicatorEvents = (processId: string) => ({
+  type: UNREGISTER_FOR_ADJUDICATOR_EVENTS as typeof UNREGISTER_FOR_ADJUDICATOR_EVENTS,
+  processId,
+});
+export type UnregisterForAdjudicatorEvents = ReturnType<typeof unregisterForAdjudicatorEvents>;
+
+export type AdjudicatorRegisterAction =
+  | RegisterForAdjudicatorEvents
+  | UnregisterForAdjudicatorEvents;
+
 export type CommonAction =
   | TransactionConfirmed
   | TransactionSentToMetamask
@@ -144,7 +228,7 @@ export type CommonAction =
   | RetryTransaction
   | MessageReceived
   | CommitmentReceived
-  | funding.FundingReceivedEvent;
+  | AdjudicatorEventAction;
 
 export type ProcedureAction = CommonAction;
 

--- a/packages/wallet/src/redux/channel-state/__tests__/channel-state.test.ts
+++ b/packages/wallet/src/redux/channel-state/__tests__/channel-state.test.ts
@@ -6,6 +6,7 @@ import * as states from '../state';
 import { itTransitionsToChannelStateType, itSendsThisMessage } from '../../__tests__/helpers';
 import * as SigningUtil from '../../../utils/signing-utils';
 import { validationFailure, SIGNATURE_FAILURE } from 'magmo-wallet-client';
+import { fundingConfirmed } from '../../internal/actions';
 
 const {
   initializingChannelState: initializingChannels,
@@ -68,7 +69,7 @@ describe('when the channel is part of the channelState', () => {
   describe('when a channel action with a channelId arrives', () => {
     it('delegates to the single channel reducer', async () => {
       const state = { ...defaults, initializedChannels };
-      const action = actions.channel.concludedEvent(channelId);
+      const action = fundingConfirmed(channelId);
       const mock = jest.fn().mockReturnValue({ state });
       Object.defineProperty(channelState, 'initializedChannelStatusReducer', { value: mock });
       channelState.channelStateReducer(state, action);

--- a/packages/wallet/src/redux/channel-state/actions.ts
+++ b/packages/wallet/src/redux/channel-state/actions.ts
@@ -170,38 +170,6 @@ export const withdrawalSuccessAcknowledged = () => ({
 });
 export type WithdrawalSuccessAcknowledged = ReturnType<typeof withdrawalSuccessAcknowledged>;
 
-export const CHALLENGE_CREATED_EVENT = 'WALLET.CHANNEL.CHALLENGE_CREATED_EVENT';
-export const challengeCreatedEvent = (channelId: string, commitment: Commitment, finalizedAt) => ({
-  channelId,
-  commitment,
-  finalizedAt,
-  type: CHALLENGE_CREATED_EVENT as typeof CHALLENGE_CREATED_EVENT,
-});
-export type ChallengeCreatedEvent = ReturnType<typeof challengeCreatedEvent>;
-
-export const CONCLUDED_EVENT = 'WALLET.CHANNEL.CONCLUDED_EVENT';
-export const concludedEvent = channelId => ({
-  channelId,
-  type: CONCLUDED_EVENT as typeof CONCLUDED_EVENT,
-});
-export type concludedEvent = ReturnType<typeof concludedEvent>;
-
-export const REFUTED_EVENT = 'WALLET.CHANNEL.REFUTED_EVENT';
-export const refutedEvent = (channelId, refuteCommitment) => ({
-  channelId,
-  refuteCommitment,
-  type: REFUTED_EVENT as typeof REFUTED_EVENT,
-});
-export type RefutedEvent = ReturnType<typeof refutedEvent>;
-
-export const RESPOND_WITH_MOVE_EVENT = 'WALLET.CHANNEL.RESPOND_WITH_MOVE_EVENT';
-export const respondWithMoveEvent = (channelId, responseCommitment) => ({
-  channelId,
-  responseCommitment,
-  type: RESPOND_WITH_MOVE_EVENT as typeof RESPOND_WITH_MOVE_EVENT,
-});
-export type RespondWithMoveEvent = ReturnType<typeof respondWithMoveEvent>;
-
 export const CONCLUDE_REQUESTED = 'WALLET.CHANNEL.CONCLUDE_REQUESTED';
 export const concludeRequested = () => ({
   type: CONCLUDE_REQUESTED as typeof CONCLUDE_REQUESTED,
@@ -245,7 +213,6 @@ export type ChannelAction =  // TODO: Some of these actions probably also belong
   | ChallengeApproved
   | ChallengeCommitmentReceived
   | ChallengeCompletionAcknowledged
-  | ChallengeCreatedEvent
   | ChallengeRejected
   | ChallengeRequested
   | ChallengeResponseAcknowledged
@@ -255,7 +222,6 @@ export type ChannelAction =  // TODO: Some of these actions probably also belong
   | ClosedOnChainAcknowledged
   | CloseSuccessAcknowledged
   | ConcludeApproved
-  | concludedEvent
   | ConcludeRejected
   | ConcludeRequested
   | FundingApproved
@@ -268,7 +234,6 @@ export type ChannelAction =  // TODO: Some of these actions probably also belong
   | PostFundSetupReceived
   | RespondWithExistingMoveChosen
   | RespondWithMoveChosen
-  | RespondWithMoveEvent
   | RespondWithRefuteChosen
   | TakeMoveInAppAcknowledged
   | WithdrawalApproved

--- a/packages/wallet/src/redux/channel-state/challenging/__tests__/challenging.test.ts
+++ b/packages/wallet/src/redux/channel-state/challenging/__tests__/challenging.test.ts
@@ -131,7 +131,7 @@ describe('when in WAIT_FOR_RESPONSE_OR_TIMEOUT', () => {
   });
 
   describe('when the opponent responds', () => {
-    const action = actions.channel.respondWithMoveEvent('0x0', '0xC1');
+    const action = actions.respondWithMoveEvent('0x0', '0x0', '0xC1');
     const updatedState = challengingReducer(state, action);
 
     itTransitionsToChannelStateType(states.ACKNOWLEDGE_CHALLENGE_RESPONSE, updatedState);

--- a/packages/wallet/src/redux/channel-state/challenging/reducer.ts
+++ b/packages/wallet/src/redux/channel-state/challenging/reducer.ts
@@ -130,7 +130,7 @@ const waitForChallengeSubmissionReducer = (
   action: WalletAction,
 ): StateWithSideEffects<states.ChannelStatus> => {
   switch (action.type) {
-    case actions.channel.CHALLENGE_CREATED_EVENT:
+    case actions.CHALLENGE_CREATED_EVENT:
       return {
         state: states.waitForChallengeSubmission({
           ...state,
@@ -156,7 +156,7 @@ const waitForChallengeConfirmationReducer = (
   action: WalletAction,
 ): StateWithSideEffects<states.ChannelStatus> => {
   switch (action.type) {
-    case actions.channel.CHALLENGE_CREATED_EVENT:
+    case actions.CHALLENGE_CREATED_EVENT:
       return {
         state: states.waitForChallengeConfirmation({
           ...state,
@@ -180,14 +180,14 @@ const waitForResponseOrTimeoutReducer = (
   action: WalletAction,
 ): StateWithSideEffects<states.ChannelStatus> => {
   switch (action.type) {
-    case actions.channel.CHALLENGE_CREATED_EVENT:
+    case actions.CHALLENGE_CREATED_EVENT:
       return {
         state: states.waitForResponseOrTimeout({
           ...state,
           challengeExpiry: bigNumberify(action.finalizedAt).toNumber(),
         }),
       };
-    case actions.channel.RESPOND_WITH_MOVE_EVENT:
+    case actions.RESPOND_WITH_MOVE_EVENT:
       const message = challengeCommitmentReceived(action.responseCommitment);
       // TODO: Right now we're just storing a dummy signature since we don't get one
       // from the challenge.

--- a/packages/wallet/src/redux/channel-state/running/__tests__/running.test.ts
+++ b/packages/wallet/src/redux/channel-state/running/__tests__/running.test.ts
@@ -72,7 +72,8 @@ describe('when in WaitForUpdate on our turn', () => {
   });
 
   describe('when the wallet detects an opponent challenge', () => {
-    const action = actions.channel.challengeCreatedEvent(
+    const action = actions.challengeCreatedEvent(
+      '0xf00',
       '0xf00',
       scenarios.preFundCommitment1,
       defaults.challengeExpiry,
@@ -130,7 +131,8 @@ describe(`when in WaitForUpdate on our opponent's turn`, () => {
   });
 
   describe('when the wallet detects an opponent challenge', () => {
-    const action = actions.channel.challengeCreatedEvent(
+    const action = actions.challengeCreatedEvent(
+      '0xf00',
       '0xf00',
       scenarios.preFundCommitment1,
       defaults.challengeExpiry,

--- a/packages/wallet/src/redux/channel-state/running/reducer.ts
+++ b/packages/wallet/src/redux/channel-state/running/reducer.ts
@@ -87,7 +87,7 @@ const waitForUpdateReducer = (
         sideEffects: { messageOutbox: handleSignatureAndValidationMessages(state, action) },
       };
 
-    case actions.channel.CHALLENGE_CREATED_EVENT:
+    case actions.CHALLENGE_CREATED_EVENT:
       // transition to responding
       return {
         state: respondingStates.chooseResponse({

--- a/packages/wallet/src/redux/direct-funding-store/__tests__/direct-funding.test.ts
+++ b/packages/wallet/src/redux/direct-funding-store/__tests__/direct-funding.test.ts
@@ -33,11 +33,12 @@ const startingIn = stage => `start in ${stage}`;
 const whenActionArrives = action => `incoming action ${action}`;
 
 describe(startingIn('any state'), () => {
-  describe(whenActionArrives(actions.funding.FUNDING_RECEIVED_EVENT), () => {
+  describe(whenActionArrives(actions.FUNDING_RECEIVED_EVENT), () => {
     describe("When it's for the correct channel", () => {
       describe('when the channel is now funded', () => {
         const state = states.notSafeToDeposit(defaultsForA);
-        const action = actions.funding.fundingReceivedEvent(
+        const action = actions.fundingReceivedEvent(
+          channelId,
           channelId,
           TOTAL_REQUIRED,
           TOTAL_REQUIRED,
@@ -47,7 +48,8 @@ describe(startingIn('any state'), () => {
       });
       describe('when the channel is still not funded', () => {
         const state = states.notSafeToDeposit(defaultsForB);
-        const action = actions.funding.fundingReceivedEvent(
+        const action = actions.fundingReceivedEvent(
+          channelId,
           channelId,
           YOUR_DEPOSIT_B,
           YOUR_DEPOSIT_B,
@@ -59,7 +61,7 @@ describe(startingIn('any state'), () => {
 
     describe("When it's for another channels", () => {
       const state = states.notSafeToDeposit(defaultsForA);
-      const action = actions.funding.fundingReceivedEvent('0xf00', TOTAL_REQUIRED, TOTAL_REQUIRED);
+      const action = actions.fundingReceivedEvent('0xf00', '0xf00', TOTAL_REQUIRED, TOTAL_REQUIRED);
       const updatedState = directFundingStateReducer(state, action);
       itChangesChannelFundingStatusTo(states.NOT_SAFE_TO_DEPOSIT, updatedState);
     });
@@ -68,10 +70,11 @@ describe(startingIn('any state'), () => {
 
 describe(startingIn(states.NOT_SAFE_TO_DEPOSIT), () => {
   // player B scenario
-  describe(whenActionArrives(actions.funding.FUNDING_RECEIVED_EVENT), () => {
+  describe(whenActionArrives(actions.FUNDING_RECEIVED_EVENT), () => {
     describe('when it is now safe to deposit', () => {
       const state = states.notSafeToDeposit(defaultsForB);
-      const action = actions.funding.fundingReceivedEvent(
+      const action = actions.fundingReceivedEvent(
+        channelId,
         channelId,
         YOUR_DEPOSIT_A,
         YOUR_DEPOSIT_A,
@@ -84,7 +87,7 @@ describe(startingIn(states.NOT_SAFE_TO_DEPOSIT), () => {
 
     describe('when it is still not safe to deposit', () => {
       const state = states.notSafeToDeposit(defaultsForB);
-      const action = actions.funding.fundingReceivedEvent(channelId, '0x', '0x');
+      const action = actions.fundingReceivedEvent(channelId, channelId, '0x', '0x');
       const updatedState = directFundingStateReducer(state, action);
 
       itChangesChannelFundingStatusTo(states.NOT_SAFE_TO_DEPOSIT, updatedState);
@@ -93,10 +96,11 @@ describe(startingIn(states.NOT_SAFE_TO_DEPOSIT), () => {
 });
 
 describe(startingIn(states.SAFE_TO_DEPOSIT), () => {
-  describe(whenActionArrives(actions.funding.FUNDING_RECEIVED_EVENT), () => {
+  describe(whenActionArrives(actions.FUNDING_RECEIVED_EVENT), () => {
     describe('when it is now fully funded', () => {
       const state = states.waitForFundingConfirmed(defaultsForB);
-      const action = actions.funding.fundingReceivedEvent(
+      const action = actions.fundingReceivedEvent(
+        channelId,
         channelId,
         YOUR_DEPOSIT_B,
         TOTAL_REQUIRED,
@@ -108,7 +112,7 @@ describe(startingIn(states.SAFE_TO_DEPOSIT), () => {
 
     describe('when it is still not fully funded', () => {
       const state = states.waitForFundingConfirmed(defaultsForB);
-      const action = actions.funding.fundingReceivedEvent(channelId, '0x', YOUR_DEPOSIT_A);
+      const action = actions.fundingReceivedEvent(channelId, channelId, '0x', YOUR_DEPOSIT_A);
       const updatedState = directFundingStateReducer(state, action);
 
       itChangesChannelFundingStatusTo(states.SAFE_TO_DEPOSIT, updatedState);
@@ -116,7 +120,7 @@ describe(startingIn(states.SAFE_TO_DEPOSIT), () => {
 
     describe('when it is for the wrong channel', () => {
       const state = states.waitForFundingConfirmed(defaultsForB);
-      const action = actions.funding.fundingReceivedEvent('0xf00', TOTAL_REQUIRED, TOTAL_REQUIRED);
+      const action = actions.fundingReceivedEvent('0xf00', '0xf00', TOTAL_REQUIRED, TOTAL_REQUIRED);
       const updatedState = directFundingStateReducer(state, action);
 
       itChangesChannelFundingStatusTo(states.SAFE_TO_DEPOSIT, updatedState);

--- a/packages/wallet/src/redux/direct-funding-store/direct-funding-state/actions.ts
+++ b/packages/wallet/src/redux/direct-funding-store/direct-funding-state/actions.ts
@@ -1,20 +1,7 @@
 import * as actions from '../../actions';
 
-export const FUNDING_RECEIVED_EVENT = 'WALLET.FUNDING.FUNDING_RECEIVED_EVENT';
-export const fundingReceivedEvent = (
-  channelId: string,
-  amount: string,
-  totalForDestination: string,
-) => ({
-  channelId,
-  amount,
-  totalForDestination,
-  type: FUNDING_RECEIVED_EVENT as typeof FUNDING_RECEIVED_EVENT,
-});
-export type FundingReceivedEvent = ReturnType<typeof fundingReceivedEvent>;
-
 export function isfundingAction(action: actions.WalletAction): action is FundingAction {
-  return action.type.match('WALLET.FUNDING') ||
+  return action.type === 'WALLET.ADJUDICATOR.FUNDING_RECEIVED_EVENT' ||
     actions.internal.isFundingAction(action) ||
     actions.isTransactionAction(action)
     ? true
@@ -22,6 +9,6 @@ export function isfundingAction(action: actions.WalletAction): action is Funding
 }
 
 export type FundingAction =
-  | FundingReceivedEvent
+  | actions.FundingReceivedEvent
   | actions.internal.InternalFundingAction
   | actions.TransactionAction;

--- a/packages/wallet/src/redux/direct-funding-store/direct-funding-state/reducer.ts
+++ b/packages/wallet/src/redux/direct-funding-store/direct-funding-state/reducer.ts
@@ -12,10 +12,7 @@ export const directFundingStateReducer = (
   state: states.DirectFundingState,
   action: actions.WalletAction,
 ): StateWithSideEffects<states.DirectFundingState> => {
-  if (
-    action.type === actions.funding.FUNDING_RECEIVED_EVENT &&
-    action.channelId === state.channelId
-  ) {
+  if (action.type === actions.FUNDING_RECEIVED_EVENT && action.channelId === state.channelId) {
     // You can always move to CHANNEL_FUNDED based on the action
     // of some arbitrary actor, so this behaviour is common regardless of the stage of
     // the state
@@ -44,7 +41,7 @@ const notSafeToDepositReducer = (
   action: actions.WalletAction,
 ): StateWithSideEffects<states.DirectFundingState> => {
   switch (action.type) {
-    case actions.funding.FUNDING_RECEIVED_EVENT:
+    case actions.FUNDING_RECEIVED_EVENT:
       if (
         action.channelId === state.channelId &&
         bigNumberify(action.totalForDestination).gte(state.safeToDepositLevel)
@@ -77,7 +74,7 @@ const waitForFundingConfirmationReducer = (
   // TODO: This code path is unreachable, but the compiler doesn't know that.
   // Can we fix that?
   switch (action.type) {
-    case actions.funding.FUNDING_RECEIVED_EVENT:
+    case actions.FUNDING_RECEIVED_EVENT:
       if (
         action.channelId === state.channelId &&
         bigNumberify(action.totalForDestination).gte(state.requestedTotalFunds)
@@ -96,7 +93,7 @@ const channelFundedReducer = (
   state: states.ChannelFunded,
   action: actions.WalletAction,
 ): StateWithSideEffects<states.DirectFundingState> => {
-  if (action.type === actions.funding.FUNDING_RECEIVED_EVENT) {
+  if (action.type === actions.FUNDING_RECEIVED_EVENT) {
     if (bigNumberify(action.totalForDestination).lt(state.requestedTotalFunds)) {
       // TODO: Deal with chain re-orgs that de-fund the channel here
       return { state };

--- a/packages/wallet/src/redux/indirect-funding/player-a/__tests__/reducer.test.ts
+++ b/packages/wallet/src/redux/indirect-funding/player-a/__tests__/reducer.test.ts
@@ -163,8 +163,8 @@ describe(startingIn(states.WAIT_FOR_DIRECT_FUNDING), () => {
     channelId: ledgerId,
     ourIndex: PlayerIndex.A,
   });
-  describe(whenActionArrives(actions.funding.FUNDING_RECEIVED_EVENT), () => {
-    const action = actions.funding.fundingReceivedEvent(defaults.ledgerId, total, total);
+  describe(whenActionArrives(actions.FUNDING_RECEIVED_EVENT), () => {
+    const action = actions.fundingReceivedEvent(channelId, defaults.ledgerId, total, total);
     const updatedState = playerAReducer(walletState, action);
 
     itTransitionToStateType(updatedState, states.WAIT_FOR_POST_FUND_SETUP_1);

--- a/packages/wallet/src/redux/indirect-funding/player-a/reducer.ts
+++ b/packages/wallet/src/redux/indirect-funding/player-a/reducer.ts
@@ -128,7 +128,6 @@ const waitForDirectFunding = (
   const indirectFundingState = selectors.getIndirectFundingState(
     state,
   ) as states.WaitForDirectFunding;
-  // Funding events currently occur directly against the ledger channel
   if (!isfundingAction(action)) {
     return state;
   } else {

--- a/packages/wallet/src/redux/indirect-funding/player-b/__tests__/reducer.test.ts
+++ b/packages/wallet/src/redux/indirect-funding/player-b/__tests__/reducer.test.ts
@@ -130,7 +130,7 @@ describe(startingIn(states.WAIT_FOR_PRE_FUND_SETUP_0), () => {
 });
 
 describe(startingIn(states.WAIT_FOR_DIRECT_FUNDING), () => {
-  describe.skip(whenActionArrives(actions.funding.FUNDING_RECEIVED_EVENT), () => {
+  describe.skip(whenActionArrives(actions.FUNDING_RECEIVED_EVENT), () => {
     // Need to hook up the direct funding store first, which isn't yet in this branch
     const state = startingState(states.waitForDirectFunding({ channelId, ledgerId }), {
       [channelId]: channelStates.waitForFundingAndPostFundSetup(appChannelStateDefaults),

--- a/packages/wallet/src/redux/reducer.ts
+++ b/packages/wallet/src/redux/reducer.ts
@@ -77,6 +77,7 @@ const waitForAdjudicatorReducer = (
         adjudicator,
         networkId,
         consensusLibrary: '0x0FA5E',
+        processStore: {},
       });
     default:
       return state;

--- a/packages/wallet/src/redux/sagas/adjudicator-watcher.ts
+++ b/packages/wallet/src/redux/sagas/adjudicator-watcher.ts
@@ -1,10 +1,11 @@
 import { getAdjudicatorContract } from '../../utils/contract-utils';
-import { call, take, put, fork, cancel, actionChannel } from 'redux-saga/effects';
+import { call, take, put, select } from 'redux-saga/effects';
 import { eventChannel } from 'redux-saga';
 import * as actions from '../actions';
 import { ethers } from 'ethers';
 import { unreachable } from '../../utils/reducer-utils';
 import { fromParameters } from 'fmg-core/lib/commitment';
+import { getAdjudicatorWatcherProcessesForChannel } from '../selectors';
 
 enum AdjudicatorEventType {
   ChallengeCreated,
@@ -21,95 +22,64 @@ interface AdjudicatorEvent {
 }
 
 export function* adjudicatorWatcher(provider) {
-  const registerActionChannel = yield actionChannel([
-    actions.REGISTER_FOR_ADJUDICATOR_EVENTS,
-    actions.UNREGISTER_FOR_ADJUDICATOR_EVENTS,
-  ]);
-  const adjudicatorWatchers = {};
   const adjudicatorEventChannel = yield call(createAdjudicatorEventChannel, provider);
-
   while (true) {
-    const registerAction: actions.AdjudicatorRegisterAction = yield take(registerActionChannel);
-    switch (registerAction.type) {
-      case actions.REGISTER_FOR_ADJUDICATOR_EVENTS:
-        // We cancel the existing listener and register the new one
-        if (adjudicatorWatchers[registerAction.processId]) {
-          yield cancel(adjudicatorWatchers[registerAction.processId]);
-        }
-        adjudicatorWatchers[registerAction.processId] = yield fork(
-          adjudicatorWatcherForProcess,
-          registerAction.processId,
-          registerAction.channelIds,
-          adjudicatorEventChannel,
-        );
-        break;
-      case actions.UNREGISTER_FOR_ADJUDICATOR_EVENTS:
-        if (adjudicatorWatchers[registerAction.processId]) {
-          yield cancel(adjudicatorWatchers[registerAction.processId]);
-        } else {
-          throw new Error(
-            `There is no adjudicator watcher registered for process ${registerAction.processId}`,
-          );
-        }
-        break;
+    const event: AdjudicatorEvent = yield take(adjudicatorEventChannel);
+
+    const processIdsToAlert = yield select(
+      getAdjudicatorWatcherProcessesForChannel,
+      event.channelId,
+    );
+
+    for (const processId of processIdsToAlert) {
+      yield dispatchEventAction(event, processId);
     }
   }
 }
 
-function* adjudicatorWatcherForProcess(
-  processId: string,
-  channelIdsToListenFor: string[],
-  adjudicatorEventChannel,
-) {
-  while (true) {
-    const event: AdjudicatorEvent = yield take(adjudicatorEventChannel);
-    const { channelId } = event;
-    // If it is not a channel we've been registered for we ignore the event
-    if (channelIdsToListenFor.indexOf(channelId) === -1) {
-      continue;
-    }
-    switch (event.eventType) {
-      case AdjudicatorEventType.ChallengeCreated:
-        const { commitment, finalizedAt } = event.eventArgs;
-        yield put(
-          actions.challengeCreatedEvent(
-            processId,
-            channelId,
-            fromParameters(commitment),
-            finalizedAt,
-          ),
-        );
-        break;
-      case AdjudicatorEventType.Concluded:
-        yield put(actions.concludedEvent(processId, channelId));
-        break;
-      case AdjudicatorEventType.Refuted:
-        yield put(
-          actions.refutedEvent(processId, channelId, fromParameters(event.eventArgs.refutation)),
-        );
-        break;
-      case AdjudicatorEventType.RespondWithMove:
-        yield put(
-          actions.respondWithMoveEvent(
-            processId,
-            channelId,
-            fromParameters(event.eventArgs.response),
-          ),
-        );
-        break;
-      case AdjudicatorEventType.Deposited:
-        yield put(
-          actions.fundingReceivedEvent(
-            processId,
-            channelId,
-            event.eventArgs.amountDeposited.toHexString(),
-            event.eventArgs.destinationHoldings.toHexString(),
-          ),
-        );
-        break;
-      default:
-        unreachable(event.eventType);
-    }
+function* dispatchEventAction(event: AdjudicatorEvent, processId: string) {
+  const { channelId } = event;
+  switch (event.eventType) {
+    case AdjudicatorEventType.ChallengeCreated:
+      const { commitment, finalizedAt } = event.eventArgs;
+      yield put(
+        actions.challengeCreatedEvent(
+          processId,
+          channelId,
+          fromParameters(commitment),
+          finalizedAt,
+        ),
+      );
+      break;
+    case AdjudicatorEventType.Concluded:
+      yield put(actions.concludedEvent(processId, channelId));
+      break;
+    case AdjudicatorEventType.Refuted:
+      yield put(
+        actions.refutedEvent(processId, channelId, fromParameters(event.eventArgs.refutation)),
+      );
+      break;
+    case AdjudicatorEventType.RespondWithMove:
+      yield put(
+        actions.respondWithMoveEvent(
+          processId,
+          channelId,
+          fromParameters(event.eventArgs.response),
+        ),
+      );
+      break;
+    case AdjudicatorEventType.Deposited:
+      yield put(
+        actions.fundingReceivedEvent(
+          processId,
+          channelId,
+          event.eventArgs.amountDeposited.toHexString(),
+          event.eventArgs.destinationHoldings.toHexString(),
+        ),
+      );
+      break;
+    default:
+      unreachable(event.eventType);
   }
 }
 

--- a/packages/wallet/src/redux/selectors.ts
+++ b/packages/wallet/src/redux/selectors.ts
@@ -45,3 +45,22 @@ export const getDirectFundingState = (
   }
   return fundingStatus;
 };
+
+export const getAdjudicatorWatcherProcessesForChannel = (
+  state: walletStates.Initialized,
+  channelId: string,
+): string[] => {
+  const processIds: string[] = [];
+
+  if (!state.processStore) {
+    return processIds;
+  }
+  for (const processId of Object.keys(state.processStore)) {
+    const { channelsToMonitor } = state.processStore[processId];
+
+    if (channelsToMonitor.indexOf(channelId) > -1) {
+      processIds.push(processId);
+    }
+  }
+  return processIds;
+};

--- a/packages/wallet/src/redux/state.ts
+++ b/packages/wallet/src/redux/state.ts
@@ -54,9 +54,19 @@ export interface Initialized extends Shared {
   networkId: number;
   adjudicator: string;
   consensusLibrary: string;
-
+  processStore: ProcessStore;
   // procedure branches are optional, and exist precisely when that procedure is running
   indirectFunding?: indirectFunding.IndirectFundingState;
+}
+
+// TODO: Once these are fleshed out they should be moved to their own file.
+export interface ProcessStore {
+  [processId: string]: ProcessState;
+}
+export interface ProcessState {
+  processId: string;
+  protocolState: any;
+  channelsToMonitor: string[];
 }
 
 export interface IndirectFundingOngoing extends Initialized {
@@ -94,7 +104,7 @@ export function waitForAdjudicator(params: Properties<WaitForAdjudicator>): Wait
 }
 
 export function initialized(params: Properties<Initialized>): Initialized {
-  const { uid, networkId, adjudicator, consensusLibrary } = params;
+  const { uid, networkId, adjudicator, consensusLibrary, processStore } = params;
   return {
     ...shared(params),
     type: WALLET_INITIALIZED,
@@ -102,6 +112,7 @@ export function initialized(params: Properties<Initialized>): Initialized {
     networkId,
     adjudicator,
     consensusLibrary,
+    processStore,
   };
 }
 


### PR DESCRIPTION
I've added the beginning of the `processState` with a `channelIdsToMonitor`. The adjudicator watcher now checks that state(via a selector) and dispatches actions with the correct process Id.