### PR TITLE
De-Funding Protocol

### DIFF
--- a/packages/wallet/src/__stories__/b-dummy-wallet-states.ts
+++ b/packages/wallet/src/__stories__/b-dummy-wallet-states.ts
@@ -56,6 +56,7 @@ const defaultInitialized: walletStates.Initialized = walletStates.initialized({
   outboxState: emptyDisplayOutboxState(),
   adjudicatorState: {},
   processStore: {},
+  fundingState: {},
 });
 
 ////////////////////////////////////////////////

--- a/packages/wallet/src/redux/protocols/defunding/__tests__/reducer.test.ts
+++ b/packages/wallet/src/redux/protocols/defunding/__tests__/reducer.test.ts
@@ -1,0 +1,78 @@
+import * as states from '../state';
+import { initialize, defundingReducer } from '../reducer';
+import * as scenarios from './scenarios';
+
+const itTransitionsTo = (result: { protocolState: states.DefundingState }, type: string) => {
+  it(`transitions to ${type}`, () => {
+    expect(result.protocolState.type).toEqual(type);
+  });
+};
+
+const itTransitionsToFailure = (
+  result: { protocolState: states.DefundingState },
+  failure: states.Failure,
+) => {
+  it(`transitions to failure with reason ${failure.reason}`, () => {
+    expect(result.protocolState).toMatchObject(failure);
+  });
+};
+
+describe('directly funded happy path', () => {
+  const scenario = scenarios.directlyFundingChannelHappyPath;
+  const { processId, sharedData } = scenario;
+
+  describe('when initializing', () => {
+    const result = initialize(processId, sharedData);
+    itTransitionsTo(result, states.WAIT_FOR_WITHDRAWAL);
+  });
+  describe(`when in ${states.WAIT_FOR_WITHDRAWAL}`, () => {
+    const state = scenario.waitForWithdrawalStart;
+    const action = scenario.withdrawalSuccessAction;
+    const result = defundingReducer(state, sharedData, action);
+
+    itTransitionsTo(result, states.SUCCESS);
+  });
+});
+
+describe('directly funded failure', () => {
+  const scenario = scenarios.directlyFundingFailure;
+  const { sharedData } = scenario;
+
+  describe(`when in ${states.WAIT_FOR_WITHDRAWAL}`, () => {
+    const state = scenario.waitForWithdrawalStart;
+    const action = scenario.withdrawalFailureAction;
+    const result = defundingReducer(state, sharedData, action);
+
+    itTransitionsToFailure(result, scenario.failure);
+  });
+});
+
+describe('indirectly funded happy path', () => {
+  const scenario = scenarios.indirectlyFundingChannelHappyPath;
+  const { processId, sharedData } = scenario;
+
+  describe('when initializing', () => {
+    const result = initialize(processId, sharedData);
+    itTransitionsTo(result, states.WAIT_FOR_LEDGER_DEFUNDING);
+  });
+  describe(`when in ${states.WAIT_FOR_LEDGER_DEFUNDING}`, () => {
+    const state = scenario.waitForLedgerDefundingStart;
+    const action = scenario.ledgerDefundingSuccessAction;
+    const result = defundingReducer(state, sharedData, action);
+
+    itTransitionsTo(result, states.SUCCESS);
+  });
+});
+
+describe('indirectly funded failure', () => {
+  const scenario = scenarios.indirectlyFundingFailure;
+  const { sharedData } = scenario;
+
+  describe(`when in ${states.WAIT_FOR_LEDGER_DEFUNDING}`, () => {
+    const state = scenario.waitForLedgerDefundingStart;
+    const action = scenario.ledgerDefundingFailureAction;
+    const result = defundingReducer(state, sharedData, action);
+
+    itTransitionsToFailure(result, scenario.failure);
+  });
+});

