### PR TITLE
Funding views

### DIFF
--- a/packages/wallet/src/components/funding/approve-strategy.tsx
+++ b/packages/wallet/src/components/funding/approve-strategy.tsx
@@ -1,0 +1,26 @@
+import React from 'react';
+import ApproveX from '../approve-x';
+import { Strategy } from '../../redux/protocols/funding';
+
+interface Props {
+  strategyChosen: (strategy: Strategy) => void;
+  cancelled: () => void;
+}
+
+export default class ApproveStrategy extends React.PureComponent<Props> {
+  render() {
+    const { strategyChosen, cancelled } = this.props;
+    return (
+      <ApproveX
+        title="Funding channel"
+        description="Do you want to fund this state channel with a re-usable ledger channel?"
+        yesMessage="Fund Channel"
+        noMessage="Cancel"
+        approvalAction={() => strategyChosen(Strategy.IndirectFunding)}
+        rejectionAction={cancelled}
+      >
+        <React.Fragment>This site wants you to fund a new state channel.</React.Fragment>
+      </ApproveX>
+    );
+  }
+}

--- a/packages/wallet/src/components/funding/choose-strategy.tsx
+++ b/packages/wallet/src/components/funding/choose-strategy.tsx
@@ -1,0 +1,26 @@
+import React from 'react';
+import ApproveX from '../approve-x';
+import { Strategy } from '../../redux/protocols/funding';
+
+interface Props {
+  strategyChosen: (strategy: Strategy) => void;
+  cancelled: () => void;
+}
+
+export default class ChooseStrategy extends React.PureComponent<Props> {
+  render() {
+    const { strategyChosen, cancelled } = this.props;
+    return (
+      <ApproveX
+        title="Funding channel"
+        description="Do you want to fund this state channel with a re-usable ledger channel?"
+        yesMessage="Fund Channel"
+        noMessage="Cancel"
+        approvalAction={() => strategyChosen(Strategy.IndirectFunding)}
+        rejectionAction={cancelled}
+      >
+        <React.Fragment>This site wants you to fund a new state channel.</React.Fragment>
+      </ApproveX>
+    );
+  }
+}

--- a/packages/wallet/src/redux/protocols/funding/player-a/container.tsx
+++ b/packages/wallet/src/redux/protocols/funding/player-a/container.tsx
@@ -8,6 +8,7 @@ import * as states from './states';
 import { unreachable } from '../../../../utils/reducer-utils';
 import { PlayerIndex } from '../../../types';
 import { Strategy } from '..';
+import ChooseStrategy from '../../../../components/funding/choose-strategy';
 
 interface Props {
   state: states.OngoingFundingState;
@@ -21,9 +22,16 @@ interface Props {
 class FundingContainer extends PureComponent<Props> {
   render() {
     const { state } = this.props;
+    const { processId } = state;
 
     switch (state.type) {
       case states.WAIT_FOR_STRATEGY_CHOICE:
+        return (
+          <ChooseStrategy
+            strategyChosen={(strategy: Strategy) => actions.strategyChosen(processId, strategy)}
+            cancelled={() => actions.cancelled(processId, PlayerIndex.B)}
+          />
+        );
       case states.WAIT_FOR_STRATEGY_RESPONSE:
       case states.WAIT_FOR_FUNDING:
       case states.WAIT_FOR_SUCCESS_CONFIRMATION:

--- a/packages/wallet/src/redux/protocols/funding/player-a/container.tsx
+++ b/packages/wallet/src/redux/protocols/funding/player-a/container.tsx
@@ -9,6 +9,8 @@ import { unreachable } from '../../../../utils/reducer-utils';
 import { PlayerIndex } from '../../../types';
 import { Strategy } from '..';
 import ChooseStrategy from '../../../../components/funding/choose-strategy';
+import WaitForOtherPlayer from '../../../../components/wait-for-other-player';
+import AcknowledgeX from '../../../../components/acknowledge-x';
 
 interface Props {
   state: states.OngoingFundingState;
@@ -33,9 +35,19 @@ class FundingContainer extends PureComponent<Props> {
           />
         );
       case states.WAIT_FOR_STRATEGY_RESPONSE:
+        return <WaitForOtherPlayer name={'strategy response'} />;
       case states.WAIT_FOR_FUNDING:
+        // TODO: embed the funding container
+        return <div />;
       case states.WAIT_FOR_SUCCESS_CONFIRMATION:
-        return <div>Hello World From Player A Funding</div>;
+        return (
+          <AcknowledgeX
+            title="Channel funded!"
+            action={() => actions.fundingSuccessAcknowledged(processId)}
+            description="You have successfully funded your channel"
+            actionTitle="Ok!"
+          />
+        );
       default:
         return unreachable(state);
     }

--- a/packages/wallet/src/redux/protocols/funding/player-b/container.tsx
+++ b/packages/wallet/src/redux/protocols/funding/player-b/container.tsx
@@ -8,6 +8,9 @@ import * as states from './states';
 import { unreachable } from '../../../../utils/reducer-utils';
 import { PlayerIndex } from '../../../types';
 import { Strategy } from '..';
+import ApproveStrategy from '../../../../components/funding/approve-strategy';
+import WaitForOtherPlayer from '../../../../components/wait-for-other-player';
+import AcknowledgeX from '../../../../components/acknowledge-x';
 
 interface Props {
   state: states.OngoingFundingState;
@@ -21,13 +24,30 @@ interface Props {
 class FundingContainer extends PureComponent<Props> {
   render() {
     const { state } = this.props;
+    const { processId } = state;
 
     switch (state.type) {
       case states.WAIT_FOR_STRATEGY_PROPOSAL:
+        return <WaitForOtherPlayer name={'strategy choice'} />;
       case states.WAIT_FOR_STRATEGY_APPROVAL:
+        return (
+          <ApproveStrategy
+            strategyChosen={(strategy: Strategy) => actions.strategyApproved(processId, strategy)}
+            cancelled={() => actions.cancelled(processId, PlayerIndex.B)}
+          />
+        );
       case states.WAIT_FOR_FUNDING:
+        // TODO: embed the funding container
+        return <div />;
       case states.WAIT_FOR_SUCCESS_CONFIRMATION:
-        return <div>Hello World From Player B Funding</div>;
+        return (
+          <AcknowledgeX
+            title="Channel funded!"
+            action={() => actions.fundingSuccessAcknowledged(processId)}
+            description="You have successfully funded your channel"
+            actionTitle="Ok!"
+          />
+        );
       default:
         return unreachable(state);
     }


### PR DESCRIPTION
Adds funding views, except when in WAIT_FOR_FUNDING.

I opted to use the `ApproveX` component in the `ChooseStrategy` component for now, since our goal is to get some form of funding working -- offering a choice will come later, with some extra UI work.