### PR TITLE
Clear contracts before start/build

### DIFF
--- a/packages/wallet/package.json
+++ b/packages/wallet/package.json
@@ -21,7 +21,7 @@
     "postinstall": "rm -f node_modules/web3/index.d.ts",
     "storybook": "start-storybook -p 9001 -c .storybook",
     "test:contracts": "npx ganache-then-jest -c ./config/jest/jest.contracts.config.js --runInBand",
-    "": "rm -rf ./build/contracts"
+    "clearContracts": "rm -rf ./build/contracts"
   },
   "dependencies": {
     "@firebase/app-types": "^0.3.2",

--- a/packages/wallet/package.json
+++ b/packages/wallet/package.json
@@ -12,7 +12,7 @@
     "start": "npm run clearContracts && node scripts/start.js",
     "build": "npm run clearContracts && node scripts/build.js",
     "test": "run-s prettier:check 'test:app --all'",
-    "test:ci": "DEV_GANACHE_PORT=8503 clearContracts run-s prettier:check build 'test:contracts --all --ci' 'test:app --all --ci --runInBand'",
+    "test:ci": "DEV_GANACHE_PORT=8503  run-s clearContracts prettier:check build 'test:contracts --all --ci' 'test:app --all --ci --runInBand'",
     "test:app": "npx run-jest -c ./config/jest/jest.config.js",
     "prettier:check": "npx prettier --check 'src/**/*.{ts,tsx}'",
     "prettier:write": "npx prettier --write 'src/**/*.{ts,tsx}'",
@@ -21,7 +21,7 @@
     "postinstall": "rm -f node_modules/web3/index.d.ts",
     "storybook": "start-storybook -p 9001 -c .storybook",
     "test:contracts": "npx ganache-then-jest -c ./config/jest/jest.contracts.config.js --runInBand",
-    "clearContracts": "rm -rf ./build/contracts"
+    "": "rm -rf ./build/contracts"
   },
   "dependencies": {
     "@firebase/app-types": "^0.3.2",

--- a/packages/wallet/package.json
+++ b/packages/wallet/package.json
@@ -9,10 +9,10 @@
     "firebase/**/grpc": "^1.16.1"
   },
   "scripts": {
-    "start": "node scripts/start.js",
-    "build": "node scripts/build.js",
+    "start": "npm run clearContracts && node scripts/start.js",
+    "build": "npm run clearContracts && node scripts/build.js",
     "test": "run-s prettier:check 'test:app --all'",
-    "test:ci": "DEV_GANACHE_PORT=8503 run-s prettier:check build 'test:contracts --all --ci' 'test:app --all --ci --runInBand'",
+    "test:ci": "DEV_GANACHE_PORT=8503 clearContracts run-s prettier:check build 'test:contracts --all --ci' 'test:app --all --ci --runInBand'",
     "test:app": "npx run-jest -c ./config/jest/jest.config.js",
     "prettier:check": "npx prettier --check 'src/**/*.{ts,tsx}'",
     "prettier:write": "npx prettier --write 'src/**/*.{ts,tsx}'",
@@ -20,7 +20,8 @@
     "ganache:start": "npx start-ganache",
     "postinstall": "rm -f node_modules/web3/index.d.ts",
     "storybook": "start-storybook -p 9001 -c .storybook",
-    "test:contracts": "npx ganache-then-jest -c ./config/jest/jest.contracts.config.js --runInBand"
+    "test:contracts": "npx ganache-then-jest -c ./config/jest/jest.contracts.config.js --runInBand",
+    "clearContracts": "rm -rf ./build/contracts"
   },
   "dependencies": {
     "@firebase/app-types": "^0.3.2",


### PR DESCRIPTION
Clear contracts before build/start to work around the `error: Returned values aren't valid, did it run Out of Gas?` that truffle generates when  trying to compile with existing artifacts.

I'm confirmed that this issue is present before https://github.com/magmo/apps/pull/368 so it doesn't look related to recent changes. It looks like it might be a bug in web3.js version that truffle is using (see https://github.com/ethereum/web3.js/issues/2492)

I've also looked at upgrading truffle but I saw the same error. I've created #375 in the backlog so we can revisit this and see if a later version of truffle addresses this (or investigate further if we're causing it somehow).

 resolves #371 