### PR TITLE
Fix Jest All debug config

### DIFF
--- a/packages/wallet/.vscode/launch.json
+++ b/packages/wallet/.vscode/launch.json
@@ -7,7 +7,12 @@
       "name": "Jest All",
       "type": "node",
       "request": "launch",
-      "args": ["scripts/test.js", "--runInBand", "--no-cache", "--env=jsdom"],
+      "args": [
+        "node_modules/.bin/jest",
+        "--runInBand",
+        "--env=jsdom",
+        "--config=${workspaceRoot}/config/jest/jest.config.js",
+      ],
       "cwd": "${workspaceRoot}",
       "protocol": "inspector",
       "console": "integratedTerminal",


### PR DESCRIPTION
Fix the jest all debug entry in launch.json (since there is no `scripts/test.js`)