### PR TITLE
Export pre-success and pre-failure scenarios from direct-funding

### DIFF
--- a/packages/wallet/src/redux/protocols/challenging/readme.md
+++ b/packages/wallet/src/redux/protocols/challenging/readme.md
@@ -41,7 +41,7 @@ Note:
 
 ## Scenarios
 
-To test all paths through the state machine we will use 5 different scenarios:
+To test all paths through the state machine we will the following scenarios:
 
 1. **Opponent responds**: `ApproveChallenge` -> `WaitForTransaction` -> `WaitForResponseOrTimeout`
    -> `AcknowledgeResponse` -> `Open`

--- a/packages/wallet/src/redux/protocols/direct-funding/__tests__/index.ts
+++ b/packages/wallet/src/redux/protocols/direct-funding/__tests__/index.ts
@@ -1,0 +1,11 @@
+import {
+  aDepositsBDepositsAHappyStates,
+  actions,
+  aDepositsBDepositsBHappyStates,
+} from './scenarios';
+
+export const preSuccessStateA = aDepositsBDepositsAHappyStates.waitForPostFundSetup;
+export const successTriggerA = actions.postFundSetup1;
+
+export const preSuccessStateB = aDepositsBDepositsBHappyStates.waitForPostFundSetup;
+export const successTriggerB = actions.postFundSetup0;

--- a/packages/wallet/src/redux/protocols/direct-funding/__tests__/index.ts
+++ b/packages/wallet/src/redux/protocols/direct-funding/__tests__/index.ts
@@ -2,6 +2,7 @@ import {
   aDepositsBDepositsAHappyStates,
   actions,
   aDepositsBDepositsBHappyStates,
+  transactionFails,
 } from './scenarios';
 
 export const preSuccessStateA = aDepositsBDepositsAHappyStates.waitForPostFundSetup;
@@ -9,3 +10,6 @@ export const successTriggerA = actions.postFundSetup1;
 
 export const preSuccessStateB = aDepositsBDepositsBHappyStates.waitForPostFundSetup;
 export const successTriggerB = actions.postFundSetup0;
+
+export const preFailureState = transactionFails.waitForDepositTransaction;
+export const failureTrigger = transactionFails.failureTrigger;

--- a/packages/wallet/src/redux/protocols/direct-funding/__tests__/reducer.test.ts
+++ b/packages/wallet/src/redux/protocols/direct-funding/__tests__/reducer.test.ts
@@ -222,9 +222,13 @@ describe(startingIn(states.WAIT_FOR_FUNDING_AND_POST_FUND_SETUP), () => {
   });
 });
 
