### PR TITLE
Ledger De-Funding

### DIFF
--- a/packages/wallet/src/redux/protocols/indirect-defunding/readme.md
+++ b/packages/wallet/src/redux/protocols/indirect-defunding/readme.md
@@ -14,24 +14,21 @@ It covers:
 
 ```mermaid
 graph TD
-  St((start))-->WFAp(WaitForApproval)
-  WFAp-->|Approve|SLU[SendLedgerUpdate]
-  WFAp-->|Rejected|F((failure))
-  SLU-->WFL(WaitForLedgerUpdate)
-  WFL-->|LedgerUpdateReceived|WFAc(WaitForAcknowledgement)
-  WFAc-->|Acknowledged|S((success))
+  St((start))-->DF{Defundable?}
+  DF --> |No| F((Failure))
+  DF --> |Yes| WFU(WaitForLedgerUpdate1)
+  WFU --> |"CommitmentReceived(Accept)"| Su((Success))
+  WFU --> |"CommitmentReceived(Reject)"| F
 ```
 
 ### Player B State machine
 
 ```mermaid
 graph TD
-  St((start))-->WFAp(WaitForApproval)
-  WFAp-->|Approve|WFL(WaitForLedgerUpdate)
-  WFAp-->|Rejected|F((failure))
-  WFL-->SLU[SendLedgerUpdate]
-  SLU-->WFAc(WaitForAcknowledgement)
-  WFAc-->|Acknowledged|S((success))
+  St((start))-->DF{Defundable?}
+  DF --> |No| F((Failure))
+  DF --> |Yes| WFU(WaitForLedgerUpdate0)
+  WFU --> |CommitmentReceived| Su((Success))
 ```
 
 Notes:

--- a/packages/wallet/src/redux/protocols/indirect-defunding/readme.md
+++ b/packages/wallet/src/redux/protocols/indirect-defunding/readme.md
@@ -27,15 +27,18 @@ graph TD
 ```mermaid
 graph TD
   St((start))-->WFAp(WaitForApproval)
-  WFAp-->|Approve|WFL
+  WFAp-->|Approve|WFL(WaitForLedgerUpdate)
   WFAp-->|Rejected|F((failure))
   WFL-->SLU[SendLedgerUpdate]
-  SLU-->|WFAc(WaitForAcknowledgement)
+  SLU-->WFAc(WaitForAcknowledgement)
   WFAc-->|Acknowledged|S((success))
 ```
 
 Notes:
 
-## Scenarios
+- Currently doesn't handle the case where one player approves, one player declines
 
-1. **Happy Path** Start->
+## Open Questions
+
+1. Is this a top-level protocol? If so what closes the channel?
+2. Can we rely on this being performed co-operatively?

--- a/packages/wallet/src/redux/protocols/indirect-defunding/readme.md
+++ b/packages/wallet/src/redux/protocols/indirect-defunding/readme.md
@@ -1,0 +1,41 @@
+# Indirect De-Funding Protocol
+
+The purpose of this protocol is handle de-funding a channel that has been indirectly funded.
+
+It covers:
+
+- Checking that a channel is closed (either finalized on chain or a conclusion proof exists)
+- Crafting a ledger update that allocates the funds to the players.
+- Waiting for a ledger response from the opponent.
+
+## State machine
+
+### Player A State machine
+
+```mermaid
+graph TD
+  St((start))-->WFAp(WaitForApproval)
+  WFAp-->|Approve|SLU[SendLedgerUpdate]
+  WFAp-->|Rejected|F((failure))
+  SLU-->WFL(WaitForLedgerUpdate)
+  WFL-->|LedgerUpdateReceived|WFAc(WaitForAcknowledgement)
+  WFAc-->|Acknowledged|S((success))
+```
+
+### Player B State machine
+
+```mermaid
+graph TD
+  St((start))-->WFAp(WaitForApproval)
+  WFAp-->|Approve|WFL
+  WFAp-->|Rejected|F((failure))
+  WFL-->SLU[SendLedgerUpdate]
+  SLU-->|WFAc(WaitForAcknowledgement)
+  WFAc-->|Acknowledged|S((success))
+```
+
+Notes:
+
+## Scenarios
+
+1. **Happy Path** Start->


### PR DESCRIPTION
Indirect de-funding reducer, scenarios and tests. This assumes that player A will always go first. There is an open issue #412 to address this.

The views and stories will be handled in #411.

Fixes #397 