--- a/packages/wallet/src/redux/protocols/defunding/__tests__/reducer.test.ts
+++ b/packages/wallet/src/redux/protocols/defunding/__tests__/reducer.test.ts
@@ -19,14 +19,14 @@ const itTransitionsToFailure = (
 
 describe('directly funded happy path', () => {
   const scenario = scenarios.directlyFundingChannelHappyPath;
-  const { processId, sharedData } = scenario;
+  const { processId, channelId, sharedData } = scenario;
 
   describe('when initializing', () => {
-    const result = initialize(processId, sharedData);
+    const result = initialize(processId, channelId, sharedData);
     itTransitionsTo(result, states.WAIT_FOR_WITHDRAWAL);
   });
   describe(`when in ${states.WAIT_FOR_WITHDRAWAL}`, () => {
-    const state = scenario.waitForWithdrawalStart;
+    const state = scenario.waitForWithdrawal;
     const action = scenario.withdrawalSuccessAction;
     const result = defundingReducer(state, sharedData, action);
 
@@ -39,7 +39,7 @@ describe('directly funded failure', () => {
   const { sharedData } = scenario;
 
   describe(`when in ${states.WAIT_FOR_WITHDRAWAL}`, () => {
-    const state = scenario.waitForWithdrawalStart;
+    const state = scenario.waitForWithdrawal;
     const action = scenario.withdrawalFailureAction;
     const result = defundingReducer(state, sharedData, action);
 
@@ -47,32 +47,42 @@ describe('directly funded failure', () => {
   });
 });
 
-describe('indirectly funded happy path', () => {
-  const scenario = scenarios.indirectlyFundingChannelHappyPath;
-  const { processId, sharedData } = scenario;
-
+describe('channel not closed', () => {
+  const scenario = scenarios.channelNotClosed;
+  const { sharedData, processId, channelId } = scenario;
   describe('when initializing', () => {
-    const result = initialize(processId, sharedData);
-    itTransitionsTo(result, states.WAIT_FOR_LEDGER_DEFUNDING);
-  });
-  describe(`when in ${states.WAIT_FOR_LEDGER_DEFUNDING}`, () => {
-    const state = scenario.waitForLedgerDefundingStart;
-    const action = scenario.ledgerDefundingSuccessAction;
-    const result = defundingReducer(state, sharedData, action);
-
-    itTransitionsTo(result, states.SUCCESS);
-  });
-});
-
-describe('indirectly funded failure', () => {
-  const scenario = scenarios.indirectlyFundingFailure;
-  const { sharedData } = scenario;
-
-  describe(`when in ${states.WAIT_FOR_LEDGER_DEFUNDING}`, () => {
-    const state = scenario.waitForLedgerDefundingStart;
-    const action = scenario.ledgerDefundingFailureAction;
-    const result = defundingReducer(state, sharedData, action);
+    const result = initialize(processId, channelId, sharedData);
 
     itTransitionsToFailure(result, scenario.failure);
   });
 });
+// TODO: These tests rely on ledger de-funding being completed
+// describe('indirectly funded happy path', () => {
+//   const scenario = scenarios.indirectlyFundingChannelHappyPath;
+//   const { processId, channelId, sharedData } = scenario;
+
+//   describe('when initializing', () => {
+//     const result = initialize(processId, channelId, sharedData);
+//     itTransitionsTo(result, states.WAIT_FOR_LEDGER_DEFUNDING);
+//   });
+//   describe(`when in ${states.WAIT_FOR_LEDGER_DEFUNDING}`, () => {
+//     const state = scenario.waitForLedgerDefunding;
+//     const action = scenario.ledgerDefundingSuccessAction;
+//     const result = defundingReducer(state, sharedData, action);
+
+//     itTransitionsTo(result, states.SUCCESS);
+//   });
+// });
+
+// describe('indirectly funded failure', () => {
+//   const scenario = scenarios.indirectlyFundingFailure;
+//   const { sharedData } = scenario;
+
+//   describe(`when in ${states.WAIT_FOR_LEDGER_DEFUNDING}`, () => {
+//     const state = scenario.waitForLedgerDefunding;
+//     const action = scenario.ledgerDefundingFailureAction;
+//     const result = defundingReducer(state, sharedData, action);
+
+//     itTransitionsToFailure(result, scenario.failure);
+//   });
+// });

--- a/packages/wallet/src/redux/protocols/defunding/__tests__/scenarios.ts
+++ b/packages/wallet/src/redux/protocols/defunding/__tests__/scenarios.ts
@@ -1,0 +1,156 @@
+import * as states from '../state';
+import * as withdrawalScenarios from '../../withdrawing/__tests__/scenarios';
+import * as testScenarios from '../../../__tests__/test-scenarios';
+import {
+  ChannelStatus,
+  RUNNING,
+  WAIT_FOR_UPDATE,
+  ChannelState,
+} from '../../../channel-state/state';
+const processId = 'process-id.123';
+
+const {
+  asAddress: address,
+  asPrivateKey: privateKey,
+  channelId,
+  libraryAddress,
+  participants,
+  channelNonce,
+  concludeCommitment1,
+  concludeCommitment2,
+  gameCommitment1,
+  gameCommitment2,
+} = testScenarios;
+
+const channelStatus: ChannelStatus = {
+  address,
+  privateKey,
+  stage: RUNNING,
+  type: WAIT_FOR_UPDATE,
+  channelId,
+  libraryAddress,
+  ourIndex: 0,
+  participants,
+  channelNonce,
+  turnNum: concludeCommitment2.turnNum,
+  funded: true,
+  lastCommitment: { commitment: concludeCommitment2, signature: '0x0' },
+  penultimateCommitment: { commitment: concludeCommitment1, signature: '0x0' },
+};
+
+const channelState: ChannelState = {
+  initializingChannels: {},
+  initializedChannels: {
+    [channelId]: channelStatus,
+  },
+};
+
+const notClosedChannelStatus = {
+  ...channelStatus,
+  lastCommitment: { commitment: gameCommitment2, signature: '0x0' },
+  penultimateCommitment: { commitment: gameCommitment1, signature: '0x0' },
+  turnNum: gameCommitment2.turnNum,
+};
+
+const notClosedChannelState = {
+  initializingChannels: {},
+  initializedChannels: {
+    [channelId]: notClosedChannelStatus,
+  },
+};
+
+const directlyFundedFundingState = {
+  [testScenarios.channelId]: {
+    directlyFunded: true,
+  },
+};
+const indirectlyFundedFundingState = {
+  [testScenarios.channelId]: {
+    directlyFunded: false,
+    fundingChannel: '0x0',
+  },
+};
+const waitForWithdrawalStart = states.waitForWithdrawal({
+  processId,
+  withdrawalState: withdrawalScenarios.happyPath.waitForApproval,
+});
+
+const waitForWithdrawalSuccess = states.waitForWithdrawal({
+  processId,
+  withdrawalState: withdrawalScenarios.happyPath.success,
+});
+
+const waitForWithdrawalFailure = states.waitForWithdrawal({
+  processId,
+  withdrawalState: withdrawalScenarios.failedTransaction.failure,
+});
+
+const waitForLedgerDefundingStart = states.waitForLedgerDefunding({
+  processId,
+  ledgerDefundingState: 'InProgress',
+});
+
+const waitForLedgerDefundingSuccess = states.waitForLedgerDefunding({
+  processId,
+  ledgerDefundingState: 'Success',
+});
+
+const waitForLedgerDefundingFailure = states.waitForLedgerDefunding({
+  processId,
+  ledgerDefundingState: 'Failure',
+});
+
+const success = states.success();
+const channelNotClosedFailure = states.failure('Channel Not Closed');
+const withdrawalFailure = states.failure('Withdrawal Failure');
+const ledgerDefundingFailure = states.failure('Ledger De-funding Failure');
+
+export const directlyFundingChannelHappyPath = {
+  // States
+  waitForWithdrawalStart,
+  waitForWithdrawalSuccess,
+  success,
+  // Shared data
+  directlyFundedFundingState,
+  channelState,
+};
+
+export const indirectlyFundingChannelHappyPath = {
+  // States
+  waitForLedgerDefundingStart,
+  waitForLedgerDefundingSuccess,
+  success,
+  // Shared data
+  indirectlyFundedFundingState,
+  channelState,
+};
+
+export const channelNotClosed = {
+  // States
+  waitForWithdrawalStart,
+  waitForWithdrawalSuccess,
+  failure: channelNotClosedFailure,
+  // Shared Data
+  directlyFundedFundingState,
+  notClosedChannelState,
+};
+
+export const directlyFundingFailure = {
+  // States
+  waitForWithdrawalStart,
+  waitForWithdrawalFailure,
+  failure: withdrawalFailure,
+  // Shared Data
+  directlyFundedFundingState,
+  channelState,
+};
+
+export const indirectlyFundingFailure = {
+  // States
+  waitForLedgerDefundingStart,
+  waitForLedgerDefundingFailure,
+  failure: ledgerDefundingFailure,
+  // Shared data
+  indirectlyFundedFundingState,
+  channelState,
+};

--- a/packages/wallet/src/redux/protocols/defunding/__tests__/scenarios.ts
+++ b/packages/wallet/src/redux/protocols/defunding/__tests__/scenarios.ts
@@ -7,6 +7,8 @@ import {
   WAIT_FOR_UPDATE,
   ChannelState,
 } from '../../../channel-state/state';
+import { EMPTY_SHARED_DATA, FundingState } from '../../../state';
+
 const processId = 'process-id.123';
 
 const {
@@ -59,7 +61,7 @@ const notClosedChannelState = {
   },
 };
 
-const directlyFundedFundingState = {
+const directlyFundedFundingState: FundingState = {
   [testScenarios.channelId]: {
     directlyFunded: true,
   },
@@ -106,23 +108,35 @@ const withdrawalFailure = states.failure('Withdrawal Failure');
 const ledgerDefundingFailure = states.failure('Ledger De-funding Failure');
 
 export const directlyFundingChannelHappyPath = {
+  processId,
   // States
   waitForWithdrawalStart,
   waitForWithdrawalSuccess,
   success,
+  // actions
+  withdrawalSuccessAction: withdrawalScenarios.happyPath.transactionConfirmed,
   // Shared data
-  directlyFundedFundingState,
-  channelState,
+  sharedData: {
+    ...EMPTY_SHARED_DATA,
+    fundingState: directlyFundedFundingState,
+    channelState,
+  },
 };
 
 export const indirectlyFundingChannelHappyPath = {
+  processId,
   // States
   waitForLedgerDefundingStart,
   waitForLedgerDefundingSuccess,
   success,
+  // actions
+  ledgerDefundingSuccessAction: withdrawalScenarios.happyPath.transactionConfirmed,
   // Shared data
-  indirectlyFundedFundingState,
-  channelState,
+  sharedData: {
+    ...EMPTY_SHARED_DATA,
+    fundingState: indirectlyFundedFundingState,
+    channelState,
+  },
 };
 
 export const channelNotClosed = {
@@ -130,9 +144,12 @@ export const channelNotClosed = {
   waitForWithdrawalStart,
   waitForWithdrawalSuccess,
   failure: channelNotClosedFailure,
-  // Shared Data
-  directlyFundedFundingState,
-  notClosedChannelState,
+  // Shared data
+  sharedData: {
+    ...EMPTY_SHARED_DATA,
+    fundingState: directlyFundedFundingState,
+    channelState: notClosedChannelState,
+  },
 };
 
 export const directlyFundingFailure = {
@@ -140,9 +157,14 @@ export const directlyFundingFailure = {
   waitForWithdrawalStart,
   waitForWithdrawalFailure,
   failure: withdrawalFailure,
-  // Shared Data
-  directlyFundedFundingState,
-  channelState,
+  // actions
+  withdrawalFailureAction: withdrawalScenarios.withdrawalRejected.rejected,
+  // shared data
+  sharedData: {
+    ...EMPTY_SHARED_DATA,
+    fundingState: directlyFundedFundingState,
+    channelState,
+  },
 };
 
 export const indirectlyFundingFailure = {
@@ -150,7 +172,12 @@ export const indirectlyFundingFailure = {
   waitForLedgerDefundingStart,
   waitForLedgerDefundingFailure,
   failure: ledgerDefundingFailure,
+  // actions
+  ledgerDefundingFailureAction: withdrawalScenarios.failedTransaction.transactionFailed,
   // Shared data
-  indirectlyFundedFundingState,
-  channelState,
+  sharedData: {
+    ...EMPTY_SHARED_DATA,
+    fundingState: indirectlyFundedFundingState,
+    channelState,
+  },
 };

--- a/packages/wallet/src/redux/protocols/defunding/__tests__/scenarios.ts
+++ b/packages/wallet/src/redux/protocols/defunding/__tests__/scenarios.ts
@@ -72,34 +72,18 @@ const indirectlyFundedFundingState = {
     fundingChannel: '0x0',
   },
 };
-const waitForWithdrawalStart = states.waitForWithdrawal({
+const waitForWithdrawal = states.waitForWithdrawal({
   processId,
-  withdrawalState: withdrawalScenarios.happyPath.waitForApproval,
+  withdrawalState: withdrawalScenarios.happyPath.waitForAcknowledgement,
 });
-
-const waitForWithdrawalSuccess = states.waitForWithdrawal({
-  processId,
-  withdrawalState: withdrawalScenarios.happyPath.success,
-});
-
 const waitForWithdrawalFailure = states.waitForWithdrawal({
   processId,
-  withdrawalState: withdrawalScenarios.failedTransaction.failure,
+  withdrawalState: withdrawalScenarios.withdrawalRejected.waitForApproval,
 });
 
-const waitForLedgerDefundingStart = states.waitForLedgerDefunding({
-  processId,
-  ledgerDefundingState: 'InProgress',
-});
-
-const waitForLedgerDefundingSuccess = states.waitForLedgerDefunding({
+const waitForLedgerDefunding = states.waitForLedgerDefunding({
   processId,
   ledgerDefundingState: 'Success',
-});
-
-const waitForLedgerDefundingFailure = states.waitForLedgerDefunding({
-  processId,
-  ledgerDefundingState: 'Failure',
 });
 
 const success = states.success();
@@ -109,12 +93,12 @@ const ledgerDefundingFailure = states.failure('Ledger De-funding Failure');
 
 export const directlyFundingChannelHappyPath = {
   processId,
+  channelId,
   // States
-  waitForWithdrawalStart,
-  waitForWithdrawalSuccess,
+  waitForWithdrawal,
   success,
   // actions
-  withdrawalSuccessAction: withdrawalScenarios.happyPath.transactionConfirmed,
+  withdrawalSuccessAction: withdrawalScenarios.happyPath.successAcknowledged,
   // Shared data
   sharedData: {
     ...EMPTY_SHARED_DATA,
@@ -125,9 +109,9 @@ export const directlyFundingChannelHappyPath = {
 
 export const indirectlyFundingChannelHappyPath = {
   processId,
+  channelId,
   // States
-  waitForLedgerDefundingStart,
-  waitForLedgerDefundingSuccess,
+  waitForLedgerDefunding,
   success,
   // actions
   ledgerDefundingSuccessAction: withdrawalScenarios.happyPath.transactionConfirmed,
@@ -140,9 +124,10 @@ export const indirectlyFundingChannelHappyPath = {
 };
 
 export const channelNotClosed = {
+  processId,
+  channelId,
   // States
-  waitForWithdrawalStart,
-  waitForWithdrawalSuccess,
+  waitForWithdrawal,
   failure: channelNotClosedFailure,
   // Shared data
   sharedData: {
@@ -153,9 +138,10 @@ export const channelNotClosed = {
 };
 
 export const directlyFundingFailure = {
+  processId,
+  channelId,
   // States
-  waitForWithdrawalStart,
-  waitForWithdrawalFailure,
+  waitForWithdrawal: waitForWithdrawalFailure,
   failure: withdrawalFailure,
   // actions
   withdrawalFailureAction: withdrawalScenarios.withdrawalRejected.rejected,
@@ -168,9 +154,10 @@ export const directlyFundingFailure = {
 };
 
 export const indirectlyFundingFailure = {
+  processId,
+  channelId,
   // States
-  waitForLedgerDefundingStart,
-  waitForLedgerDefundingFailure,
+  waitForLedgerDefunding,
   failure: ledgerDefundingFailure,
   // actions
   ledgerDefundingFailureAction: withdrawalScenarios.failedTransaction.transactionFailed,

--- a/packages/wallet/src/redux/protocols/defunding/actions.ts
+++ b/packages/wallet/src/redux/protocols/defunding/actions.ts
@@ -1,4 +1,5 @@
 import { WithdrawalAction } from '../withdrawing/actions';
+import { TransactionConfirmed } from '../transaction-submission/actions';
 // TODO: Replace once ledger defunding actions are defined
-type LedgerDefundingAction = any;
+type LedgerDefundingAction = TransactionConfirmed;
 export type DefundingAction = WithdrawalAction | LedgerDefundingAction;

--- a/packages/wallet/src/redux/protocols/defunding/actions.ts
+++ b/packages/wallet/src/redux/protocols/defunding/actions.ts
@@ -1,0 +1,4 @@
+import { WithdrawalAction } from '../withdrawing/actions';
+// TODO: Replace once ledger defunding actions are defined
+type LedgerDefundingAction = any;
+export type DefundingAction = WithdrawalAction | LedgerDefundingAction;

--- a/packages/wallet/src/redux/protocols/defunding/container.tsx
+++ b/packages/wallet/src/redux/protocols/defunding/container.tsx
@@ -1,0 +1,31 @@
+import * as states from './state';
+import { PureComponent } from 'react';
+import { Withdrawal } from '../withdrawing/container';
+import React from 'react';
+import Failure from '../shared-components/failure';
+import Success from '../shared-components/success';
+import { connect } from 'react-redux';
+
+interface Props {
+  state: states.DefundingState;
+}
+
+class DefundingContainer extends PureComponent<Props> {
+  render() {
+    const { state } = this.props;
+    switch (state.type) {
+      case states.WAIT_FOR_WITHDRAWAL:
+        return <Withdrawal state={state.withdrawalState} />;
+      case states.WAIT_FOR_LEDGER_DEFUNDING:
+        return <div>TODO: Ledger defunding container</div>;
+      case states.FAILURE:
+        return <Failure name="de-funding" reason={state.reason} />;
+      case states.SUCCESS:
+        return <Success name="de-funding" />;
+    }
+  }
+}
+export const Defunding = connect(
+  () => ({}),
+  () => ({}),
+)(DefundingContainer);

--- a/packages/wallet/src/redux/protocols/defunding/readme.md
+++ b/packages/wallet/src/redux/protocols/defunding/readme.md
@@ -15,8 +15,8 @@ graph TD
   S((start))-->ICC{Is Channel Closed}
   ICC-->|No|F((failure))
   ICC-->|Yes|ID{Is Direct Channel}
-  ID-->|Yes|WP((Withdrawing Protocol))
-  ID -->|No|LDP((Ledger De-funding Protocol))
+  ID-->|Yes|WP(Wait for Withdrawal)
+  ID -->|No|LDP(Wait for Ledger De-funding)
   WP-->|Withdrawal protocol success|Su((success))
   LDP-->|Ledger de-funding protocol success|Su((success))
   WP-->|Withdrawal protocol failure|F((failure))
@@ -29,8 +29,8 @@ graph TD
 
 ## Scenarios
 
-1. **Directly Funded Channel Happy Path** - Start -> Is Channel Closed -> Yes-> Is Direct Channel -> Yes -> Withdrawing Protocol->Withdrawal Protocol Complete -> Success
-2. **Ledger Funded Channel Happy Path** - Start -> Is Channel Closed -> Yes-> Is Direct Channel -> No -> Ledger de-funding Protocol->Ledger de-funding Protocol Complete -> Success
+1. **Directly Funded Channel Happy Path** - Start -> Is Channel Closed -> Yes-> Is Direct Channel -> Yes -> Wait for Withdrawal->Withdrawal Protocol Complete -> Success
+2. **Ledger Funded Channel Happy Path** - Start -> Is Channel Closed -> Yes-> Is Direct Channel -> No -> Wait for Ledger de-funding -> Ledger de-funding Protocol Complete -> Success
 3. **Channel Not Closed** - Start -> Is Channel Closed -> No -> Failure
-4. **Withdrawal Failure** - Start -> Is Channel Closed -> Yes -> Is Direct Channel -> Yes -> Withdrawing Protocol-> Withdrawal Protocol Failure -> Failure
-5. **Ledger de-funding Failure** - Start -> Is Channel Closed -> Yes-> Is Direct Channel -> No -> Ledger de-funding Protocol->Ledger de-funding Protocol Failure -> Failure
+4. **Withdrawal Failure** - Start -> Is Channel Closed -> Yes -> Is Direct Channel -> Yes -> Wait for Withdrawal-> Withdrawal Protocol Failure -> Failure
+5. **Ledger de-funding Failure** - Start -> Is Channel Closed -> Yes-> Is Direct Channel -> No ->Wait for Ledger de-funding->Ledger de-funding Protocol Failure -> Failure

--- a/packages/wallet/src/redux/protocols/defunding/readme.md
+++ b/packages/wallet/src/redux/protocols/defunding/readme.md
@@ -1,0 +1,36 @@
+# De-Funding Protocol
+
+This protocol handles de-funding a channel. It includes:
+
+- Checking to see that a channel is finalized (either concluded or finalized on chain)
+- If a direct channel, initiates the withdrawal protocol.
+- Monitoring the blockchain for a response or timeout.
+
+## State machine
+
+The protocol is implemented with the following state machine
+
+```mermaid
+graph TD
+  S((start))-->ICC{Is Channel Closed}
+  ICC-->|No|F((failure))
+  ICC-->|Yes|ID{Is Direct Channel}
+  ID-->|Yes|WP((Withdrawing Protocol))
+  ID -->|No|LDP((Ledger De-funding Protocol))
+  WP-->|Withdrawal protocol success|Su((success))
+  LDP-->|Ledger de-funding protocol success|Su((success))
+  WP-->|Withdrawal protocol failure|F((failure))
+  LDP-->|Ledger de-funding protocol failure|F((failure))
+```
+
+## Notes
+
+- Withdrawal Complete/Failure and Ledger de-funding Complete/Failure are not actions. They are checks on the sub-protocol state to see if success/failure has been reached.
+
+## Scenarios
+
+1. **Directly Funded Channel Happy Path** - Start -> Is Channel Closed -> Yes-> Is Direct Channel -> Yes -> Withdrawing Protocol->Withdrawal Protocol Complete -> Success
+2. **Ledger Funded Channel Happy Path** - Start -> Is Channel Closed -> Yes-> Is Direct Channel -> No -> Ledger de-funding Protocol->Ledger de-funding Protocol Complete -> Success
+3. **Channel Not Closed** - Start -> Is Channel Closed -> No -> Failure
+4. **Withdrawal Failure** - Start -> Is Channel Closed -> Yes -> Is Direct Channel -> Yes -> Withdrawing Protocol-> Withdrawal Protocol Failure -> Failure
+5. **Ledger de-funding Failure** - Start -> Is Channel Closed -> Yes-> Is Direct Channel -> No -> Ledger de-funding Protocol->Ledger de-funding Protocol Failure -> Failure

--- a/packages/wallet/src/redux/protocols/defunding/reducer.ts
+++ b/packages/wallet/src/redux/protocols/defunding/reducer.ts
@@ -2,12 +2,31 @@ import { SharedData } from '../../state';
 import { ProtocolStateWithSharedData } from '..';
 import * as states from './state';
 import { DefundingAction } from './actions';
+import * as helpers from '../helpers';
+import { withdrawalReducer, initialize as withdrawalInitialize } from './../withdrawing/reducer';
+import * as selectors from '../../selectors';
+import * as actions from './actions';
+import { isWithdrawalAction } from '../withdrawing/actions';
+import { SUCCESS, FAILURE } from '../withdrawing/states';
+import { unreachable } from '../../../utils/reducer-utils';
 
 export const initialize = (
   processId: string,
+  channelId: string,
   sharedData: SharedData,
 ): ProtocolStateWithSharedData<states.DefundingState> => {
-  return { protocolState: states.success(), sharedData };
+  if (!helpers.channelIsClosed(channelId, sharedData)) {
+    return { protocolState: states.failure('Channel Not Closed'), sharedData };
+  }
+  if (helpers.isChannelDirectlyFunded(channelId, sharedData)) {
+    return createWaitForWithdrawal(sharedData, processId, channelId);
+  } else {
+    const protocolState = states.waitForLedgerDefunding({
+      processId,
+      ledgerDefundingState: 'Started',
+    });
+    return { protocolState, sharedData };
+  }
 };
 
 export const defundingReducer = (
@@ -15,5 +34,71 @@ export const defundingReducer = (
   sharedData: SharedData,
   action: DefundingAction,
 ): ProtocolStateWithSharedData<states.DefundingState> => {
+  switch (protocolState.type) {
+    case states.WAIT_FOR_WITHDRAWAL:
+      return waitForWithdrawalReducer(protocolState, sharedData, action);
+    case states.FAILURE:
+    case states.SUCCESS:
+    case states.WAIT_FOR_LEDGER_DEFUNDING:
+      return { protocolState, sharedData };
+    default:
+      return unreachable(protocolState);
+  }
   return { protocolState, sharedData };
+};
+
+const waitForWithdrawalReducer = (
+  protocolState: states.WaitForWithdrawal,
+  sharedData: SharedData,
+  action: actions.DefundingAction,
+) => {
+  if (!isWithdrawalAction(action)) {
+    return { protocolState, sharedData };
+  }
+  const { protocolState: newWithdrawalState, sharedData: newSharedData } = withdrawalReducer(
+    protocolState.withdrawalState,
+    sharedData,
+    action,
+  );
+  if (newWithdrawalState.type === SUCCESS) {
+    return {
+      protocolState: states.success(),
+      sharedData: newSharedData,
+    };
+  } else if (newWithdrawalState.type === FAILURE) {
+    return {
+      protocolState: states.failure('Withdrawal Failure'),
+      sharedData: newSharedData,
+    };
+  } else {
+    return {
+      protocolState: states.waitForWithdrawal({
+        ...protocolState,
+        withdrawalState: newWithdrawalState,
+      }),
+      sharedData: newSharedData,
+    };
+  }
+};
+
+const createWaitForWithdrawal = (sharedData: SharedData, processId: string, channelId: string) => {
+  const withdrawalAmount = getWithdrawalAmount(sharedData, channelId);
+
+  const { protocolState: withdrawalState, sharedData: newSharedData } = withdrawalInitialize(
+    withdrawalAmount,
+    channelId,
+    processId,
+    sharedData,
+  );
+
+  const protocolState = states.waitForWithdrawal({
+    processId,
+    withdrawalState,
+  });
+
+  return { protocolState, sharedData: newSharedData };
+};
+const getWithdrawalAmount = (sharedData: SharedData, channelId: string) => {
+  const channelState = selectors.getChannelState(sharedData, channelId);
+  return channelState.lastCommitment.commitment.allocation[channelState.ourIndex];
 };

--- a/packages/wallet/src/redux/protocols/defunding/reducer.ts
+++ b/packages/wallet/src/redux/protocols/defunding/reducer.ts
@@ -1,0 +1,19 @@
+import { SharedData } from '../../state';
+import { ProtocolStateWithSharedData } from '..';
+import * as states from './state';
+import { DefundingAction } from './actions';
+
+export const initialize = (
+  processId: string,
+  sharedData: SharedData,
+): ProtocolStateWithSharedData<states.DefundingState> => {
+  return { protocolState: states.success(), sharedData };
+};
+
+export const defundingReducer = (
+  protocolState: states.DefundingState,
+  sharedData: SharedData,
+  action: DefundingAction,
+): ProtocolStateWithSharedData<states.DefundingState> => {
+  return { protocolState, sharedData };
+};

--- a/packages/wallet/src/redux/protocols/defunding/state.ts
+++ b/packages/wallet/src/redux/protocols/defunding/state.ts
@@ -1,0 +1,68 @@
+import { WithdrawalState } from '../withdrawing/states';
+import { Properties } from '../../utils';
+
+export const WAIT_FOR_WITHDRAWAL = 'WaitForWithdrawal';
+export const WAIT_FOR_LEDGER_DEFUNDING = 'WaitForLedgerDefunding';
+export const FAILURE = 'Failure';
+export const SUCCESS = 'Success';
+
+export type DefundingState = WaitForWithdrawal | WaitForLedgerDefunding | Failure | Success;
+
+export type FailureReason =
+  | 'Withdrawal Failure'
+  | 'Ledger De-funding Failure'
+  | 'Channel Not Closed';
+
+export interface WaitForWithdrawal {
+  type: typeof WAIT_FOR_WITHDRAWAL;
+  processId: string;
+  withdrawalState: WithdrawalState;
+}
+
+export interface WaitForLedgerDefunding {
+  type: typeof WAIT_FOR_LEDGER_DEFUNDING;
+  processId: string;
+  // TODO: This will be typed to Ledger Defunding state when it exists
+  ledgerDefundingState: any;
+}
+
+export interface Failure {
+  type: typeof FAILURE;
+  reason: string;
+}
+
+export interface Success {
+  type: typeof SUCCESS;
+}
+
+// -------
+// Helpers
+// -------
+
+export function isTerminal(state: DefundingState): state is Failure | Success {
+  return state.type === FAILURE || state.type === SUCCESS;
+}
+
+// -------
+// Constructors
+// -------
+
+export function waitForWithdrawal(properties: Properties<WaitForWithdrawal>): WaitForWithdrawal {
+  const { processId, withdrawalState } = properties;
+  return { type: WAIT_FOR_WITHDRAWAL, processId, withdrawalState };
+}
+
+export function waitForLedgerDefunding(
+  properties: Properties<WaitForLedgerDefunding>,
+): WaitForLedgerDefunding {
+  const { processId, ledgerDefundingState } = properties;
+  return { type: WAIT_FOR_LEDGER_DEFUNDING, processId, ledgerDefundingState };
+}
+
+export function success(): Success {
+  return { type: SUCCESS };
+}
+
+export function failure(reason: FailureReason): Failure {
+  return { type: FAILURE, reason };
+}

--- a/packages/wallet/src/redux/protocols/helpers.ts
+++ b/packages/wallet/src/redux/protocols/helpers.ts
@@ -1,0 +1,32 @@
+import * as selectors from '../selectors';
+import { SharedData } from '../state';
+import { CommitmentType } from 'magmo-wallet-client/node_modules/fmg-core';
+
+export const channelIsClosed = (channelId: string, sharedData: SharedData): boolean => {
+  return (
+    channelHasConclusionProof(channelId, sharedData) ||
+    channelFinalizedOnChain(channelId, sharedData)
+  );
+};
+
+export const channelHasConclusionProof = (channelId: string, sharedData: SharedData): boolean => {
+  const channelState = selectors.getOpenedChannelState(sharedData, channelId);
+  const { lastCommitment, penultimateCommitment } = channelState;
+  return (
+    lastCommitment.commitment.commitmentType === CommitmentType.Conclude &&
+    penultimateCommitment.commitment.commitmentType === CommitmentType.Conclude
+  );
+};
+
+export const channelFinalizedOnChain = (channelId: string, sharedData: SharedData): boolean => {
+  const channelState = selectors.getAdjudicatorChannelState(sharedData, channelId);
+  return channelState && channelState.finalized;
+};
+
+export const isChannelDirectlyFunded = (channelId: string, sharedData: SharedData): boolean => {
+  const channelFundingState = selectors.getChannelFundingState(sharedData, channelId);
+  if (!channelFundingState) {
+    throw new Error(`No funding state for ${channelId}. Cannot determine funding type.`);
+  }
+  return channelFundingState.directlyFunded;
+};

--- a/packages/wallet/src/redux/protocols/index.ts
+++ b/packages/wallet/src/redux/protocols/index.ts
@@ -4,13 +4,15 @@ import { WithdrawalState } from './withdrawing/states';
 import { SharedData } from '../state';
 import { RespondingState } from './responding/state';
 import { FundingState } from './funding/states';
+import { DefundingState } from './defunding/state';
 
 export type ProtocolState =
   | IndirectFundingState
   | DirectFundingState
   | WithdrawalState
   | RespondingState
-  | FundingState;
+  | FundingState
+  | DefundingState;
 
 export type ProtocolReducer<T extends ProtocolState> = (
   protocolState: T,

--- a/packages/wallet/src/redux/protocols/indirect-funding/__tests__/reducer.test.ts
+++ b/packages/wallet/src/redux/protocols/indirect-funding/__tests__/reducer.test.ts
@@ -14,6 +14,7 @@ const emptySharedData = {
   outboxState: emptyDisplayOutboxState(),
   channelState: emptyChannelState(),
   adjudicatorState: {},
+  fundingState: {},
 };
 
 const defaultProtocolState = indirectFundingStates.playerB.waitForApproval(channelId);

--- a/packages/wallet/src/redux/protocols/indirect-funding/player-a/__tests__/scenarios.ts
+++ b/packages/wallet/src/redux/protocols/indirect-funding/player-a/__tests__/scenarios.ts
@@ -111,6 +111,7 @@ const constructWalletState = (
       outboxState: emptyDisplayOutboxState(),
       channelState,
       adjudicatorState: {},
+      fundingState: {},
     },
   };
 };

--- a/packages/wallet/src/redux/protocols/indirect-funding/player-b/__tests__/reducer.test.ts
+++ b/packages/wallet/src/redux/protocols/indirect-funding/player-b/__tests__/reducer.test.ts
@@ -112,6 +112,7 @@ const startingState = (
       adjudicatorState: {},
       outboxState: emptyDisplayOutboxState(),
       channelState,
+      fundingState: {},
     },
   };
 };

--- a/packages/wallet/src/redux/protocols/withdrawing/actions.ts
+++ b/packages/wallet/src/redux/protocols/withdrawing/actions.ts
@@ -1,5 +1,6 @@
 import { BaseProcessAction } from '../actions';
 import { TransactionAction } from '../transaction-submission/actions';
+import { WalletAction, isTransactionAction } from '../../actions';
 
 export const WITHDRAWAL_APPROVED = 'WALLET.WITHDRAWAL_APPROVED';
 export const WITHDRAWAL_SUCCESS_ACKNOWLEDGED = 'WITHDRAWAL_SUCCESS_ACKNOWLEDGED';
@@ -46,3 +47,12 @@ export const withdrawalSuccessAcknowledged = (
   type: WITHDRAWAL_SUCCESS_ACKNOWLEDGED as typeof WITHDRAWAL_SUCCESS_ACKNOWLEDGED,
   processId,
 });
+
+export const isWithdrawalAction = (action: WalletAction): action is WithdrawalAction => {
+  return (
+    isTransactionAction(action) ||
+    action.type === WITHDRAWAL_APPROVED ||
+    action.type === WITHDRAWAL_SUCCESS_ACKNOWLEDGED ||
+    action.type === WITHDRAWAL_REJECTED
+  );
+};

--- a/packages/wallet/src/redux/selectors.ts
+++ b/packages/wallet/src/redux/selectors.ts
@@ -1,6 +1,6 @@
 import { OpenedState, OPENING, ChannelStatus } from './channel-state/state';
 import * as walletStates from './state';
-import { SharedData } from './state';
+import { SharedData, FundingState } from './state';
 
 export const getOpenedChannelState = (state: SharedData, channelId: string): OpenedState => {
   const channelStatus = getChannelState(state, channelId);
@@ -37,6 +37,21 @@ export const getAdjudicatorWatcherProcessesForChannel = (
   return processIds;
 };
 
-export const getAdjudicatorState = (state: walletStates.Initialized) => {
-  return state.channelState;
+export const getAdjudicatorState = (state: SharedData) => {
+  return state.adjudicatorState;
+};
+
+export const getAdjudicatorChannelState = (state: SharedData, channelId: string) => {
+  return getAdjudicatorState(state)[channelId];
+};
+
+export const getFundingState = (state: SharedData): FundingState => {
+  return state.fundingState;
+};
+
+export const getChannelFundingState = (
+  state: SharedData,
+  channelId: string,
+): walletStates.ChannelFundingState => {
+  return state.fundingState[channelId];
 };

--- a/packages/wallet/src/redux/state.ts
+++ b/packages/wallet/src/redux/state.ts
@@ -69,7 +69,7 @@ export interface ProcessState {
 }
 
 export interface FundingState {
-  [channelId: string]: FundingState;
+  [channelId: string]: ChannelFundingState;
 }
 
 export interface ChannelFundingState {

--- a/packages/wallet/src/redux/state.ts
+++ b/packages/wallet/src/redux/state.ts
@@ -36,6 +36,7 @@ export interface SharedData {
   channelState: ChannelState;
   outboxState: OutboxState;
   adjudicatorState: AdjudicatorState;
+  fundingState: FundingState;
 }
 
 export interface WaitForLogin extends SharedData {
@@ -67,6 +68,15 @@ export interface ProcessState {
   channelsToMonitor: string[];
 }
 
+export interface FundingState {
+  [channelId: string]: FundingState;
+}
+
+export interface ChannelFundingState {
+  directlyFunded: boolean;
+  fundingChannel?: string;
+}
+
 export interface IndirectFundingOngoing extends Initialized {
   indirectFunding: indirectFunding.IndirectFundingState;
 }
@@ -81,11 +91,12 @@ export const EMPTY_SHARED_DATA: SharedData = {
   outboxState: emptyDisplayOutboxState(),
   channelState: emptyChannelState(),
   adjudicatorState: {},
+  fundingState: {},
 };
 
 export function sharedData(params: SharedData): SharedData {
-  const { outboxState, channelState, adjudicatorState } = params;
-  return { outboxState, channelState, adjudicatorState };
+  const { outboxState, channelState, adjudicatorState, fundingState } = params;
+  return { outboxState, channelState, adjudicatorState, fundingState };
 }
 
 export function waitForLogin(): WaitForLogin {


### PR DESCRIPTION
A protocol responsible for defunding a channel. Based on the channel type it delegates to either the withdrawal protocol or ledger de-funding protocol.

Once the the ledger de-funding protocol is completed this protocol might need to be revisited and slightly tweaked.

No stories were created as there are no unique views for the protocol

Fixes #396 