### PR TITLE
Export success/failure states and triggers from transaction-submission

### DIFF
--- a/packages/wallet/src/redux/protocols/challenging/__tests__/scenarios.ts
+++ b/packages/wallet/src/redux/protocols/challenging/__tests__/scenarios.ts
@@ -1,6 +1,6 @@
 import * as states from '../states';
 import * as actions from '../actions';
-import * as tsScenarios from '../../transaction-submission/__tests__/scenarios';
+import * as tsScenarios from '../../transaction-submission/__tests__';
 import { setChannel, EMPTY_SHARED_DATA } from '../../../state';
 import { ChannelStatus, waitForPreFundSetup, waitForUpdate } from '../../../channel-state/state';
 import * as channelScenarios from '../../../__tests__/test-scenarios';
@@ -48,8 +48,8 @@ const ourTurn = waitForUpdate({
 // Defaults
 // --------
 const processId = 'processId';
-const tsPreSuccess = tsScenarios.happyPath.waitForConfirmation;
-const tsPreFailure = tsScenarios.transactionFailed.waitForConfirmation;
+const tsPreSuccess = tsScenarios.preSuccessState;
+const tsPreFailure = tsScenarios.preFailureState;
 const storage = (channelState: ChannelStatus) => setChannel(EMPTY_SHARED_DATA, channelState);
 
 const defaults = { processId, channelId, storage: storage(theirTurn) };
@@ -80,8 +80,8 @@ const failure = (reason: Reason) => states.failure({ reason });
 const challengeApproved = actions.challengeApproved(processId);
 const challengeDenied = actions.challengeDenied(processId);
 const challengeTimedOut = actions.challengeTimedOut(processId);
-const transactionSuccessTrigger = tsScenarios.happyPath.confirmed;
-const transactionFailureTrigger = tsScenarios.transactionFailed.failed;
+const transactionSuccessTrigger = tsScenarios.successTrigger;
+const transactionFailureTrigger = tsScenarios.failureTrigger;
 const responseReceived = actions.challengeResponseReceived(processId);
 const responseAcknowledged = actions.challengeResponseAcknowledged(processId);
 const timeoutAcknowledged = actions.challengeTimeoutAcknowledged(processId);

--- a/packages/wallet/src/redux/protocols/direct-funding/__tests__/scenarios.ts
+++ b/packages/wallet/src/redux/protocols/direct-funding/__tests__/scenarios.ts
@@ -7,7 +7,7 @@ import { PlayerIndex } from '../../../types';
 import * as globalTestScenarios from '../../../__tests__/test-scenarios';
 import * as scenarios from '../../../__tests__/test-scenarios';
 import * as testScenarios from '../../../__tests__/test-scenarios';
-import * as transactionSubmissionScenarios from '../../transaction-submission/__tests__/scenarios';
+import * as transactionSubmissionScenarios from '../../transaction-submission/__tests__';
 import * as states from '../state';
 
 const { channelId, twoThree } = scenarios;
@@ -86,14 +86,14 @@ export const aDepositsBDepositsAHappyStates = {
   waitForDepositTransactionStart: constructWalletState(
     states.waitForDepositTransaction({
       ...defaultsForA,
-      transactionSubmissionState: transactionSubmissionScenarios.happyPath.waitForSend,
+      transactionSubmissionState: transactionSubmissionScenarios.initialState,
     }),
     waitForFundingChannelState,
   ),
   waitForDepositTransactionEnd: constructWalletState(
     states.waitForDepositTransaction({
       ...defaultsForA,
-      transactionSubmissionState: transactionSubmissionScenarios.happyPath.waitForConfirmation,
+      transactionSubmissionState: transactionSubmissionScenarios.preSuccessState,
     }),
     waitForFundingChannelState,
   ),
@@ -126,14 +126,14 @@ export const aDepositsBDepositsBHappyStates = {
   waitForDepositTransactionStart: constructWalletState(
     states.waitForDepositTransaction({
       ...defaultsForB,
-      transactionSubmissionState: transactionSubmissionScenarios.happyPath.waitForSend,
+      transactionSubmissionState: transactionSubmissionScenarios.initialState,
     }),
     waitForFundingChannelState,
   ),
   waitForDepositTransactionEnd: constructWalletState(
     states.waitForDepositTransaction({
       ...defaultsForB,
-      transactionSubmissionState: transactionSubmissionScenarios.happyPath.waitForConfirmation,
+      transactionSubmissionState: transactionSubmissionScenarios.preSuccessState,
     }),
     waitForFundingChannelState,
   ),

--- a/packages/wallet/src/redux/protocols/responding/__tests__/scenarios.ts
+++ b/packages/wallet/src/redux/protocols/responding/__tests__/scenarios.ts
@@ -1,7 +1,7 @@
 import * as states from '../state';
 import * as actions from '../actions';
 import * as testScenarios from '../../../__tests__/test-scenarios';
-import * as transactionScenarios from '../../transaction-submission/__tests__/scenarios';
+import * as transactionScenarios from '../../transaction-submission/__tests__';
 import { EMPTY_SHARED_DATA, SharedData } from '../../../state';
 
 import {
@@ -63,7 +63,7 @@ const refuteChannelState = {
     [channelId]: refuteChannelStatus,
   },
 };
-const transactionSubmissionState = transactionScenarios.happyPath.waitForConfirmation;
+const transactionSubmissionState = transactionScenarios.preSuccessState;
 const processId = 'process-id.123';
 const sharedData: SharedData = { ...EMPTY_SHARED_DATA, channelState };
 const props = { processId, transactionSubmissionState, sharedData };

--- a/packages/wallet/src/redux/protocols/transaction-submission/__tests__/index.ts
+++ b/packages/wallet/src/redux/protocols/transaction-submission/__tests__/index.ts
@@ -1,0 +1,9 @@
+import { happyPath, transactionFailed } from './scenarios';
+
+export const initialState = happyPath.waitForSend;
+
+export const preSuccessState = happyPath.waitForConfirmation;
+export const successTrigger = happyPath.confirmed;
+
+export const preFailureState = transactionFailed.waitForConfirmation;
+export const failureTrigger = transactionFailed.failed;

--- a/packages/wallet/src/redux/protocols/withdrawing/__tests__/scenarios.ts
+++ b/packages/wallet/src/redux/protocols/withdrawing/__tests__/scenarios.ts
@@ -1,7 +1,7 @@
 import * as states from '../states';
 import * as actions from '../actions';
 import * as transactionActions from '../../transaction-submission/actions';
-import * as transactionScenarios from '../../transaction-submission/__tests__/scenarios';
+import * as transactionScenarios from '../../transaction-submission/__tests__';
 import {
   ChannelStatus,
   RUNNING,
@@ -72,7 +72,7 @@ const withdrawalAddress = Wallet.createRandom().address;
 const processId = 'process-id.123';
 const sharedData: SharedData = { ...EMPTY_SHARED_DATA, channelState };
 const withdrawalAmount = web3Utils.toWei('5');
-const transactionSubmissionState = transactionScenarios.happyPath.waitForConfirmation;
+const transactionSubmissionState = transactionScenarios.preSuccessState;
 const props = {
   transaction,
   processId,


### PR DESCRIPTION
This PR adds `preSuccessState`, `preFailureState`, `successTrigger` and `failureTrigger` exports from the `transaction-submission/__tests__`. Other protocols can use these to simulate the sub-protocol completing successfully or failing.

Assuming the format here is ok, we should probably make sure every protocol export these states and actions.