### PR TITLE
accept  separate args

### DIFF
--- a/packages/wallet/src/redux/protocols/index.ts
+++ b/packages/wallet/src/redux/protocols/index.ts
@@ -10,7 +10,8 @@ export interface SharedData {
 export type ProtocolState = IndirectFundingState;
 
 export type ProtocolReducer<T extends ProtocolState> = (
-  state: ProtocolStateWithSharedData<T>,
+  protocolState: T,
+  sharedData: SharedData,
   action,
 ) => ProtocolStateWithSharedData<T>;
 


### PR DESCRIPTION
The Protocol reducer signature now accepts protocolState and sharedData as separate args.