### PR TITLE
Player A sends funding strategy to player B

### DIFF
--- a/packages/wallet/src/redux/protocols/funding/index.ts
+++ b/packages/wallet/src/redux/protocols/funding/index.ts
@@ -1,0 +1,3 @@
+export enum Strategy {
+  IndirectFunding = 'IndirectFunding',
+}

--- a/packages/wallet/src/redux/protocols/funding/player-a/__tests__/reducer.test.ts
+++ b/packages/wallet/src/redux/protocols/funding/player-a/__tests__/reducer.test.ts
@@ -4,6 +4,7 @@ import { fundingReducer as reducer } from '../reducer';
 import { ProtocolStateWithSharedData } from '../../..';
 import { itSendsThisMessage } from '../../../../__tests__/helpers';
 import { messageRelayRequested } from 'magmo-wallet-client';
+import { strategyProposed } from '../../player-b/actions';
 
 function whenIn(state) {
   return `when in ${state}`;
@@ -20,9 +21,10 @@ describe('happyPath', () => {
 
     itTransitionsTo(result, states.WAIT_FOR_STRATEGY_RESPONSE);
     const { processId, strategy, opponentAddress } = scenario;
+    const sentAction = strategyProposed(processId, strategy);
     itSendsThisMessage(
       result,
-      messageRelayRequested(opponentAddress, { processId, data: { strategy } }),
+      messageRelayRequested(opponentAddress, { processId, data: { sentAction } }),
     );
   });
 

--- a/packages/wallet/src/redux/protocols/funding/player-a/__tests__/reducer.test.ts
+++ b/packages/wallet/src/redux/protocols/funding/player-a/__tests__/reducer.test.ts
@@ -3,6 +3,7 @@ import * as states from '../states';
 import { fundingReducer as reducer } from '../reducer';
 import { ProtocolStateWithSharedData } from '../../..';
 import { itSendsThisMessage } from '../../../../__tests__/helpers';
+import { messageRelayRequested } from 'magmo-wallet-client';
 
 function whenIn(state) {
   return `when in ${state}`;
@@ -18,6 +19,11 @@ describe('happyPath', () => {
     const result = reducer(state, sharedData, action);
 
     itTransitionsTo(result, states.WAIT_FOR_STRATEGY_RESPONSE);
+    const { processId, strategy, opponentAddress } = scenario;
+    itSendsThisMessage(
+      result,
+      messageRelayRequested(opponentAddress, { processId, data: { strategy } }),
+    );
   });
 
   describe(whenIn(states.WAIT_FOR_STRATEGY_RESPONSE), () => {

--- a/packages/wallet/src/redux/protocols/funding/player-a/__tests__/scenarios.ts
+++ b/packages/wallet/src/redux/protocols/funding/player-a/__tests__/scenarios.ts
@@ -22,12 +22,15 @@ import { EMPTY_SHARED_DATA } from '../../../../state';
 // ---------
 const processId = 'process-id.123';
 const sharedData = EMPTY_SHARED_DATA;
+const targetChannelId = '0x123';
+const opponentAddress = '0xf00';
 
 const props = {
   processId,
   sharedData,
   fundingState: 'funding state' as 'funding state',
-  targetChannelId: '0x123',
+  targetChannelId,
+  opponentAddress,
 };
 
 // ----

--- a/packages/wallet/src/redux/protocols/funding/player-a/__tests__/scenarios.ts
+++ b/packages/wallet/src/redux/protocols/funding/player-a/__tests__/scenarios.ts
@@ -3,6 +3,7 @@ import * as actions from '../actions';
 import { PlayerIndex } from '../../../../types';
 
 import { EMPTY_SHARED_DATA } from '../../../../state';
+import { Strategy } from '../..';
 
 // To test all paths through the state machine we will use 4 different scenarios:
 //
@@ -22,6 +23,7 @@ import { EMPTY_SHARED_DATA } from '../../../../state';
 // ---------
 const processId = 'process-id.123';
 const sharedData = EMPTY_SHARED_DATA;
+const strategy = Strategy.IndirectFunding;
 const targetChannelId = '0x123';
 const opponentAddress = '0xf00';
 
@@ -31,6 +33,7 @@ const props = {
   fundingState: 'funding state' as 'funding state',
   targetChannelId,
   opponentAddress,
+  strategy,
 };
 
 // ----
@@ -47,7 +50,7 @@ const failure2 = states.failure('Opponent refused');
 // -------
 // Actions
 // -------
-const strategyChosen = actions.strategyChosen(processId);
+const strategyChosen = actions.strategyChosen(processId, strategy);
 const strategyApproved = actions.strategyApproved(processId);
 const successConfirmed = actions.fundingSuccessAcknowledged(processId);
 

--- a/packages/wallet/src/redux/protocols/funding/player-a/actions.ts
+++ b/packages/wallet/src/redux/protocols/funding/player-a/actions.ts
@@ -1,5 +1,6 @@
 import { BaseProcessAction } from '../../actions';
 import { PlayerIndex } from '../../../types';
+import { Strategy } from '..';
 
 export type FundingAction =
   | StrategyChosen
@@ -17,6 +18,7 @@ export const CANCELLED_BY_OPPONENT = 'WALLET.FUNDING.CANCELLED_BY_OPPONENT';
 
 export interface StrategyChosen extends BaseProcessAction {
   type: typeof STRATEGY_CHOSEN;
+  strategy: Strategy;
 }
 
 export interface StrategyApproved extends BaseProcessAction {
@@ -40,9 +42,10 @@ export interface Cancelled extends BaseProcessAction {
 // Creators
 // --------
 
-export const strategyChosen = (processId: string): StrategyChosen => ({
+export const strategyChosen = (processId: string, strategy): StrategyChosen => ({
   type: STRATEGY_CHOSEN,
   processId,
+  strategy,
 });
 
 export const strategyApproved = (processId: string): StrategyApproved => ({

--- a/packages/wallet/src/redux/protocols/funding/player-a/container.tsx
+++ b/packages/wallet/src/redux/protocols/funding/player-a/container.tsx
@@ -7,11 +7,12 @@ import * as states from './states';
 
 import { unreachable } from '../../../../utils/reducer-utils';
 import { PlayerIndex } from '../../../types';
+import { Strategy } from '..';
 
 interface Props {
   state: states.OngoingFundingState;
-  strategyChosen: (processId: string) => void;
-  strategyApproved: (processId: string) => void;
+  strategyChosen: (processId: string, strategy: Strategy) => void;
+  strategyApproved: (processId: string, strategy: Strategy) => void;
   strategyRejected: (processId: string) => void;
   fundingSuccessAcknowledged: (processId: string) => void;
   cancelled: (processId: string, by: PlayerIndex) => void;

--- a/packages/wallet/src/redux/protocols/funding/player-a/reducer.ts
+++ b/packages/wallet/src/redux/protocols/funding/player-a/reducer.ts
@@ -10,6 +10,7 @@ import { ProtocolStateWithSharedData } from '../..';
 import { unreachable } from '../../../../utils/reducer-utils';
 import { PlayerIndex } from '../../../types';
 import { fundingFailure, messageRelayRequested } from 'magmo-wallet-client';
+import { strategyProposed } from '../player-b/actions';
 
 type EmbeddedAction = IndirectFundingAction;
 
@@ -55,7 +56,8 @@ function strategyChosen(
   }
   const { processId, opponentAddress } = state;
   const { strategy } = action;
-  const payload = { processId, data: { strategy } };
+  const sentAction = strategyProposed(processId, strategy);
+  const payload = { processId, data: { sentAction } };
   const message = messageRelayRequested(opponentAddress, payload);
   return {
     protocolState: states.waitForStrategyResponse({ ...state, strategy }),

--- a/packages/wallet/src/redux/protocols/funding/player-a/reducer.ts
+++ b/packages/wallet/src/redux/protocols/funding/player-a/reducer.ts
@@ -53,7 +53,8 @@ function strategyChosen(
   if (state.type !== states.WAIT_FOR_STRATEGY_CHOICE) {
     return { protocolState: state, sharedData };
   }
-  return { protocolState: states.waitForStrategyResponse(state), sharedData };
+  const { strategy } = action;
+  return { protocolState: states.waitForStrategyResponse({ ...state, strategy }), sharedData };
 }
 
 function strategyApproved(

--- a/packages/wallet/src/redux/protocols/funding/player-a/reducer.ts
+++ b/packages/wallet/src/redux/protocols/funding/player-a/reducer.ts
@@ -9,7 +9,7 @@ import { SharedData, queueMessage } from '../../../state';
 import { ProtocolStateWithSharedData } from '../..';
 import { unreachable } from '../../../../utils/reducer-utils';
 import { PlayerIndex } from '../../../types';
-import { fundingFailure } from 'magmo-wallet-client';
+import { fundingFailure, messageRelayRequested } from 'magmo-wallet-client';
 
 type EmbeddedAction = IndirectFundingAction;
 
@@ -53,8 +53,14 @@ function strategyChosen(
   if (state.type !== states.WAIT_FOR_STRATEGY_CHOICE) {
     return { protocolState: state, sharedData };
   }
+  const { processId, opponentAddress } = state;
   const { strategy } = action;
-  return { protocolState: states.waitForStrategyResponse({ ...state, strategy }), sharedData };
+  const payload = { processId, data: { strategy } };
+  const message = messageRelayRequested(opponentAddress, payload);
+  return {
+    protocolState: states.waitForStrategyResponse({ ...state, strategy }),
+    sharedData: queueMessage(sharedData, message),
+  };
 }
 
 function strategyApproved(

--- a/packages/wallet/src/redux/protocols/funding/player-a/states.ts
+++ b/packages/wallet/src/redux/protocols/funding/player-a/states.ts
@@ -1,4 +1,5 @@
 import { Properties as P } from '../../../utils';
+import { Strategy } from '..';
 
 export type FundingState =
   | WaitForStrategyChoice
@@ -30,6 +31,7 @@ export interface WaitForStrategyChoice extends BaseState {
 export interface WaitForStrategyResponse extends BaseState {
   type: typeof WAIT_FOR_STRATEGY_RESPONSE;
   targetChannelId: string;
+  strategy: Strategy;
 }
 
 export interface WaitForFunding extends BaseState {
@@ -72,8 +74,14 @@ export function waitForStrategyChoice(p: P<WaitForStrategyChoice>): WaitForStrat
 }
 
 export function waitForStrategyResponse(p: P<WaitForStrategyResponse>): WaitForStrategyResponse {
-  const { processId, opponentAddress, targetChannelId } = p;
-  return { type: WAIT_FOR_STRATEGY_RESPONSE, processId, opponentAddress, targetChannelId };
+  const { processId, opponentAddress, targetChannelId, strategy } = p;
+  return {
+    type: WAIT_FOR_STRATEGY_RESPONSE,
+    processId,
+    opponentAddress,
+    targetChannelId,
+    strategy,
+  };
 }
 
 export function waitForFunding(p: P<WaitForFunding>): WaitForFunding {

--- a/packages/wallet/src/redux/protocols/funding/player-a/states.ts
+++ b/packages/wallet/src/redux/protocols/funding/player-a/states.ts
@@ -17,32 +17,32 @@ export const WAIT_FOR_SUCCESS_CONFIRMATION = 'WaitForSuccessConfirmation';
 export const FAILURE = 'Failure';
 export const SUCCESS = 'Success';
 
-export interface WaitForStrategyChoice {
+interface BaseState {
+  processId: string;
+  opponentAddress: string;
+}
+
+export interface WaitForStrategyChoice extends BaseState {
   type: typeof WAIT_FOR_STRATEGY_CHOICE;
   targetChannelId: string;
-  processId: string;
 }
 
-export interface WaitForStrategyResponse {
+export interface WaitForStrategyResponse extends BaseState {
   type: typeof WAIT_FOR_STRATEGY_RESPONSE;
   targetChannelId: string;
-  processId: string;
 }
 
-export interface WaitForFunding {
+export interface WaitForFunding extends BaseState {
   type: typeof WAIT_FOR_FUNDING;
-  processId: string;
   fundingState: 'funding state';
 }
 
-export interface WaitForPostFundSetup {
+export interface WaitForPostFundSetup extends BaseState {
   type: typeof WAIT_FOR_POSTFUND_SETUP;
-  processId: string;
 }
 
-export interface WaitForSuccessConfirmation {
+export interface WaitForSuccessConfirmation extends BaseState {
   type: typeof WAIT_FOR_SUCCESS_CONFIRMATION;
-  processId: string;
 }
 
 export interface Failure {
@@ -67,30 +67,30 @@ export function isTerminal(state: FundingState): state is Failure | Success {
 // ------------
 
 export function waitForStrategyChoice(p: P<WaitForStrategyChoice>): WaitForStrategyChoice {
-  const { processId, targetChannelId } = p;
-  return { type: WAIT_FOR_STRATEGY_CHOICE, processId, targetChannelId };
+  const { processId, opponentAddress, targetChannelId } = p;
+  return { type: WAIT_FOR_STRATEGY_CHOICE, processId, targetChannelId, opponentAddress };
 }
 
 export function waitForStrategyResponse(p: P<WaitForStrategyResponse>): WaitForStrategyResponse {
-  const { processId, targetChannelId } = p;
-  return { type: WAIT_FOR_STRATEGY_RESPONSE, processId, targetChannelId };
+  const { processId, opponentAddress, targetChannelId } = p;
+  return { type: WAIT_FOR_STRATEGY_RESPONSE, processId, opponentAddress, targetChannelId };
 }
 
 export function waitForFunding(p: P<WaitForFunding>): WaitForFunding {
-  const { processId, fundingState } = p;
-  return { type: WAIT_FOR_FUNDING, processId, fundingState };
+  const { processId, opponentAddress, fundingState } = p;
+  return { type: WAIT_FOR_FUNDING, processId, opponentAddress, fundingState };
 }
 
 export function waitForPostFundSetup(p: P<WaitForPostFundSetup>): WaitForPostFundSetup {
-  const { processId } = p;
-  return { type: WAIT_FOR_POSTFUND_SETUP, processId };
+  const { processId, opponentAddress } = p;
+  return { type: WAIT_FOR_POSTFUND_SETUP, processId, opponentAddress };
 }
 
 export function waitForSuccessConfirmation(
   p: P<WaitForSuccessConfirmation>,
 ): WaitForSuccessConfirmation {
-  const { processId } = p;
-  return { type: WAIT_FOR_SUCCESS_CONFIRMATION, processId };
+  const { processId, opponentAddress } = p;
+  return { type: WAIT_FOR_SUCCESS_CONFIRMATION, processId, opponentAddress };
 }
 
 export function success(): Success {

--- a/packages/wallet/src/redux/protocols/funding/player-b/__tests__/scenarios.ts
+++ b/packages/wallet/src/redux/protocols/funding/player-b/__tests__/scenarios.ts
@@ -22,12 +22,15 @@ import { EMPTY_SHARED_DATA } from '../../../../state';
 // ---------
 const processId = 'process-id.123';
 const sharedData = EMPTY_SHARED_DATA;
+const targetChannelId = '0x1324';
+const opponentAddress = '0xf00';
 
 const props = {
   processId,
   sharedData,
   fundingState: 'funding state' as 'funding state',
-  targetChannelId: '0x1324',
+  targetChannelId,
+  opponentAddress,
 };
 
 // ------

--- a/packages/wallet/src/redux/protocols/funding/player-b/__tests__/scenarios.ts
+++ b/packages/wallet/src/redux/protocols/funding/player-b/__tests__/scenarios.ts
@@ -3,6 +3,7 @@ import * as actions from '../actions';
 import { PlayerIndex } from '../../../../types';
 
 import { EMPTY_SHARED_DATA } from '../../../../state';
+import { Strategy } from '../..';
 
 // To test all paths through the state machine we will use 4 different scenarios:
 //
@@ -24,6 +25,7 @@ const processId = 'process-id.123';
 const sharedData = EMPTY_SHARED_DATA;
 const targetChannelId = '0x1324';
 const opponentAddress = '0xf00';
+const strategy = Strategy.IndirectFunding;
 
 const props = {
   processId,
@@ -31,6 +33,7 @@ const props = {
   fundingState: 'funding state' as 'funding state',
   targetChannelId,
   opponentAddress,
+  strategy,
 };
 
 // ------
@@ -47,8 +50,8 @@ const failure2 = states.failure('Opponent refused');
 // -------
 // Actions
 // -------
-const strategyProposed = actions.strategyProposed(processId);
-const strategyApproved = actions.strategyApproved(processId);
+const strategyProposed = actions.strategyProposed(processId, strategy);
+const strategyApproved = actions.strategyApproved(processId, strategy);
 const successConfirmed = actions.fundingSuccessAcknowledged(processId);
 const strategyRejected = actions.strategyRejected(processId);
 const cancelledByB = actions.cancelled(processId, PlayerIndex.B);

--- a/packages/wallet/src/redux/protocols/funding/player-b/actions.ts
+++ b/packages/wallet/src/redux/protocols/funding/player-b/actions.ts
@@ -1,5 +1,6 @@
 import { BaseProcessAction } from '../../actions';
 import { PlayerIndex } from '../../../types';
+import { Strategy } from '..';
 
 export type FundingAction =
   | StrategyProposed
@@ -17,10 +18,12 @@ export const CANCELLED_BY_OPPONENT = 'WALLET.FUNDING.CANCELLED_BY_OPPONENT';
 
 export interface StrategyProposed extends BaseProcessAction {
   type: typeof STRATEGY_PROPOSED;
+  strategy: Strategy;
 }
 
 export interface StrategyApproved extends BaseProcessAction {
   type: typeof STRATEGY_APPROVED;
+  strategy: Strategy;
 }
 
 export interface FundingSuccessAcknowledged extends BaseProcessAction {
@@ -40,14 +43,16 @@ export interface Cancelled extends BaseProcessAction {
 // Creators
 // --------
 
-export const strategyProposed = (processId: string): StrategyProposed => ({
+export const strategyProposed = (processId: string, strategy): StrategyProposed => ({
   type: STRATEGY_PROPOSED,
   processId,
+  strategy,
 });
 
-export const strategyApproved = (processId: string): StrategyApproved => ({
+export const strategyApproved = (processId: string, strategy): StrategyApproved => ({
   type: STRATEGY_APPROVED,
   processId,
+  strategy,
 });
 
 export const fundingSuccessAcknowledged = (processId: string): FundingSuccessAcknowledged => ({

--- a/packages/wallet/src/redux/protocols/funding/player-b/container.tsx
+++ b/packages/wallet/src/redux/protocols/funding/player-b/container.tsx
@@ -7,11 +7,12 @@ import * as states from './states';
 
 import { unreachable } from '../../../../utils/reducer-utils';
 import { PlayerIndex } from '../../../types';
+import { Strategy } from '..';
 
 interface Props {
   state: states.OngoingFundingState;
-  strategyChosen: (processId: string) => void;
-  strategyApproved: (processId: string) => void;
+  strategyChosen: (processId: string, strategy: Strategy) => void;
+  strategyApproved: (processId: string, strategy: Strategy) => void;
   strategyRejected: (processId: string) => void;
   fundingSuccessAcknowledged: (processId: string) => void;
   cancelled: (processId: string, by: PlayerIndex) => void;

--- a/packages/wallet/src/redux/protocols/funding/player-b/reducer.ts
+++ b/packages/wallet/src/redux/protocols/funding/player-b/reducer.ts
@@ -54,7 +54,8 @@ function strategyProposed(
     return { protocolState: state, sharedData };
   }
 
-  return { protocolState: states.waitForStrategyApproval(state), sharedData };
+  const { strategy } = action;
+  return { protocolState: states.waitForStrategyApproval({ ...state, strategy }), sharedData };
 }
 
 function strategyApproved(

--- a/packages/wallet/src/redux/protocols/funding/player-b/states.ts
+++ b/packages/wallet/src/redux/protocols/funding/player-b/states.ts
@@ -1,4 +1,5 @@
 import { Properties as P } from '../../../utils';
+import { Strategy } from '..';
 
 export type FundingState =
   | WaitForStrategyProposal
@@ -30,6 +31,7 @@ export interface WaitForStrategyProposal extends BaseState {
 export interface WaitForStrategyApproval extends BaseState {
   type: typeof WAIT_FOR_STRATEGY_APPROVAL;
   targetChannelId: string;
+  strategy: Strategy;
 }
 
 export interface WaitForFunding extends BaseState {
@@ -72,8 +74,14 @@ export function waitForStrategyProposal(p: P<WaitForStrategyProposal>): WaitForS
 }
 
 export function waitForStrategyApproval(p: P<WaitForStrategyApproval>): WaitForStrategyApproval {
-  const { processId, opponentAddress, targetChannelId } = p;
-  return { type: WAIT_FOR_STRATEGY_APPROVAL, processId, opponentAddress, targetChannelId };
+  const { processId, opponentAddress, targetChannelId, strategy } = p;
+  return {
+    type: WAIT_FOR_STRATEGY_APPROVAL,
+    processId,
+    opponentAddress,
+    targetChannelId,
+    strategy,
+  };
 }
 
 export function waitForFunding(p: P<WaitForFunding>): WaitForFunding {

--- a/packages/wallet/src/redux/protocols/funding/player-b/states.ts
+++ b/packages/wallet/src/redux/protocols/funding/player-b/states.ts
@@ -17,32 +17,32 @@ export const WAIT_FOR_SUCCESS_CONFIRMATION = 'WaitForSuccessConfirmation';
 export const FAILURE = 'Failure';
 export const SUCCESS = 'Success';
 
-export interface WaitForStrategyProposal {
+interface BaseState {
+  processId: string;
+  opponentAddress: string;
+}
+
+export interface WaitForStrategyProposal extends BaseState {
   type: typeof WAIT_FOR_STRATEGY_PROPOSAL;
   targetChannelId: string;
-  processId: string;
 }
 
-export interface WaitForStrategyApproval {
+export interface WaitForStrategyApproval extends BaseState {
   type: typeof WAIT_FOR_STRATEGY_APPROVAL;
   targetChannelId: string;
-  processId: string;
 }
 
-export interface WaitForFunding {
+export interface WaitForFunding extends BaseState {
   type: typeof WAIT_FOR_FUNDING;
-  processId: string;
   fundingState: 'funding state';
 }
 
-export interface WaitForPostFundSetup {
+export interface WaitForPostFundSetup extends BaseState {
   type: typeof WAIT_FOR_POSTFUND_SETUP;
-  processId: string;
 }
 
-export interface WaitForSuccessConfirmation {
+export interface WaitForSuccessConfirmation extends BaseState {
   type: typeof WAIT_FOR_SUCCESS_CONFIRMATION;
-  processId: string;
 }
 
 export interface Failure {
@@ -67,30 +67,30 @@ export function isTerminal(state: FundingState): state is Failure | Success {
 // ------------
 
 export function waitForStrategyProposal(p: P<WaitForStrategyProposal>): WaitForStrategyProposal {
-  const { processId, targetChannelId } = p;
-  return { type: WAIT_FOR_STRATEGY_PROPOSAL, processId, targetChannelId };
+  const { processId, opponentAddress, targetChannelId } = p;
+  return { type: WAIT_FOR_STRATEGY_PROPOSAL, processId, opponentAddress, targetChannelId };
 }
 
 export function waitForStrategyApproval(p: P<WaitForStrategyApproval>): WaitForStrategyApproval {
-  const { processId, targetChannelId } = p;
-  return { type: WAIT_FOR_STRATEGY_APPROVAL, processId, targetChannelId };
+  const { processId, opponentAddress, targetChannelId } = p;
+  return { type: WAIT_FOR_STRATEGY_APPROVAL, processId, opponentAddress, targetChannelId };
 }
 
 export function waitForFunding(p: P<WaitForFunding>): WaitForFunding {
-  const { processId, fundingState } = p;
-  return { type: WAIT_FOR_FUNDING, processId, fundingState };
+  const { processId, opponentAddress, fundingState } = p;
+  return { type: WAIT_FOR_FUNDING, processId, opponentAddress, fundingState };
 }
 
 export function waitForPostFundSetup(p: P<WaitForPostFundSetup>): WaitForPostFundSetup {
-  const { processId } = p;
-  return { type: WAIT_FOR_POSTFUND_SETUP, processId };
+  const { processId, opponentAddress } = p;
+  return { type: WAIT_FOR_POSTFUND_SETUP, processId, opponentAddress };
 }
 
 export function waitForSuccessConfirmation(
   p: P<WaitForSuccessConfirmation>,
 ): WaitForSuccessConfirmation {
-  const { processId } = p;
-  return { type: WAIT_FOR_SUCCESS_CONFIRMATION, processId };
+  const { processId, opponentAddress } = p;
+  return { type: WAIT_FOR_SUCCESS_CONFIRMATION, processId, opponentAddress };
 }
 
 export function success(): Success {


### PR DESCRIPTION
Two choices were made here:
A. the opponent's messaging address is stored directly on the protocol state, as an alternative to extracting the participant's _signing_ address from the channel store
B. player A sends an action to player B, so that player B's top level reducer can, if they wish, extract the action from the message and route it to a process' reducer.

I'd like feedback on these two choices before moving forward.