### PR TITLE
Messaging

### DIFF
--- a/packages/magmo-wallet-client/src/wallet-types.ts
+++ b/packages/magmo-wallet-client/src/wallet-types.ts
@@ -1,10 +1,4 @@
-export type WalletMessagePayload = ProtocolPayload | ProcessPayload;
-export interface ProtocolPayload {
-  protocol: string;
-  data: any;
-}
-
-export interface ProcessPayload {
+export interface WalletMessagePayload {
   processId: string;
   data: any;
 }

--- a/packages/wallet/src/redux/channel-state/closing/reducer.ts
+++ b/packages/wallet/src/redux/channel-state/closing/reducer.ts
@@ -21,7 +21,6 @@ import {
   ConcludeAndWithdrawArgs,
 } from '../../../utils/transaction-generator';
 import { StateWithSideEffects } from '../../utils';
-import { WalletProtocol } from '../../types';
 
 export const closingReducer = (
   state: channelStates.ClosingState,
@@ -370,7 +369,6 @@ const composeConcludePosition = (state: channelStates.ClosingState) => {
   const commitmentSignature = signCommitment(concludeCommitment, state.privateKey);
   const sendCommitmentAction = messageRelayRequested(state.participants[1 - state.ourIndex], {
     processId: state.channelId,
-    protocol: WalletProtocol.DirectFunding,
     data: {
       concludeCommitment,
       commitmentSignature,

--- a/packages/wallet/src/redux/channel-state/funding/__tests__/funding.test.ts
+++ b/packages/wallet/src/redux/channel-state/funding/__tests__/funding.test.ts
@@ -12,7 +12,6 @@ import {
 } from '../../../__tests__/helpers';
 import * as outgoing from 'magmo-wallet-client/lib/wallet-events';
 import * as SigningUtil from '../../../../utils/signing-utils';
-import { WalletProtocol } from '../../../types';
 const {
   asAddress,
   asPrivateKey,
@@ -141,7 +140,6 @@ describe('start in WaitForFundingConfirmation', () => {
       state.participants[1 - state.ourIndex],
       {
         processId: state.channelId,
-        protocol: WalletProtocol.DirectFunding,
         data: {
           commitment: postFundCommitment2,
           signature: MOCK_SIGNATURE,

--- a/packages/wallet/src/redux/channel-state/funding/reducer.ts
+++ b/packages/wallet/src/redux/channel-state/funding/reducer.ts
@@ -10,7 +10,6 @@ import { signCommitment, validCommitmentSignature } from '../../../utils/signing
 import { Channel, Commitment, CommitmentType } from 'fmg-core';
 import { handleSignatureAndValidationMessages } from '../../../utils/state-utils';
 import { StateWithSideEffects } from '../../utils';
-import { WalletProtocol } from '../../types';
 
 export const fundingReducer = (
   state: states.FundingState,
@@ -257,7 +256,6 @@ const composePostFundCommitment = (
 
   const sendCommitmentAction = messageRelayRequested(state.participants[1 - state.ourIndex], {
     processId: state.channelId,
-    protocol: WalletProtocol.DirectFunding,
     data: {
       commitment: postFundSetupCommitment,
       signature: commitmentSignature,

--- a/packages/wallet/src/redux/outbox/__tests__/reducer.test.ts
+++ b/packages/wallet/src/redux/outbox/__tests__/reducer.test.ts
@@ -4,19 +4,16 @@ import * as actions from '../../actions';
 import * as outgoing from 'magmo-wallet-client/lib/wallet-events';
 import * as scenarios from '../../__tests__/test-scenarios';
 import { OutboxState } from '../state';
-import { WalletProtocol } from '../../types';
 
 const { mockTransactionOutboxItem } = scenarios;
 
 describe('when a side effect occured', () => {
   const sendFundingDeclinedActionA = outgoing.messageRelayRequested('0xa00', {
     processId: '0x0',
-    protocol: WalletProtocol.DirectFunding,
     data: 'FundingDeclined',
   });
   const sendFundingDeclinedActionB = outgoing.messageRelayRequested('0xb00', {
     processId: '0x0',
-    protocol: WalletProtocol.DirectFunding,
     data: 'FundingDeclined',
   });
   const displayOutbox = [outgoing.hideWallet(), outgoing.showWallet()];

--- a/packages/wallet/src/redux/protocols/direct-funding/reducer.ts
+++ b/packages/wallet/src/redux/protocols/direct-funding/reducer.ts
@@ -6,7 +6,7 @@ import * as actions from '../../actions';
 import { ProtocolReducer, ProtocolStateWithSharedData } from '../../protocols';
 import * as selectors from '../../selectors';
 import { SharedData } from '../../state';
-import { WalletProtocol, PlayerIndex } from '../../types';
+import { PlayerIndex } from '../../types';
 import { isTransactionAction } from '../transaction-submission/actions';
 import {
   initialize as initTransactionState,
@@ -245,13 +245,7 @@ const createAndSendPostFundCommitment = (sharedData: SharedData, channelId: stri
     outboxState: {
       ...sharedData.outboxState,
       messageOutbox: [
-        createCommitmentMessageRelay(
-          WalletProtocol.DirectFunding,
-          theirAddress(channelState),
-          channelId,
-          commitment,
-          signature,
-        ),
+        createCommitmentMessageRelay(theirAddress(channelState), channelId, commitment, signature),
       ],
     },
   };

--- a/packages/wallet/src/redux/protocols/indirect-funding/player-a/reducer.ts
+++ b/packages/wallet/src/redux/protocols/indirect-funding/player-a/reducer.ts
@@ -6,7 +6,7 @@ import * as actions from '../../../actions';
 import * as selectors from '../../../selectors';
 
 import { unreachable } from '../../../../utils/reducer-utils';
-import { PlayerIndex, WalletProtocol } from '../../../types';
+import { PlayerIndex } from '../../../types';
 
 import { Channel } from 'fmg-core';
 import { channelID } from 'magmo-wallet-client/node_modules/fmg-core/lib/channel';
@@ -262,7 +262,6 @@ const createAndSendFinalUpdateCommitment = (
   // Send out the commitment to the opponent
   newSharedData.outboxState.messageOutbox = [
     createCommitmentMessageRelay(
-      WalletProtocol.IndirectFunding,
       ledgerChannelState.participants[PlayerIndex.B],
       appChannelId,
       commitment,
@@ -300,7 +299,6 @@ const createAndSendFirstUpdateCommitment = (
   // Send out the commitment to the opponent
   newSharedData.outboxState.messageOutbox = [
     createCommitmentMessageRelay(
-      WalletProtocol.IndirectFunding,
       ledgerChannelState.participants[PlayerIndex.B],
       appChannelId,
       commitment,
@@ -347,7 +345,6 @@ const createLedgerChannel = (
 
   const { commitment, signature } = preFundSetupCommitment;
   const preFundSetupMessage = createCommitmentMessageRelay(
-    WalletProtocol.IndirectFunding,
     appChannelState.participants[PlayerIndex.B],
     appChannelState.channelId,
     commitment,

--- a/packages/wallet/src/redux/protocols/indirect-funding/player-b/reducer.ts
+++ b/packages/wallet/src/redux/protocols/indirect-funding/player-b/reducer.ts
@@ -26,7 +26,7 @@ import { FundingAction, isDirectFundingAction } from '../../direct-funding/actio
 import * as channelState from '../../../channel-state/state';
 import { Commitment } from 'fmg-core/lib/commitment';
 import { composePreFundCommitment } from '../../../../utils/commitment-utils';
-import { PlayerIndex, WalletProtocol } from '../../../types';
+import { PlayerIndex } from '../../../types';
 import * as selectors from '../../../selectors';
 import { SharedData } from '../../../state';
 
@@ -283,7 +283,6 @@ const respondWithPreFundSetup = (
 
   // Send the message to the opponent.
   const preFundSetupMessage = createCommitmentMessageRelay(
-    WalletProtocol.IndirectFunding,
     appChannelState.participants[PlayerIndex.B],
     appChannelState.channelId,
     commitment,

--- a/packages/wallet/src/redux/protocols/indirect-funding/reducer-helpers.ts
+++ b/packages/wallet/src/redux/protocols/indirect-funding/reducer-helpers.ts
@@ -20,7 +20,6 @@ import {
 } from '../../protocols/direct-funding/state';
 import * as selectors from '../../selectors';
 import { setChannel, SharedData } from '../../state';
-import { WalletProtocol } from '../../types';
 import { directFundingStateReducer } from '../direct-funding/reducer';
 import {
   confirmFundingForChannel,
@@ -86,7 +85,6 @@ export const createAndSendPostFundCommitment = (
 
   newSharedData.outboxState.messageOutbox = [
     createCommitmentMessageRelay(
-      WalletProtocol.IndirectFunding,
       theirAddress(appChannelState),
       ledgerChannelId,
       commitment,
@@ -125,7 +123,6 @@ export const createAndSendUpdateCommitment = (
   // Send out the commitment to the opponent
   newSharedState.outboxState.messageOutbox = [
     createCommitmentMessageRelay(
-      WalletProtocol.IndirectFunding,
       theirAddress(appChannelState),
       appChannelId,
       commitment,

--- a/packages/wallet/src/redux/protocols/reducer-helpers.ts
+++ b/packages/wallet/src/redux/protocols/reducer-helpers.ts
@@ -6,7 +6,6 @@ import { channelStateReducer } from '../channel-state/reducer';
 import { accumulateSideEffects } from '../outbox';
 import { SideEffects } from '../outbox/state';
 import { SharedData } from '../state';
-import { WalletProtocol } from '../types';
 import * as magmoWalletClient from 'magmo-wallet-client';
 
 export const updateChannelState = (
@@ -46,14 +45,13 @@ export const confirmFundingForChannel = (sharedData: SharedData, channelId: stri
 };
 
 export const createCommitmentMessageRelay = (
-  protocol: WalletProtocol,
   to: string,
   processId: string,
   commitment: Commitment,
   signature: string,
 ) => {
   const payload = {
-    protocol,
+    processId,
     data: { commitment, signature, processId },
   };
   return messageRelayRequested(to, payload);

--- a/packages/wallet/src/redux/sagas/message-listener.ts
+++ b/packages/wallet/src/redux/sagas/message-listener.ts
@@ -3,7 +3,6 @@ import * as incoming from 'magmo-wallet-client/lib/wallet-instructions';
 
 import * as actions from '../actions';
 import { eventChannel } from 'redux-saga';
-import { unreachable } from '../../utils/reducer-utils';
 
 export function* messageListener() {
   const postMessageEventChannel = eventChannel(emitter => {
@@ -55,15 +54,14 @@ export function* messageListener() {
 function handleIncomingMessage(action: incoming.ReceiveMessage) {
   const { messagePayload } = action as incoming.ReceiveMessage;
 
-  if ('processId' in messagePayload) {
-    const { data, processId } = messagePayload;
-    if ('commitment' in data) {
-      return actions.commitmentReceived(processId, data.commitment, data.signature);
-    } else {
-      return actions.messageReceived(processId, data);
-    }
-  } else if ('protocol' in messagePayload) {
-    throw new Error('Unexpected message');
+  const { data, processId } = messagePayload;
+
+  if ('commitment' in data) {
+    return actions.commitmentReceived(processId, data.commitment, data.signature);
+  } else if ('type' in data) {
+    // TODO: It would be nice if eventually every message simply wrapped an action
+    return data;
+  } else {
+    return actions.messageReceived(processId, data);
   }
-  return unreachable(messagePayload);
 }

--- a/packages/wallet/src/utils/commitment-utils.ts
+++ b/packages/wallet/src/utils/commitment-utils.ts
@@ -5,7 +5,6 @@ import { signCommitment } from './signing-utils';
 import { Channel } from 'fmg-core';
 import { SignedCommitment } from '../redux/channel-state/shared/state';
 import { messageRelayRequested } from 'magmo-wallet-client/lib/wallet-events';
-import { WalletProtocol } from '../redux/types';
 import { ChannelStatus } from '../redux/channel-state/state';
 
 export const hasConsensusBeenReached = (
@@ -126,7 +125,6 @@ export const composeConcludeCommitment = (channelState: ChannelStatus) => {
     channelState.participants[1 - channelState.ourIndex],
     {
       processId: channelState.channelId,
-      protocol: WalletProtocol.DirectFunding,
       data: {
         concludeCommitment,
         commitmentSignature,


### PR DESCRIPTION
- The messagePayload never has a `protocol` property anymore
- Messages can now simply wrap an action, (any data object with a `type`
property) which is immediately dispatched