### PR TITLE
use function modifiers in the RPS contract

### DIFF
--- a/packages/rps/contracts/RockPaperScissorsGame.sol
+++ b/packages/rps/contracts/RockPaperScissorsGame.sol
@@ -63,14 +63,14 @@ contract RockPaperScissorsGame {
         }
     }
 
-    modifier resolutionsUnchanged(RockPaperScissorsCommitment.RPSCommitmentStruct memory oldCommitment, RockPaperScissorsCommitment.RPSCommitmentStruct memory newCommitment) {
+    modifier allocationsUnchanged(RockPaperScissorsCommitment.RPSCommitmentStruct memory oldCommitment, RockPaperScissorsCommitment.RPSCommitmentStruct memory newCommitment) {
         uint aOldBal = oldCommitment.allocation[0];
         uint bOldBal = oldCommitment.allocation[1];
         uint aNewBal = newCommitment.allocation[0];
         uint bNewBal = newCommitment.allocation[1];
 
-        require(aOldBal == aNewBal,"The resolution for player A must be the same between commitments."); // resolution unchanged
-        require(bOldBal == bNewBal,"The resolution for player B must be the same between commitments."); // resolution unchanged
+        require(aOldBal == aNewBal,"The allocation for player A must be the same between commitments."); 
+        require(bOldBal == bNewBal,"The allocation for player B must be the same between commitments."); 
         _;
     }
 
@@ -79,9 +79,9 @@ contract RockPaperScissorsGame {
         _;
     }
 
-    modifier integerOverflowPrevented(RockPaperScissorsCommitment.RPSCommitmentStruct memory oldCommitment, RockPaperScissorsCommitment.RPSCommitmentStruct memory newCommitment) {
-        require(oldCommitment.allocation[0] >= newCommitment.stake, "The allocation for player A must not fall below the stake (Preventing a integer overflow attack).");
-        require(oldCommitment.allocation[1] >= newCommitment.stake, "The allocation for player B must not fall below the stake (Preventing a integer overflow attack).");
+    modifier allocationsNotLessThanStake(RockPaperScissorsCommitment.RPSCommitmentStruct memory oldCommitment, RockPaperScissorsCommitment.RPSCommitmentStruct memory newCommitment) {
+        require(oldCommitment.allocation[0] >= newCommitment.stake, "The allocation for player A must not fall below the stake.");
+        require(oldCommitment.allocation[1] >= newCommitment.stake, "The allocation for player B must not fall below the stake.");
         _;
     }
 
@@ -89,9 +89,9 @@ contract RockPaperScissorsGame {
     function validateStartToRoundProposed(RockPaperScissorsCommitment.RPSCommitmentStruct memory oldCommitment, RockPaperScissorsCommitment.RPSCommitmentStruct memory newCommitment)
      private
      pure
-     resolutionsUnchanged(oldCommitment, newCommitment)
+     allocationsUnchanged(oldCommitment, newCommitment)
      stakeUnchanged(oldCommitment, newCommitment)
-     integerOverflowPrevented(oldCommitment, newCommitment)
+     allocationsNotLessThanStake(oldCommitment, newCommitment)
      {
         // we should maybe require that aPreCommit isn't empty, but then it will only hurt a later if it is
     }
@@ -99,14 +99,14 @@ contract RockPaperScissorsGame {
     function validateStartToConcluded(RockPaperScissorsCommitment.RPSCommitmentStruct memory oldCommitment, RockPaperScissorsCommitment.RPSCommitmentStruct memory newCommitment)
     private
     pure
-    resolutionsUnchanged(oldCommitment, newCommitment)
+    allocationsUnchanged(oldCommitment, newCommitment)
     stakeUnchanged(oldCommitment, newCommitment)
     { }
 
     function validateRoundProposedToRejected(RockPaperScissorsCommitment.RPSCommitmentStruct memory oldCommitment, RockPaperScissorsCommitment.RPSCommitmentStruct memory newCommitment)
     private
     pure
-    resolutionsUnchanged(oldCommitment, newCommitment)
+    allocationsUnchanged(oldCommitment, newCommitment)
     stakeUnchanged(oldCommitment, newCommitment)
     { }
 
@@ -116,8 +116,8 @@ contract RockPaperScissorsGame {
     stakeUnchanged(oldCommitment, newCommitment)
     {
         // a will have to reveal, so remove the stake beforehand
-        require(newCommitment.allocation[0] == oldCommitment.allocation[0] - oldCommitment.stake,"Resolution for player A should be decremented by 1 stake from the previous commitment.");
-        require(newCommitment.allocation[1] == oldCommitment.allocation[1] + oldCommitment.stake,"Resolution for player B should be incremented by 1 stake from the previous commitment.");
+        require(newCommitment.allocation[0] == oldCommitment.allocation[0] - oldCommitment.stake,"Allocation for player A should be decremented by 1 stake from the previous commitment.");
+        require(newCommitment.allocation[1] == oldCommitment.allocation[1] + oldCommitment.stake,"Allocation for player B should be incremented by 1 stake from the previous commitment.");
         require(newCommitment.preCommit == oldCommitment.preCommit,"Precommit should be the same as the previous commitment.");
     }
 
@@ -128,7 +128,7 @@ contract RockPaperScissorsGame {
     {
         uint256 aWinnings;
         uint256 bWinnings;
-        require(newCommitment.bWeapon == oldCommitment.bWeapon,"Player Bs play should be the same between commitments.");
+        require(newCommitment.bWeapon == oldCommitment.bWeapon,"Player B's weapon should be the same between commitments.");
 
         // check hash matches
         // need to convert Weapon -> uint256 to get hash to work
@@ -138,14 +138,14 @@ contract RockPaperScissorsGame {
         // calculate winnings
         (aWinnings, bWinnings) = winnings(newCommitment.aWeapon, newCommitment.bWeapon, newCommitment.stake);
 
-        require(newCommitment.allocation[0] == oldCommitment.allocation[0] + aWinnings,"Player A's resolution should be updated with the winning");
-        require(newCommitment.allocation[1] == oldCommitment.allocation[1] - 2 * oldCommitment.stake + bWinnings,"Player B's resolution should be updated with the winning");
+        require(newCommitment.allocation[0] == oldCommitment.allocation[0] + aWinnings,"Player A's allocation should be updated with the winnings.");
+        require(newCommitment.allocation[1] == oldCommitment.allocation[1] - 2 * oldCommitment.stake + bWinnings,"Player B's allocation should be updated with the winnings.");
     }
 
     function validateRevealToStart(RockPaperScissorsCommitment.RPSCommitmentStruct memory oldCommitment, RockPaperScissorsCommitment.RPSCommitmentStruct memory newCommitment)
     private
     pure
-    resolutionsUnchanged(oldCommitment, newCommitment)
+    allocationsUnchanged(oldCommitment, newCommitment)
     stakeUnchanged(oldCommitment, newCommitment)
     { }
 }

--- a/packages/rps/contracts/RockPaperScissorsGame.sol
+++ b/packages/rps/contracts/RockPaperScissorsGame.sol
@@ -3,8 +3,10 @@ pragma experimental ABIEncoderV2;
 
 import "fmg-core/contracts/Commitment.sol";
 import "./RockPaperScissorsCommitment.sol";
+import "openzeppelin-solidity/contracts/math/SafeMath.sol";
 
 contract RockPaperScissorsGame {
+    using SafeMath for uint256;
     // The following transitions are allowed:
     //
     // Start -> RoundProposed
@@ -116,8 +118,8 @@ contract RockPaperScissorsGame {
     stakeUnchanged(oldCommitment, newCommitment)
     {
         // a will have to reveal, so remove the stake beforehand
-        require(newCommitment.allocation[0] == oldCommitment.allocation[0] - oldCommitment.stake,"Allocation for player A should be decremented by 1 stake from the previous commitment.");
-        require(newCommitment.allocation[1] == oldCommitment.allocation[1] + oldCommitment.stake,"Allocation for player B should be incremented by 1 stake from the previous commitment.");
+        require(newCommitment.allocation[0] == oldCommitment.allocation[0].sub(oldCommitment.stake),"Allocation for player A should be decremented by 1 stake from the previous commitment.");
+        require(newCommitment.allocation[1] == oldCommitment.allocation[1].add(oldCommitment.stake),"Allocation for player B should be incremented by 1 stake from the previous commitment.");
         require(newCommitment.preCommit == oldCommitment.preCommit,"Precommit should be the same as the previous commitment.");
     }
 
@@ -138,8 +140,8 @@ contract RockPaperScissorsGame {
         // calculate winnings
         (aWinnings, bWinnings) = winnings(newCommitment.aWeapon, newCommitment.bWeapon, newCommitment.stake);
 
-        require(newCommitment.allocation[0] == oldCommitment.allocation[0] + aWinnings,"Player A's allocation should be updated with the winnings.");
-        require(newCommitment.allocation[1] == oldCommitment.allocation[1] - 2 * oldCommitment.stake + bWinnings,"Player B's allocation should be updated with the winnings.");
+        require(newCommitment.allocation[0] == oldCommitment.allocation[0].add(aWinnings),"Player A's allocation should be updated with the winnings.");
+        require(newCommitment.allocation[1] == oldCommitment.allocation[1].sub(oldCommitment.stake.mul(2)).add(bWinnings),"Player B's allocation should be updated with the winnings.");
     }
 
     function validateRevealToStart(RockPaperScissorsCommitment.RPSCommitmentStruct memory oldCommitment, RockPaperScissorsCommitment.RPSCommitmentStruct memory newCommitment)

--- a/packages/rps/package.json
+++ b/packages/rps/package.json
@@ -59,6 +59,7 @@
     "npm-run-all": "4.1.5",
     "object-assign": "4.1.1",
     "object-hash": "^1.3.0",
+    "openzeppelin-solidity": "^2.2.0",
     "promise": "8.0.1",
     "prop-types": "^15.6.2",
     "raf": "3.4.0",

--- a/packages/rps/src/contract-tests/rock-paper-scissors.test.ts
+++ b/packages/rps/src/contract-tests/rock-paper-scissors.test.ts
@@ -89,7 +89,7 @@ describe('Rock paper Scissors', () => {
     );
   });
 
-  it('disallows transitions where the allocations changes incorrectly', async () => {
+  it('disallows transitions where the allocations change incorrectly', async () => {
     const coreCommitment1 = asCoreCommitment(postFundSetupB);
     const coreCommitment2 = asCoreCommitment(propose2);
     expect.assertions(1);
@@ -115,5 +115,25 @@ describe('Rock paper Scissors', () => {
         ),
       'The allocation for player A must not fall below the stake.',
     );
+  });
+
+
+  // The following scenario is highly notional, since the situation should (and is) prevented from occuring at the Propose stage
+  it('Reverts an underflow via SafeMath', async () => {
+    reveal.stake = accept.stake = bigNumberify(20).toHexString();
+    accept.allocation = [bigNumberify(0).toHexString(), bigNumberify(0).toHexString()] as [string, string];
+    reveal.allocation = [bigNumberify(40).toHexString(), bigNumberify(0).toHexString()] as [string, string];
+
+    const coreCommitment1 = asCoreCommitment(accept);
+    const coreCommitment2 = asCoreCommitment(reveal);
+    expect.assertions(1);
+    await expectRevert(
+      () =>
+        rpsContract.validTransition(
+          asEthersObject(coreCommitment1),
+          asEthersObject(coreCommitment2),
+        ),
+      'revert',
+    ); // Note that SafeMath does not have revert messages
   });
 });

--- a/packages/rps/src/contract-tests/rock-paper-scissors.test.ts
+++ b/packages/rps/src/contract-tests/rock-paper-scissors.test.ts
@@ -18,6 +18,7 @@ describe('Rock paper Scissors', () => {
 
   let postFundSetupB: RPSCommitment;
   let propose: RPSCommitment;
+  let propose2: RPSCommitment;
   let accept: RPSCommitment;
   let reveal: RPSCommitment;
   let resting: RPSCommitment;
@@ -33,8 +34,8 @@ describe('Rock paper Scissors', () => {
     const scenario = scenarios.build(libraryAddress, account1.address, account2.address);
     postFundSetupB = scenario.postFundSetupB;
     propose = scenario.propose;
+    propose2 = scenario.propose2;
     accept = scenario.accept;
-
     reveal = scenario.reveal;
     resting = scenario.resting;
   });
@@ -80,6 +81,21 @@ describe('Rock paper Scissors', () => {
           asEthersObject(coreCommitment2),
         ),
       'The stake should be the same between commitments',
+    );
+  });
+
+  it('disallows transitions where resolution changes incorrectly', async () => {
+    reveal.stake = bigNumberify(88).toHexString();
+    const coreCommitment1 = asCoreCommitment(postFundSetupB);
+    const coreCommitment2 = asCoreCommitment(propose2);
+    expect.assertions(1);
+    await expectRevert(
+      () =>
+        rpsContract.validTransition(
+          asEthersObject(coreCommitment1),
+          asEthersObject(coreCommitment2),
+        ),
+      'The resolution for player A must be the same between commitments',
     );
   });
 });

--- a/packages/rps/src/contract-tests/rock-paper-scissors.test.ts
+++ b/packages/rps/src/contract-tests/rock-paper-scissors.test.ts
@@ -17,8 +17,11 @@ describe('Rock paper Scissors', () => {
   let rpsContract;
 
   let postFundSetupB: RPSCommitment;
+  let postFundSetupB2: RPSCommitment;
   let propose: RPSCommitment;
   let propose2: RPSCommitment;
+  let propose3: RPSCommitment;
+
   let accept: RPSCommitment;
   let reveal: RPSCommitment;
   let resting: RPSCommitment;
@@ -33,8 +36,10 @@ describe('Rock paper Scissors', () => {
     const account2 = ethers.Wallet.createRandom();
     const scenario = scenarios.build(libraryAddress, account1.address, account2.address);
     postFundSetupB = scenario.postFundSetupB;
+    postFundSetupB2 = scenario.postFundSetupB2;
     propose = scenario.propose;
     propose2 = scenario.propose2;
+    propose3 = scenario.propose3;
     accept = scenario.accept;
     reveal = scenario.reveal;
     resting = scenario.resting;
@@ -84,8 +89,7 @@ describe('Rock paper Scissors', () => {
     );
   });
 
-  it('disallows transitions where resolution changes incorrectly', async () => {
-    reveal.stake = bigNumberify(88).toHexString();
+  it('disallows transitions where the allocations changes incorrectly', async () => {
     const coreCommitment1 = asCoreCommitment(postFundSetupB);
     const coreCommitment2 = asCoreCommitment(propose2);
     expect.assertions(1);
@@ -95,7 +99,21 @@ describe('Rock paper Scissors', () => {
           asEthersObject(coreCommitment1),
           asEthersObject(coreCommitment2),
         ),
-      'The resolution for player A must be the same between commitments',
+      'The allocation for player A must be the same between commitments',
+    );
+  });
+
+  it('disallows a stake that the players cannot afford', async () => {
+    const coreCommitment1 = asCoreCommitment(postFundSetupB2);
+    const coreCommitment2 = asCoreCommitment(propose3);
+    expect.assertions(1);
+    await expectRevert(
+      () =>
+        rpsContract.validTransition(
+          asEthersObject(coreCommitment1),
+          asEthersObject(coreCommitment2),
+        ),
+      'The allocation for player A must not fall below the stake.',
     );
   });
 });

--- a/packages/rps/src/contract-tests/rock-paper-scissors.test.ts
+++ b/packages/rps/src/contract-tests/rock-paper-scissors.test.ts
@@ -117,12 +117,17 @@ describe('Rock paper Scissors', () => {
     );
   });
 
-
   // The following scenario is highly notional, since the situation should (and is) prevented from occuring at the Propose stage
   it('Reverts an underflow via SafeMath', async () => {
     reveal.stake = accept.stake = bigNumberify(20).toHexString();
-    accept.allocation = [bigNumberify(0).toHexString(), bigNumberify(0).toHexString()] as [string, string];
-    reveal.allocation = [bigNumberify(40).toHexString(), bigNumberify(0).toHexString()] as [string, string];
+    accept.allocation = [bigNumberify(0).toHexString(), bigNumberify(0).toHexString()] as [
+      string,
+      string
+    ];
+    reveal.allocation = [bigNumberify(40).toHexString(), bigNumberify(0).toHexString()] as [
+      string,
+      string
+    ];
 
     const coreCommitment1 = asCoreCommitment(accept);
     const coreCommitment2 = asCoreCommitment(reveal);

--- a/packages/rps/src/core/test-scenarios.ts
+++ b/packages/rps/src/core/test-scenarios.ts
@@ -273,6 +273,13 @@ export function build(
       aWeapon,
       salt,
     }),
+    propose2: commitmentHelper.proposeFromSalt({
+      ...baseWithBuyIn,
+      turnNum: 4,
+      allocation: fourSix,
+      aWeapon,
+      salt,
+    }),
     accept: commitmentHelper.accept({
       ...baseWithBuyIn,
       turnNum: 5,

--- a/packages/rps/src/core/test-scenarios.ts
+++ b/packages/rps/src/core/test-scenarios.ts
@@ -260,6 +260,13 @@ export function build(
       allocation: fiveFive,
       commitmentCount: 1,
     }),
+    postFundSetupB2: commitmentHelper.postFundSetupB({
+      ...baseWithBuyIn,
+      turnNum: 3,
+      allocation: fiveFive,
+      commitmentCount: 1,
+      roundBuyIn: bigNumberify(100).toHexString(),
+    }),
     aWeapon,
     salt,
     preCommit,
@@ -279,6 +286,14 @@ export function build(
       allocation: fourSix,
       aWeapon,
       salt,
+    }),
+    propose3: commitmentHelper.proposeFromSalt({
+      ...baseWithBuyIn,
+      turnNum: 4,
+      allocation: fiveFive,
+      aWeapon,
+      salt,
+      roundBuyIn: bigNumberify(100).toHexString(),
     }),
     accept: commitmentHelper.accept({
       ...baseWithBuyIn,

--- a/packages/rps/yarn.lock
+++ b/packages/rps/yarn.lock
@@ -10073,6 +10073,11 @@ onetime@^2.0.0:
   dependencies:
     mimic-fn "^1.0.0"
 
+openzeppelin-solidity@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/openzeppelin-solidity/-/openzeppelin-solidity-2.2.0.tgz#1f0e857f53bda29b77a8e72f9a629db81015fd34"
+  integrity sha512-HfQq0xyT+EPs/lTWEd5Odu4T7CYdYe+qwf54EH28FQZthp4Bs6IWvOlOumTdS2dvpwZoTXURAopHn2LN1pwAGQ==
+
 opn@5.4.0, opn@^5.1.0, opn@^5.4.0:
   version "5.4.0"
   resolved "https://registry.yarnpkg.com/opn/-/opn-5.4.0.tgz#cb545e7aab78562beb11aa3bfabc7042e1761035"


### PR DESCRIPTION
This should mean less code duplication, and make it slightly easier to audit the contract. It was also an excuse to revisit the contract tests: I added one for resolutions being changed incorrectly. I was about to do the same for the 'integer overflow prevented' check, but realised that I did not understand why it has the name it does.

It seems clear that both players should have enough funds to pay the stake to the winner if they lose -- but the message in the relevant `require` statement wasn't doing much justice to that. 

Can anyone enlighten me about the overflow? If a user's allocation has overflowed, it seems to me that we have far bigger problems than safely starting a new game...