### PR TITLE
WalletMessagePayload has either a processId or a protocol

### DIFF
--- a/packages/magmo-wallet-client/src/wallet-types.ts
+++ b/packages/magmo-wallet-client/src/wallet-types.ts
@@ -1,5 +1,10 @@
-export interface WalletMessagePayload {
-  processId: string;
+export type WalletMessagePayload = ProtocolPayload | ProcessPayload;
+export interface ProtocolPayload {
   protocol: string;
+  data: any;
+}
+
+export interface ProcessPayload {
+  processId: string;
   data: any;
 }

--- a/packages/wallet/src/redux/actions.ts
+++ b/packages/wallet/src/redux/actions.ts
@@ -51,10 +51,9 @@ export type MetamaskLoadError = ReturnType<typeof metamaskLoadError>;
 
 export type Message = 'FundingDeclined';
 export const MESSAGE_RECEIVED = 'WALLET.COMMON.MESSAGE_RECEIVED';
-export const messageReceived = (processId: string, protocol: WalletProtocol, data: Message) => ({
+export const messageReceived = (processId: string, data: Message) => ({
   type: MESSAGE_RECEIVED as typeof MESSAGE_RECEIVED,
   processId,
-  protocol,
   data,
 });
 export type MessageReceived = ReturnType<typeof messageReceived>;
@@ -62,13 +61,11 @@ export type MessageReceived = ReturnType<typeof messageReceived>;
 export const COMMITMENT_RECEIVED = 'WALLET.COMMON.COMMITMENT_RECEIVED';
 export const commitmentReceived = (
   processId: string,
-  protocol: WalletProtocol,
   commitment: Commitment,
   signature: string,
 ) => ({
   type: COMMITMENT_RECEIVED as typeof COMMITMENT_RECEIVED,
   processId,
-  protocol,
   commitment,
   signature,
 });

--- a/packages/wallet/src/redux/channel-state/closing/__tests__/closing.test.ts
+++ b/packages/wallet/src/redux/channel-state/closing/__tests__/closing.test.ts
@@ -111,7 +111,6 @@ describe('start in WaitForOpponentConclude', () => {
 
     const action = actions.commitmentReceived(
       channelId,
-      WalletProtocol.DirectFunding,
       ('commitment' as unknown) as Commitment,
       '0x0',
     );

--- a/packages/wallet/src/redux/channel-state/funding/__tests__/funding.test.ts
+++ b/packages/wallet/src/redux/channel-state/funding/__tests__/funding.test.ts
@@ -94,12 +94,7 @@ describe('start in WaitForFundingAndPostFundSetup', () => {
     const state = startingState('A');
     const validateMock = jest.fn().mockReturnValue(true);
     Object.defineProperty(SigningUtil, 'validCommitmentSignature', { value: validateMock });
-    const action = actions.commitmentReceived(
-      channelId,
-      WalletProtocol.DirectFunding,
-      postFundCommitment1,
-      MOCK_SIGNATURE,
-    );
+    const action = actions.commitmentReceived(channelId, postFundCommitment1, MOCK_SIGNATURE);
     const updatedState = fundingReducer(state, action);
 
     itTransitionsToChannelStateType(states.WAIT_FOR_FUNDING_AND_POST_FUND_SETUP, updatedState);
@@ -112,12 +107,7 @@ describe('start in WaitForFundingAndPostFundSetup', () => {
     const validateMock = jest.fn().mockReturnValue(true);
     Object.defineProperty(SigningUtil, 'validCommitmentSignature', { value: validateMock });
 
-    const action = actions.commitmentReceived(
-      channelId,
-      WalletProtocol.DirectFunding,
-      postFundCommitment1,
-      MOCK_SIGNATURE,
-    );
+    const action = actions.commitmentReceived(channelId, postFundCommitment1, MOCK_SIGNATURE);
     const updatedState = fundingReducer(state, action);
 
     itTransitionsToChannelStateType(states.WAIT_FOR_FUNDING_CONFIRMATION, updatedState);
@@ -173,12 +163,7 @@ describe('start in AWaitForPostFundSetup', () => {
 
     const testDefaults = { ...defaultsA, ...justReceivedPostFundSetupA };
     const state = states.aWaitForPostFundSetup({ ...testDefaults });
-    const action = actions.commitmentReceived(
-      channelId,
-      WalletProtocol.DirectFunding,
-      postFundCommitment2,
-      MOCK_SIGNATURE,
-    );
+    const action = actions.commitmentReceived(channelId, postFundCommitment2, MOCK_SIGNATURE);
     const updatedState = fundingReducer(state, action);
 
     itTransitionsToChannelStateType(states.WAIT_FOR_UPDATE, updatedState);
@@ -194,12 +179,7 @@ describe('start in BWaitForPostFundSetup', () => {
     const state = states.bWaitForPostFundSetup(testDefaults);
     const validateMock = jest.fn().mockReturnValue(true);
     Object.defineProperty(SigningUtil, 'validSignature', { value: validateMock });
-    const action = actions.commitmentReceived(
-      channelId,
-      WalletProtocol.DirectFunding,
-      postFundCommitment1,
-      MOCK_SIGNATURE,
-    );
+    const action = actions.commitmentReceived(channelId, postFundCommitment1, MOCK_SIGNATURE);
     const updatedState = fundingReducer(state, action);
 
     itTransitionsToChannelStateType(states.WAIT_FOR_UPDATE, updatedState);

--- a/packages/wallet/src/redux/protocols/indirect-funding/player-a/__tests__/reducer.test.ts
+++ b/packages/wallet/src/redux/protocols/indirect-funding/player-a/__tests__/reducer.test.ts
@@ -5,7 +5,6 @@ import * as channelStates from '../../../../channel-state/state';
 import { PlayerIndex } from 'magmo-wallet-client/lib/wallet-instructions';
 import { itSendsThisMessage, itTransitionsToChannelStateType } from '../../../../__tests__/helpers';
 import { MESSAGE_RELAY_REQUESTED } from 'magmo-wallet-client';
-import { WalletProtocol } from '../../../../types';
 import * as SigningUtil from '../../../../../utils/signing-utils';
 import {} from '../../../../__tests__/test-scenarios';
 import * as testScenarios from '../../../../__tests__/test-scenarios';
@@ -127,7 +126,6 @@ describe(startingIn(states.WAIT_FOR_PRE_FUND_SETUP_1), () => {
   describe(whenActionArrives(actions.COMMITMENT_RECEIVED), () => {
     const action = actions.commitmentReceived(
       ledgerId,
-      WalletProtocol.IndirectFunding,
       testScenarios.ledgerCommitments.preFundCommitment1,
       '0x0',
     );
@@ -185,7 +183,6 @@ describe(startingIn(states.WAIT_FOR_POST_FUND_SETUP_1), () => {
   describe(whenActionArrives(actions.COMMITMENT_RECEIVED), () => {
     const action = actions.commitmentReceived(
       ledgerId,
-      WalletProtocol.IndirectFunding,
       testScenarios.ledgerCommitments.postFundCommitment1,
       '0x0',
     );
@@ -215,7 +212,6 @@ describe(startingIn(states.WAIT_FOR_LEDGER_UPDATE_1), () => {
   describe(whenActionArrives(actions.COMMITMENT_RECEIVED), () => {
     const action = actions.commitmentReceived(
       ledgerId,
-      WalletProtocol.IndirectFunding,
       testScenarios.ledgerCommitments.ledgerUpdate1,
       '0x0',
     );

--- a/packages/wallet/src/redux/protocols/indirect-funding/player-b/__tests__/reducer.test.ts
+++ b/packages/wallet/src/redux/protocols/indirect-funding/player-b/__tests__/reducer.test.ts
@@ -10,7 +10,6 @@ import {
   itTransitionsToChannelStateType,
   itSendsNoMessage,
 } from '../../../../__tests__/helpers';
-import { WalletProtocol } from '../../../../types';
 import { PlayerIndex } from 'magmo-wallet-client/lib/wallet-instructions';
 
 import * as SigningUtil from '../../../../../utils/signing-utils';
@@ -133,12 +132,7 @@ describe(startingIn(states.WAIT_FOR_PRE_FUND_SETUP_0), () => {
       channelStates.waitForFundingAndPostFundSetup(appChannelStateDefaults),
     );
 
-    const action = actions.commitmentReceived(
-      channelId,
-      WalletProtocol.IndirectFunding,
-      preFundCommitment0,
-      'signature',
-    );
+    const action = actions.commitmentReceived(channelId, preFundCommitment0, 'signature');
     const updatedState = playerBReducer(state.protocolState, state.sharedData, action);
 
     itTransitionToStateType(updatedState, states.WAIT_FOR_DIRECT_FUNDING);
@@ -184,12 +178,7 @@ describe(startingIn(states.WAIT_FOR_POST_FUND_SETUP_0), () => {
       }),
     );
 
-    const action = actions.commitmentReceived(
-      channelId,
-      WalletProtocol.IndirectFunding,
-      postFundCommitment0,
-      'signature',
-    );
+    const action = actions.commitmentReceived(channelId, postFundCommitment0, 'signature');
     const updatedState = playerBReducer(state.protocolState, state.sharedData, action);
 
     itTransitionToStateType(updatedState, states.WAIT_FOR_LEDGER_UPDATE_0);
@@ -219,7 +208,6 @@ describe(startingIn(states.WAIT_FOR_LEDGER_UPDATE_0), () => {
 
     const action = actions.commitmentReceived(
       channelId,
-      WalletProtocol.IndirectFunding,
       ledgerCommitments.ledgerUpdate0,
       'signature',
     );
@@ -253,7 +241,6 @@ describe(startingIn(states.WAIT_FOR_CONSENSUS), () => {
 
     const action = actions.commitmentReceived(
       channelId,
-      WalletProtocol.IndirectFunding,
       ledgerCommitments.ledgerUpdate2,
       'signature',
     );

--- a/packages/wallet/src/redux/protocols/indirect-funding/reducer-helpers.ts
+++ b/packages/wallet/src/redux/protocols/indirect-funding/reducer-helpers.ts
@@ -247,9 +247,8 @@ export const createCommitmentMessageRelay = (
   signature: string,
 ) => {
   const payload = {
-    processId,
     protocol: WalletProtocol.IndirectFunding,
-    data: { commitment, signature },
+    data: { commitment, signature, processId },
   };
   return messageRelayRequested(to, payload);
 };


### PR DESCRIPTION
Right now, no messages should arrive that don't have a `processId`, so I semi-arbitrarily opted to throw an error to handle that case.