-describe(startingIn(states.FUNDING_SUCCESS), () => {
-  it.skip('works', () => {
-    expect.assertions(1);
+describe('transaction-fails scenario', () => {
+  describe('when in WaitForDepositTransaction', () => {
+    const state = scenarios.transactionFails.waitForDepositTransaction;
+    const action = scenarios.transactionFails.failureTrigger;
+    const updatedState = directFundingStateReducer(state.protocolState, state.sharedData, action);
+
+    itTransitionsTo(updatedState, states.FUNDING_FAILURE);
   });
 });
 

--- a/packages/wallet/src/redux/protocols/direct-funding/__tests__/scenarios.ts
+++ b/packages/wallet/src/redux/protocols/direct-funding/__tests__/scenarios.ts
@@ -178,6 +178,23 @@ export const aDepositsBDepositsBHappyStates = {
   ),
 };
 
+export const transactionFails = {
+  waitForDepositTransaction: constructWalletState(
+    states.waitForDepositTransaction({
+      ...defaultsForA,
+      transactionSubmissionState: transactionSubmissionScenarios.preFailureState,
+    }),
+    waitForFundingChannelState,
+  ),
+  failureTrigger: transactionSubmissionScenarios.failureTrigger,
+
+  failure: constructWalletState(
+    states.fundingFailure(defaultsForA),
+    // TODO: this is an incorrect channel state
+    waitForFundingChannelState,
+  ),
+};
+
 export const actions = {
   postFundSetup0: globalActions.commitmentReceived(
     channelId,

--- a/packages/wallet/src/redux/protocols/direct-funding/components/funding-step.tsx
+++ b/packages/wallet/src/redux/protocols/direct-funding/components/funding-step.tsx
@@ -12,6 +12,7 @@ export enum Step {
   WAIT_FOR_DEPOSIT_TRANSACTION,
   WAITING_FOR_FUNDING_CONFIRMATION,
   CHANNEL_FUNDED,
+  FUNDING_FAILED,
 }
 
 const fundingStepByState = (state: directFundingState.DirectFundingState): Step => {
@@ -23,6 +24,9 @@ const fundingStepByState = (state: directFundingState.DirectFundingState): Step 
       return Step.WAITING_FOR_FUNDING_CONFIRMATION;
     case directFundingState.FUNDING_SUCCESS:
       return Step.CHANNEL_FUNDED;
+    case directFundingState.FUNDING_FAILURE:
+      // todo: restrict this to non-terminal states
+      return Step.FUNDING_FAILED;
     default:
       return unreachable(state);
   }

--- a/packages/wallet/src/redux/protocols/direct-funding/container.tsx
+++ b/packages/wallet/src/redux/protocols/direct-funding/container.tsx
@@ -30,6 +30,9 @@ class DirectFundingContainer extends PureComponent<Props> {
             transactionName={'direct deposit'}
           />
         );
+      case directFundingStates.FUNDING_FAILURE:
+        // todo: restrict the container to non-terminal states
+        return <div>This shouldn't ever get shown.</div>;
       default:
         return unreachable(directFundingState);
     }

--- a/packages/wallet/src/redux/protocols/direct-funding/readme.md
+++ b/packages/wallet/src/redux/protocols/direct-funding/readme.md
@@ -25,3 +25,11 @@ ST-->WFFCPF
 
 - If the transaction submission state machine fails, we do not retry the transaction.
 - There are no protections against missing the blockchain funding events.
+
+## Test scenarios
+
+To test all paths through the state machine we will use the following scenarios:
+
+1. **A-deposits-B-deposits-A**: `WaitForDepositTransaction` -> `WaitForConfirmationAndPostFund` -> `ChannelFunded`
+2. **A-deposits-B-deposits-B**: `NotSafeToDeposit` -> `WaitForDepositTransaction` -> `WaitForConfirmationAndPostFund` -> `ChannelFunded`
+3. **Transaction fails**: `WaitForDepositTransaction` -> `Failure`

--- a/packages/wallet/src/redux/protocols/direct-funding/reducer.ts
+++ b/packages/wallet/src/redux/protocols/direct-funding/reducer.ts
@@ -50,6 +50,9 @@ export const directFundingStateReducer: DFReducer = (
       return waitForFundingAndPostFundSetupReducer(state, sharedData, action);
     case states.FUNDING_SUCCESS:
       return channelFundedReducer(state, sharedData, action);
+    case states.FUNDING_FAILURE:
+      // todo: restrict the reducer to only accept non-terminal states
+      return { protocolState: state, sharedData };
     default:
       return unreachable(state);
   }
@@ -199,8 +202,7 @@ const waitForDepositTransactionReducer: DFReducer = (
         sharedData,
       };
     } else {
-      // TODO: treat the transaction failure case
-      return { protocolState, sharedData };
+      return { protocolState: states.fundingFailure(protocolState), sharedData };
     }
   }
 };

--- a/packages/wallet/src/redux/protocols/direct-funding/state.ts
+++ b/packages/wallet/src/redux/protocols/direct-funding/state.ts
@@ -12,12 +12,15 @@ export const NOT_SAFE_TO_DEPOSIT = 'NOT_SAFE_TO_DEPOSIT';
 export const WAIT_FOR_DEPOSIT_TRANSACTION = 'WAIT_FOR_DEPOSIT_TRANSACTION';
 export const WAIT_FOR_FUNDING_AND_POST_FUND_SETUP = 'WAIT_FOR_FUNDING_AND_POST_FUND_SETUP';
 export const FUNDING_SUCCESS = 'CHANNEL_FUNDED';
+export const FUNDING_FAILURE = 'FUNDING_FAILURE';
 // Funding status
 export type ChannelFundingStatus =
   | typeof NOT_SAFE_TO_DEPOSIT
   | typeof WAIT_FOR_DEPOSIT_TRANSACTION
   | typeof WAIT_FOR_FUNDING_AND_POST_FUND_SETUP
-  | typeof FUNDING_SUCCESS;
+  | typeof FUNDING_SUCCESS
+  | typeof FUNDING_FAILURE;
+
 export const DIRECT_FUNDING = 'FUNDING_TYPE.DIRECT';
 export interface BaseDirectFundingState {
   processId: string;
@@ -43,6 +46,11 @@ export interface WaitForFundingAndPostFundSetup extends BaseDirectFundingState {
 export interface FundingSuccess extends BaseDirectFundingState {
   type: typeof FUNDING_SUCCESS;
 }
+
+export interface FundingFailure extends BaseDirectFundingState {
+  type: typeof FUNDING_FAILURE;
+}
+
 // constructors
 export const baseDirectFundingState: Constructor<BaseDirectFundingState> = params => {
   const {
@@ -96,11 +104,20 @@ export const fundingSuccess: Constructor<FundingSuccess> = params => {
     type: FUNDING_SUCCESS,
   };
 };
+
+export const fundingFailure: Constructor<FundingFailure> = params => {
+  return {
+    ...baseDirectFundingState(params),
+    type: FUNDING_FAILURE,
+  };
+};
+
 export type DirectFundingState =
   | NotSafeToDeposit
   | WaitForDepositTransaction
   | WaitForFundingAndPostFundSetup
-  | FundingSuccess;
+  | FundingSuccess
+  | FundingFailure;
 
 export function initialDirectFundingState(
   action: DirectFundingRequested,


### PR DESCRIPTION
This work is driven by the need to have success and failure scenarios from the direct-funding protocol, in order to test the indirect-funding protocol. This PR:

* Adds the failure case to direct-funding
* Transitions to this state in the case of a failed transaction
* Exports the pre-success state, pre-failure state and the success/failure triggers for use in testing other protocols.

The failure case is very basic and will need revisiting. As currently written, if the transaction fails and one player abandons, the other player will be stuck.