### PR TITLE
Finish off Concluding protocol

### DIFF
--- a/packages/wallet/src/redux/actions.ts
+++ b/packages/wallet/src/redux/actions.ts
@@ -12,6 +12,8 @@ import {
 } from './protocols/transaction-submission/actions';
 import { WithdrawalAction } from './protocols/withdrawing/actions';
 import { RespondingAction } from './protocols/responding/actions';
+import { DefundingAction } from './protocols/defunding/actions';
+import { ConcludingAction } from './protocols/concluding/actions';
 export * from './protocols/transaction-submission/actions';
 
 export type TransactionAction = TA;
@@ -154,7 +156,9 @@ export type ProtocolAction =
   | indirectFunding.Action
   | WithdrawalAction
   | RespondingAction
-  | application.ApplicationAction;
+  | application.ApplicationAction
+  | DefundingAction
+  | ConcludingAction;
 
 export type WalletAction =
   | AdjudicatorKnown

--- a/packages/wallet/src/redux/protocols/concluding/__tests__/reducer.test.ts
+++ b/packages/wallet/src/redux/protocols/concluding/__tests__/reducer.test.ts
@@ -24,11 +24,11 @@ describe('[ Happy path ] scenario', () => {
     const action = scenario.actions.concludeReceived;
     const result = concludingReducer(state, storage, action);
 
-    itTransitionsTo(result, 'AcknowledgeChannelConcluded');
+    itTransitionsTo(result, 'AcknowledgeConcludeReceived');
   });
 
-  describe('when in AcknowledgeChannelConcluded', () => {
-    const state = scenario.states.acknowledgeChannelConcluded;
+  describe('when in AcknowledgeConcludeReceived', () => {
+    const state = scenario.states.acknowledgeConcludeReceived;
     const action = scenario.actions.defundChosen;
     const result = concludingReducer(state, storage, action);
 
@@ -37,6 +37,14 @@ describe('[ Happy path ] scenario', () => {
 
   describe('when in WaitForDefund', () => {
     const state = scenario.states.waitForDefund;
+    const action = scenario.actions.defunded;
+    const result = concludingReducer(state, storage, action);
+
+    itTransitionsTo(result, 'AcknowledgeSuccess');
+  });
+
+  describe('when in AcknowledgeSuccess', () => {
+    const state = scenario.states.acknowledgeSuccess;
     const action = scenario.actions.defunded;
     const result = concludingReducer(state, storage, action);
 
@@ -51,11 +59,11 @@ describe('[ Channel doesnt exist ] scenario', () => {
   describe('when initializing', () => {
     const result = initialize('NotInitializedChannelId', processId, storage);
 
-    itTransitionsTo(result, 'AcknowledgeChannelDoesntExist');
+    itTransitionsToAcknowledgeFailure(result, 'ChannelDoesntExist');
   });
 
-  describe('when in AcknowledgeChannelDoesntExist', () => {
-    const state = scenario.states.acknowledgeChannelDoesntExist;
+  describe('when in AcknowledgeFailure', () => {
+    const state = scenario.states.acknowledgeFailure;
     const action = scenario.actions.acknowledged;
     const result = concludingReducer(state, storage, action);
 
@@ -70,12 +78,12 @@ describe('[ Concluding Not Possible ] scenario', () => {
   describe('when initializing', () => {
     const result = initialize(channelId, processId, storage);
 
-    itTransitionsTo(result, 'AcknowledgeConcludingImpossible');
+    itTransitionsToAcknowledgeFailure(result, 'NotYourTurn');
   });
 
-  describe('when in AcknowledgeConcludingImpossible', () => {
-    const state = scenario.states.acknowledgeConcludingImpossible;
-    const action = scenario.actions.concludingImpossibleAcknowledged;
+  describe('when in AcknowledgeFailure', () => {
+    const state = scenario.states.acknowledgeFailure;
+    const action = scenario.actions.acknowledged;
     const result = concludingReducer(state, storage, action);
 
     itTransitionsToFailure(result, 'NotYourTurn');
@@ -104,10 +112,10 @@ describe('[ Defunding Failed ] scenario', () => {
     const action = scenario.actions.defundFailed;
     const result = concludingReducer(state, storage, action);
 
-    itTransitionsTo(result, 'AcknowledgeDefundFailed');
+    itTransitionsToAcknowledgeFailure(result, 'DefundFailed');
   });
 
-  describe('when inAcknowledgeDefundFailed', () => {
+  describe('when in AcknowledgeDefundFailed', () => {
     const state = scenario.states.acknowledgeDefundFailed;
     const action = scenario.actions.acknowledged;
     const result = concludingReducer(state, storage, action);
@@ -126,6 +134,15 @@ function itTransitionsToFailure(result: ReturnVal, reason: FailureReason) {
   it(`transitions to Failure with reason ${reason}`, () => {
     expect(result.state.type).toEqual('Failure');
     if (result.state.type === 'Failure') {
+      expect(result.state.reason).toEqual(reason);
+    }
+  });
+}
+
+function itTransitionsToAcknowledgeFailure(result: ReturnVal, reason: FailureReason) {
+  it(`transitions to Failure with reason ${reason}`, () => {
+    expect(result.state.type).toEqual('AcknowledgeFailure');
+    if (result.state.type === 'AcknowledgeFailure') {
       expect(result.state.reason).toEqual(reason);
     }
   });

--- a/packages/wallet/src/redux/protocols/concluding/__tests__/reducer.test.ts
+++ b/packages/wallet/src/redux/protocols/concluding/__tests__/reducer.test.ts
@@ -37,7 +37,7 @@ describe('[ Happy path ]', () => {
 
   describe('when in WaitForDefund', () => {
     const state = scenario.states.waitForDefund;
-    const action = scenario.actions.defundSucceeded;
+    const action = scenario.actions.successTrigger;
     const result = concludingReducer(state, storage, action);
 
     itTransitionsTo(result, 'AcknowledgeSuccess');
@@ -108,8 +108,8 @@ describe('[ Defunding Failed ]', () => {
   const { storage } = scenario;
 
   describe('when in WaitForDefund', () => {
-    const state = scenario.states.waitForDefund;
-    const action = scenario.actions.defundFailed;
+    const state = scenario.states.waitForDefund2;
+    const action = scenario.actions.failureTrigger;
     const result = concludingReducer(state, storage, action);
 
     itTransitionsToAcknowledgeFailure(result, 'DefundFailed');

--- a/packages/wallet/src/redux/protocols/concluding/__tests__/reducer.test.ts
+++ b/packages/wallet/src/redux/protocols/concluding/__tests__/reducer.test.ts
@@ -116,7 +116,7 @@ describe('[ Defunding Failed ]', () => {
   });
 
   describe('when in AcknowledgeFailure', () => {
-    const state = scenario.states.acknowledgeDefundFailed;
+    const state = scenario.states.acknowledgeFailure;
     const action = scenario.actions.acknowledged;
     const result = concludingReducer(state, storage, action);
 

--- a/packages/wallet/src/redux/protocols/concluding/__tests__/reducer.test.ts
+++ b/packages/wallet/src/redux/protocols/concluding/__tests__/reducer.test.ts
@@ -15,7 +15,7 @@ describe('[ Happy path ]', () => {
     const state = scenario.states.approveConcluding;
     const action = scenario.actions.concludeSent;
     const result = concludingReducer(state, storage, action);
-    // TODO check that the conclude has actually been sent
+    expect(result.sideEffects.messageOutbox.messagePayload.data.concludeCommitment).toBeDefined();
     itTransitionsTo(result, 'WaitForOpponentConclude');
   });
 

--- a/packages/wallet/src/redux/protocols/concluding/__tests__/reducer.test.ts
+++ b/packages/wallet/src/redux/protocols/concluding/__tests__/reducer.test.ts
@@ -1,6 +1,7 @@
 import * as scenarios from './scenarios';
 import { concludingReducer, initialize, ReturnVal } from '../reducer';
 import { ConcludingStateType, FailureReason } from '../states';
+import { expectThisCommitmentSent } from '../../../__tests__/helpers';
 
 describe('[ Happy path ]', () => {
   const scenario = scenarios.happyPath;
@@ -15,7 +16,7 @@ describe('[ Happy path ]', () => {
     const state = scenario.states.approveConcluding;
     const action = scenario.actions.concludeSent;
     const result = concludingReducer(state, storage, action);
-    expect(result.sideEffects.messageOutbox.messagePayload.data.concludeCommitment).toBeDefined();
+    expectThisCommitmentSent(result, scenario.commitments.concludeCommitment);
     itTransitionsTo(result, 'WaitForOpponentConclude');
   });
 

--- a/packages/wallet/src/redux/protocols/concluding/__tests__/reducer.test.ts
+++ b/packages/wallet/src/redux/protocols/concluding/__tests__/reducer.test.ts
@@ -2,7 +2,7 @@ import * as scenarios from './scenarios';
 import { concludingReducer, initialize, ReturnVal } from '../reducer';
 import { ConcludingStateType, FailureReason } from '../states';
 
-describe('[ Happy path ] scenario', () => {
+describe('[ Happy path ]', () => {
   const scenario = scenarios.happyPath;
   const { channelId, processId, storage } = scenario;
 
@@ -37,7 +37,7 @@ describe('[ Happy path ] scenario', () => {
 
   describe('when in WaitForDefund', () => {
     const state = scenario.states.waitForDefund;
-    const action = scenario.actions.defunded;
+    const action = scenario.actions.defundSucceeded;
     const result = concludingReducer(state, storage, action);
 
     itTransitionsTo(result, 'AcknowledgeSuccess');
@@ -45,14 +45,14 @@ describe('[ Happy path ] scenario', () => {
 
   describe('when in AcknowledgeSuccess', () => {
     const state = scenario.states.acknowledgeSuccess;
-    const action = scenario.actions.defunded;
+    const action = scenario.actions.acknowledged;
     const result = concludingReducer(state, storage, action);
 
     itTransitionsTo(result, 'Success');
   });
 });
 
-describe('[ Channel doesnt exist ] scenario', () => {
+describe('[ Channel doesnt exist ]', () => {
   const scenario = scenarios.channelDoesntExist;
   const { processId, storage } = scenario;
 
@@ -71,7 +71,7 @@ describe('[ Channel doesnt exist ] scenario', () => {
   });
 });
 
-describe('[ Concluding Not Possible ] scenario', () => {
+describe('[ Concluding Not Possible ]', () => {
   const scenario = scenarios.concludingNotPossible;
   const { channelId, processId, storage } = scenario;
 
@@ -90,7 +90,7 @@ describe('[ Concluding Not Possible ] scenario', () => {
   });
 });
 
-describe('[ Concluding Cancelled ] scenario', () => {
+describe('[ Concluding Cancelled ]', () => {
   const scenario = scenarios.concludingCancelled;
   const { storage } = scenario;
 
@@ -103,7 +103,7 @@ describe('[ Concluding Cancelled ] scenario', () => {
   });
 });
 
-describe('[ Defunding Failed ] scenario', () => {
+describe('[ Defunding Failed ]', () => {
   const scenario = scenarios.defundingFailed;
   const { storage } = scenario;
 
@@ -115,7 +115,7 @@ describe('[ Defunding Failed ] scenario', () => {
     itTransitionsToAcknowledgeFailure(result, 'DefundFailed');
   });
 
-  describe('when in AcknowledgeDefundFailed', () => {
+  describe('when in AcknowledgeFailure', () => {
     const state = scenario.states.acknowledgeDefundFailed;
     const action = scenario.actions.acknowledged;
     const result = concludingReducer(state, storage, action);
@@ -140,7 +140,7 @@ function itTransitionsToFailure(result: ReturnVal, reason: FailureReason) {
 }
 
 function itTransitionsToAcknowledgeFailure(result: ReturnVal, reason: FailureReason) {
-  it(`transitions to Failure with reason ${reason}`, () => {
+  it(`transitions to AcknowledgeFailure with reason ${reason}`, () => {
     expect(result.state.type).toEqual('AcknowledgeFailure');
     if (result.state.type === 'AcknowledgeFailure') {
       expect(result.state.reason).toEqual(reason);

--- a/packages/wallet/src/redux/protocols/concluding/__tests__/scenarios.ts
+++ b/packages/wallet/src/redux/protocols/concluding/__tests__/scenarios.ts
@@ -1,4 +1,10 @@
 import * as states from '../states';
+import {
+  preSuccessState,
+  preFailureState,
+  successTrigger,
+  failureTrigger,
+} from '../../defunding/__tests__';
 import * as actions from '../actions';
 import * as channelScenarios from '../../../__tests__/test-scenarios';
 
@@ -33,7 +39,8 @@ const defaults = { processId, channelId };
 const approveConcluding = states.approveConcluding(defaults);
 const waitForOpponentConclude = states.waitForOpponentConclude(defaults);
 const acknowledgeConcludeReceived = states.acknowledgeConcludeReceived(defaults);
-const waitForDefund = states.waitForDefund(defaults);
+const waitForDefund = states.waitForDefund({ ...defaults, defundingState: preSuccessState });
+const waitForDefund2 = states.waitForDefund({ ...defaults, defundingState: preFailureState });
 const acknowledgeSuccess = states.acknowledgeSuccess(defaults);
 const success = states.success();
 
@@ -43,9 +50,7 @@ const success = states.success();
 const concludeSent = actions.concludeSent(processId);
 const concludeReceived = actions.concludeReceived(processId);
 const defundChosen = actions.defundChosen(processId);
-const defundSucceeded = actions.defundSucceeded(processId);
 const concludingImpossibleAcknowledged = actions.acknowledged(processId);
-const defundFailed = actions.defundFailed(processId);
 const cancelled = actions.cancelled(processId);
 const acknowledged = actions.acknowledged(processId);
 
@@ -67,7 +72,7 @@ export const happyPath = {
     concludeSent,
     concludeReceived,
     defundChosen,
-    defundSucceeded,
+    successTrigger,
     acknowledged,
   },
 };
@@ -113,7 +118,7 @@ export const defundingFailed = {
   ...defaults,
   storage: storage(ourTurn),
   states: {
-    waitForDefund,
+    waitForDefund2,
     acknowledgeFailure: states.acknowledgeFailure({
       ...defaults,
       reason: 'DefundFailed',
@@ -121,7 +126,7 @@ export const defundingFailed = {
     failure: states.failure({ reason: 'DefundFailed' }),
   },
   actions: {
-    defundFailed,
     acknowledged,
+    failureTrigger,
   },
 };

--- a/packages/wallet/src/redux/protocols/concluding/__tests__/scenarios.ts
+++ b/packages/wallet/src/redux/protocols/concluding/__tests__/scenarios.ts
@@ -32,12 +32,22 @@ const defaults = { processId, channelId };
 // ------
 const approveConcluding = states.approveConcluding(defaults);
 const waitForOpponentConclude = states.waitForOpponentConclude(defaults);
-const acknowledgeChannelConcluded = states.acknowledgeChannelConcluded(defaults);
+const acknowledgeConcludeReceived = states.acknowledgeConcludeReceived(defaults);
 const waitForDefund = states.waitForDefund(defaults);
+const acknowledgeSuccess = states.acknowledgeSuccess(defaults);
 const success = states.success();
-const acknowledgeConcludingImpossible = states.acknowledgeConcludingImpossible(defaults);
-const acknowledgeChannelDoesntExist = states.acknowledgeChannelDoesntExist(defaults);
-const acknowledgeDefundFailed = states.acknowledgeDefundFailed(defaults);
+const acknowledgeConcludingImpossible = states.acknowledgeFailure({
+  ...defaults,
+  reason: 'NotYourTurn',
+});
+const acknowledgeChannelDoesntExist = states.acknowledgeFailure({
+  ...defaults,
+  reason: 'ChannelDoesntExist',
+});
+const acknowledgeDefundFailed = states.acknowledgeFailure({
+  ...defaults,
+  reason: 'DefundFailed',
+});
 
 // -------
 // Actions
@@ -46,7 +56,7 @@ const concludeSent = actions.concludeSent(processId);
 const concludeReceived = actions.concludeReceived(processId);
 const defundChosen = actions.defundChosen(processId);
 const defunded = actions.defunded(processId);
-const concludingImpossibleAcknowledged = actions.resignationImpossibleAcknowledged(processId);
+const concludingImpossibleAcknowledged = actions.acknowledged(processId);
 const defundFailed = actions.defundFailed(processId);
 const cancelled = actions.cancelled(processId);
 const acknowledged = actions.acknowledged(processId);
@@ -60,8 +70,9 @@ export const happyPath = {
   states: {
     approveConcluding,
     waitForOpponentConclude,
-    acknowledgeChannelConcluded,
+    acknowledgeConcludeReceived,
     waitForDefund,
+    acknowledgeSuccess,
     success,
   },
   actions: {
@@ -77,6 +88,7 @@ export const channelDoesntExist = {
   storage: storage(ourTurn),
   states: {
     acknowledgeChannelDoesntExist,
+    acknowledgeFailure: states.acknowledgeFailure({ ...defaults, reason: 'ChannelDoesntExist' }),
     failure: states.failure({ reason: 'ChannelDoesntExist' }),
   },
   actions: {
@@ -89,10 +101,12 @@ export const concludingNotPossible = {
   storage: storage(theirTurn),
   states: {
     acknowledgeConcludingImpossible,
+    acknowledgeFailure: states.acknowledgeFailure({ ...defaults, reason: 'NotYourTurn' }),
     failure: states.failure({ reason: 'NotYourTurn' }),
   },
   actions: {
     concludingImpossibleAcknowledged,
+    acknowledged,
   },
 };
 

--- a/packages/wallet/src/redux/protocols/concluding/__tests__/scenarios.ts
+++ b/packages/wallet/src/redux/protocols/concluding/__tests__/scenarios.ts
@@ -7,6 +7,7 @@ import {
 } from '../../defunding/__tests__';
 import * as actions from '../actions';
 import * as channelScenarios from '../../../__tests__/test-scenarios';
+import { CommitmentType, Commitment } from 'fmg-core';
 
 // -----------------
 // Channel Scenarios
@@ -24,6 +25,15 @@ const theirTurn = channelFromCommitments(
   privateKey,
 );
 const ourTurn = channelFromCommitments(signedCommitment20, signedCommitment21, address, privateKey);
+
+const concludeCommitment: Commitment = {
+  ...signedCommitment21.commitment,
+  channel: channelScenarios.channel,
+  commitmentCount: 0,
+  commitmentType: CommitmentType.Conclude,
+  appAttributes: '0x0',
+  turnNum: 22,
+};
 
 // --------
 // Defaults
@@ -74,6 +84,9 @@ export const happyPath = {
     defundChosen,
     successTrigger,
     acknowledged,
+  },
+  commitments: {
+    concludeCommitment,
   },
 };
 

--- a/packages/wallet/src/redux/protocols/concluding/__tests__/scenarios.ts
+++ b/packages/wallet/src/redux/protocols/concluding/__tests__/scenarios.ts
@@ -55,7 +55,7 @@ const acknowledgeDefundFailed = states.acknowledgeFailure({
 const concludeSent = actions.concludeSent(processId);
 const concludeReceived = actions.concludeReceived(processId);
 const defundChosen = actions.defundChosen(processId);
-const defunded = actions.defunded(processId);
+const defundSucceeded = actions.defundSucceeded(processId);
 const concludingImpossibleAcknowledged = actions.acknowledged(processId);
 const defundFailed = actions.defundFailed(processId);
 const cancelled = actions.cancelled(processId);
@@ -79,7 +79,8 @@ export const happyPath = {
     concludeSent,
     concludeReceived,
     defundChosen,
-    defunded,
+    defundSucceeded,
+    acknowledged,
   },
 };
 

--- a/packages/wallet/src/redux/protocols/concluding/__tests__/scenarios.ts
+++ b/packages/wallet/src/redux/protocols/concluding/__tests__/scenarios.ts
@@ -36,18 +36,6 @@ const acknowledgeConcludeReceived = states.acknowledgeConcludeReceived(defaults)
 const waitForDefund = states.waitForDefund(defaults);
 const acknowledgeSuccess = states.acknowledgeSuccess(defaults);
 const success = states.success();
-const acknowledgeConcludingImpossible = states.acknowledgeFailure({
-  ...defaults,
-  reason: 'NotYourTurn',
-});
-const acknowledgeChannelDoesntExist = states.acknowledgeFailure({
-  ...defaults,
-  reason: 'ChannelDoesntExist',
-});
-const acknowledgeDefundFailed = states.acknowledgeFailure({
-  ...defaults,
-  reason: 'DefundFailed',
-});
 
 // -------
 // Actions
@@ -88,7 +76,6 @@ export const channelDoesntExist = {
   ...defaults,
   storage: storage(ourTurn),
   states: {
-    acknowledgeChannelDoesntExist,
     acknowledgeFailure: states.acknowledgeFailure({ ...defaults, reason: 'ChannelDoesntExist' }),
     failure: states.failure({ reason: 'ChannelDoesntExist' }),
   },
@@ -101,7 +88,6 @@ export const concludingNotPossible = {
   ...defaults,
   storage: storage(theirTurn),
   states: {
-    acknowledgeConcludingImpossible,
     acknowledgeFailure: states.acknowledgeFailure({ ...defaults, reason: 'NotYourTurn' }),
     failure: states.failure({ reason: 'NotYourTurn' }),
   },
@@ -128,7 +114,10 @@ export const defundingFailed = {
   storage: storage(ourTurn),
   states: {
     waitForDefund,
-    acknowledgeDefundFailed,
+    acknowledgeFailure: states.acknowledgeFailure({
+      ...defaults,
+      reason: 'DefundFailed',
+    }),
     failure: states.failure({ reason: 'DefundFailed' }),
   },
   actions: {

--- a/packages/wallet/src/redux/protocols/concluding/actions.ts
+++ b/packages/wallet/src/redux/protocols/concluding/actions.ts
@@ -3,8 +3,6 @@ export type ConcludingAction =
   | ConcludeSent
   | ConcludeReceived
   | DefundChosen
-  | DefundFailed
-  | DefundSucceeded
   | Acknowledged;
 export interface Cancelled {
   type: 'CONCLUDING.CANCELLED';
@@ -23,16 +21,6 @@ export interface ConcludeReceived {
 
 export interface DefundChosen {
   type: 'DEFUND.CHOSEN';
-  processId: string;
-}
-
-export interface DefundFailed {
-  type: 'DEFUND.FAILED';
-  processId: string;
-}
-
-export interface DefundSucceeded {
-  type: 'DEFUND.SUCCEEDED';
   processId: string;
 }
 
@@ -62,16 +50,6 @@ export const concludeReceived = (processId: string): ConcludeReceived => ({
 
 export const defundChosen = (processId: string): DefundChosen => ({
   type: 'DEFUND.CHOSEN',
-  processId,
-});
-
-export const defundFailed = (processId: string): DefundFailed => ({
-  type: 'DEFUND.FAILED',
-  processId,
-});
-
-export const defundSucceeded = (processId: string): DefundSucceeded => ({
-  type: 'DEFUND.SUCCEEDED',
   processId,
 });
 

--- a/packages/wallet/src/redux/protocols/concluding/actions.ts
+++ b/packages/wallet/src/redux/protocols/concluding/actions.ts
@@ -16,11 +16,6 @@ export interface ConcludeSent {
   processId: string;
 }
 
-export interface ConcludingImpossibleAcknowledged {
-  type: 'CONCLUDING.IMPOSSIBLE.ACKNOWLEDGED';
-  processId: string;
-}
-
 export interface ConcludeReceived {
   type: 'CONCLUDE.RECEIVED';
   processId: string;

--- a/packages/wallet/src/redux/protocols/concluding/actions.ts
+++ b/packages/wallet/src/redux/protocols/concluding/actions.ts
@@ -1,7 +1,6 @@
 export type ConcludingAction =
   | Cancelled
   | ConcludeSent
-  | ConcludingImpossibleAcknowledged
   | ConcludeReceived
   | DefundChosen
   | DefundFailed
@@ -58,13 +57,6 @@ export const cancelled = (processId: string): Cancelled => ({
 
 export const concludeSent = (processId: string): ConcludeSent => ({
   type: 'CONCLUDE.SENT',
-  processId,
-});
-
-export const resignationImpossibleAcknowledged = (
-  processId: string,
-): ConcludingImpossibleAcknowledged => ({
-  type: 'CONCLUDING.IMPOSSIBLE.ACKNOWLEDGED',
   processId,
 });
 

--- a/packages/wallet/src/redux/protocols/concluding/actions.ts
+++ b/packages/wallet/src/redux/protocols/concluding/actions.ts
@@ -4,7 +4,7 @@ export type ConcludingAction =
   | ConcludeReceived
   | DefundChosen
   | DefundFailed
-  | Defunded
+  | DefundSucceeded
   | Acknowledged;
 export interface Cancelled {
   type: 'CONCLUDING.CANCELLED';
@@ -36,8 +36,8 @@ export interface DefundFailed {
   processId: string;
 }
 
-export interface Defunded {
-  type: 'DEFUNDED';
+export interface DefundSucceeded {
+  type: 'DEFUND.SUCCEEDED';
   processId: string;
 }
 
@@ -75,8 +75,8 @@ export const defundFailed = (processId: string): DefundFailed => ({
   processId,
 });
 
-export const defunded = (processId: string): Defunded => ({
-  type: 'DEFUNDED',
+export const defundSucceeded = (processId: string): DefundSucceeded => ({
+  type: 'DEFUND.SUCCEEDED',
   processId,
 });
 

--- a/packages/wallet/src/redux/protocols/concluding/container.tsx
+++ b/packages/wallet/src/redux/protocols/concluding/container.tsx
@@ -14,56 +14,40 @@ interface Props {
   state: NonTerminalConcludingState;
   approve: (processId: string) => void;
   deny: (processId: string) => void;
-  acknowledgeConcludingImpossible: (processId: string) => void;
   defund: (processId: string) => void;
   acknowledge: (processId: string) => void;
 }
 
 class ConcludingContainer extends PureComponent<Props> {
   render() {
-    const {
-      state,
-      deny,
-      approve,
-      acknowledgeConcludingImpossible,
-      defund,
-      acknowledge,
-    } = this.props;
+    const { state, deny, approve, defund, acknowledge } = this.props;
     const processId = state.processId;
     switch (state.type) {
-      case 'AcknowledgeConcludingImpossible':
+      case 'AcknowledgeSuccess':
         return (
           <Acknowledge
-            title="Concluding Not Possible"
-            description="You must wait until it is your turn; or else challenge the other player if they are unresponsive."
-            acknowledge={() => acknowledgeConcludingImpossible(state.processId)}
+            title="Concluding Succesful"
+            description="Your channel was closed and defunded."
+            acknowledge={() => acknowledge(state.processId)}
+          />
+        );
+      case 'AcknowledgeFailure':
+        return (
+          <Acknowledge
+            title="Concluding Failed"
+            description={state.reason}
+            acknowledge={() => acknowledge(state.processId)}
           />
         );
       case 'WaitForOpponentConclude':
         return <WaitForOpponentConclude />;
-      case 'AcknowledgeChannelConcluded':
+      case 'AcknowledgeConcludeReceived':
         return <ApproveDefunding approve={() => defund(processId)} />;
       case 'WaitForDefund':
         return <WaitForDefunding />;
       case 'ApproveConcluding':
         return (
           <ApproveConcluding deny={() => deny(processId)} approve={() => approve(processId)} />
-        );
-      case 'AcknowledgeDefundFailed':
-        return (
-          <Acknowledge
-            title="Defunding failed"
-            description="You weren't able to defund the channel"
-            acknowledge={() => acknowledge(state.processId)}
-          />
-        );
-      case 'AcknowledgeChannelDoesntExist':
-        return (
-          <Acknowledge
-            title="Concluding failed"
-            description="The channel does not exist."
-            acknowledge={() => acknowledge(state.processId)}
-          />
         );
       default:
         return unreachable(state);
@@ -74,7 +58,6 @@ class ConcludingContainer extends PureComponent<Props> {
 const mapDispatchToProps = {
   approve: actions.concludeSent,
   deny: actions.cancelled,
-  acknowledgeConcludingImpossible: actions.resignationImpossibleAcknowledged,
   defund: actions.defundChosen,
   acknowledge: actions.acknowledged,
 };

--- a/packages/wallet/src/redux/protocols/concluding/readme.md
+++ b/packages/wallet/src/redux/protocols/concluding/readme.md
@@ -26,7 +26,7 @@ graph TD
   E --> |Yes| MT{My turn?}
   MT  --> |Yes| CC(ApproveConcluding)
   MT  --> |No| AF(AcknowledgeFailure)
-  CC  --> |CANCELLED| F
+  CC  --> |CONCLUDING.CANCELLED| F
   CC  --> |CONCLUDE.SENT| WOC(WaitForOpponentConclude)
   WOC --> |CONCLUDE.RECEIVED| ACR(AcknowledgeConcludeReceived)
   ACR --> |DEFUND.CHOSEN| D(WaitForDefund)
@@ -45,10 +45,10 @@ graph TD
 We will use the following scenarios for testing:
 
 1. **Happy path**: `ApproveConcluding` -> `WaitForOpponentConclude` -> `AcknowledgeChannelConcluded` -> `WaitForDefund` -> `Success`
-2. **Channel doesnt exist** `Failure`
-3. **Concluding not possible**: `AcknowledgeConcludingImpossible` -> `Failure`
+2. **Channel doesnt exist** `AcknowledgeFailure` -> `Failure`
+3. **Concluding not possible**: `AcknowledgeFailure` -> `Failure`
 4. **Concluding cancelled** `ApproveConcluding` -> `Failure`
-5. **Defund failed** `WaitForDefund` -> `Failure`
+5. **Defund failed** `WaitForDefund` -> `AcknowledgeFailure` -> `Failure`
 
 # Terminology
 

--- a/packages/wallet/src/redux/protocols/concluding/readme.md
+++ b/packages/wallet/src/redux/protocols/concluding/readme.md
@@ -30,14 +30,29 @@ graph TD
   CC  --> |CONCLUDE.SENT| WOC(WaitForOpponentConclude)
   WOC --> |CONCLUDE.RECEIVED| ACR(AcknowledgeConcludeReceived)
   ACR --> |DEFUND.CHOSEN| D(WaitForDefund)
-  D   --> |DEFUND.SUCCEEDED| AS(AcknowledgeSuccess)
+  D   --> |defunding protocol succeeded| AS(AcknowledgeSuccess)
   AS -->  |ACKNOWLEDGED| SS((Success))
-  D   --> |DEFUND.FAILED| AF(AcknowledgeFailure)
+  D   --> |defunding protocol failed| AF(AcknowledgeFailure)
   style S  fill:#efdd20
   style E  fill:#efdd20
   style MT fill:#efdd20
   style SS fill:#58ef21
   style F  fill:#f45941
+  style D stroke:#333,stroke-width:4px
+```
+
+Key:
+
+```mermaid
+graph TD
+L{Flow Logic} --> NT1(Non-Terminal States)
+NT1 --> C
+C(Call child reducer) -->|child return status| NT2
+NT2(More Non-Terminal States) --> |ACTION| T
+T((Terminal States))
+  style T  fill:#efdd20
+  style L fill:#efdd20
+  style C stroke:#333,stroke-width:4px
 ```
 
 ## Scenarios

--- a/packages/wallet/src/redux/protocols/concluding/readme.md
+++ b/packages/wallet/src/redux/protocols/concluding/readme.md
@@ -21,19 +21,18 @@ The protocol is implemented with the following state machine
 ```mermaid
 graph TD
   S((Start)) --> E{Channel Exists?}
-  E --> |No| ACDE(AcknowledgeChannelDoesntExist)
-  ACDE -->|ACKNOWLEDGED| F((Failure))
+  E --> |No| AF(AcknowledgeFailure)
+  AF -->|ACKNOWLEDGED| F((Failure))
   E --> |Yes| MT{My turn?}
   MT  --> |Yes| CC(ApproveConcluding)
-  MT  --> |No| RC(AcknowledgeConcludingImpossible)
+  MT  --> |No| AF(AcknowledgeFailure)
   CC  --> |CANCELLED| F
   CC  --> |CONCLUDE.SENT| WOC(WaitForOpponentConclude)
-  WOC --> |CONCLUDE.RECEIVED| ACC(AcknowledgeChannelConcluded)
-  ACC --> |DEFUND.CHOSEN| D(WaitForDefund)
-  D   --> |DEFUND.SUCCEEDED| SS((Success))
-  D   --> |DEFUND.FAILED| ADF(AcknowledgeDefundFailed)
-  ADF -->|ACKNOWLEDGED| F((Failure))
-  RC  --> |CONCLUDING.IMPOSSIBLE.ACKNOWLEDGED| F
+  WOC --> |CONCLUDE.RECEIVED| ACR(AcknowledgeConcludeReceived)
+  ACR --> |DEFUND.CHOSEN| D(WaitForDefund)
+  D   --> |DEFUND.SUCCEEDED| AS(AcknowledgeSuccess)
+  AS -->  |ACKNOWLEDGED| SS((Success))
+  D   --> |DEFUND.FAILED| AF(AcknowledgeFailure)
   style S  fill:#efdd20
   style E  fill:#efdd20
   style MT fill:#efdd20

--- a/packages/wallet/src/redux/protocols/concluding/readme.md
+++ b/packages/wallet/src/redux/protocols/concluding/readme.md
@@ -44,15 +44,21 @@ graph TD
 Key:
 
 ```mermaid
-graph TD
-L{Flow Logic} --> NT1(Non-Terminal States)
-NT1 --> C
-C(Call child reducer) -->|child return status| NT2
-NT2(More Non-Terminal States) --> |ACTION| T
-T((Terminal States))
-  style T  fill:#efdd20
+  graph TD
+  St((Start))-->L
+  L{Flow Logic} --> NT1(Non-Terminal States)
+  NT1 -->|ACTION| C
+  C(Call child reducer) -->|child return status| NT2
+  NT2(More Non-Terminal States) --> |SUCCESS_TRIGGER| Su
+  Su((Success))
+  NT2(More Non-Terminal States) --> |FAILURE_TRIGGER| F
+  F((Failure))
+
+  style St  fill:#efdd20
   style L fill:#efdd20
   style C stroke:#333,stroke-width:4px
+  style Su fill:#58ef21
+  style F  fill:#f45941
 ```
 
 ## Scenarios

--- a/packages/wallet/src/redux/protocols/concluding/reducer.ts
+++ b/packages/wallet/src/redux/protocols/concluding/reducer.ts
@@ -53,7 +53,10 @@ export function concludingReducer(
 export function initialize(channelId: string, processId: string, storage: Storage): ReturnVal {
   const channelState = getChannel(storage, channelId);
   if (!channelState) {
-    return { state: acknowledgeFailure({ processId, reason: 'ChannelDoesntExist' }), storage };
+    return {
+      state: acknowledgeFailure({ processId, channelId, reason: 'ChannelDoesntExist' }),
+      storage,
+    };
   }
   if (ourTurn(channelState)) {
     // if it's our turn now, we may resign

--- a/packages/wallet/src/redux/protocols/concluding/reducer.ts
+++ b/packages/wallet/src/redux/protocols/concluding/reducer.ts
@@ -141,11 +141,7 @@ function defundChosen(state: NonTerminalCState, storage: Storage): ReturnVal {
   }
   // initialize defunding state machine
 
-  const protocolStateWithSharedData = initializeDefunding(
-    state.processId,
-    storage.channelStore.activeAppChannelId,
-    storage,
-  );
+  const protocolStateWithSharedData = initializeDefunding(state.processId, 'channelId', storage);
   const defundingState = protocolStateWithSharedData.protocolState;
   return { state: waitForDefund({ ...state, defundingState }), storage };
 }

--- a/packages/wallet/src/redux/protocols/concluding/reducer.ts
+++ b/packages/wallet/src/redux/protocols/concluding/reducer.ts
@@ -144,7 +144,11 @@ function defundChosen(state: NonTerminalCState, storage: Storage): ReturnVal {
   }
   // initialize defunding state machine
 
-  const protocolStateWithSharedData = initializeDefunding(state.processId, 'channelId', storage);
+  const protocolStateWithSharedData = initializeDefunding(
+    state.processId,
+    state.channelId,
+    storage,
+  );
   const defundingState = protocolStateWithSharedData.protocolState;
   return { state: waitForDefund({ ...state, defundingState }), storage };
 }

--- a/packages/wallet/src/redux/protocols/concluding/reducer.ts
+++ b/packages/wallet/src/redux/protocols/concluding/reducer.ts
@@ -101,8 +101,8 @@ function concludeSent(state: NonTerminalCState, storage: Storage): ReturnVal {
     return { state, storage };
   }
 
-  if (storage.activeAppChannelId) {
-    const channelId = storage.activeAppChannelId;
+  if (storage.channelStore.activeAppChannelId) {
+    const channelId = storage.channelStore.activeAppChannelId;
 
     const channelState = getChannel(storage, channelId) as ChannelState;
 
@@ -116,7 +116,7 @@ function concludeSent(state: NonTerminalCState, storage: Storage): ReturnVal {
       state: waitForOpponentConclude({
         ...state,
         turnNum: concludeCommitment.turnNum,
-        penultimateCommitment: storage.channelStore[channelId].lastCommitment,
+        penultimateCommitment: storage.channelStore.initializedChannels.lastCommitment,
         lastCommitment: { commitment: concludeCommitment, signature: commitmentSignature },
       }),
       sideEffects: { messageOutbox: sendCommitmentAction },
@@ -140,8 +140,12 @@ function defundChosen(state: NonTerminalCState, storage: Storage): ReturnVal {
     return { state, storage };
   }
   // initialize defunding state machine
-  // TODO get proper channelId
-  const protocolStateWithSharedData = initializeDefunding(state.processId, 'channelId', storage);
+
+  const protocolStateWithSharedData = initializeDefunding(
+    state.processId,
+    storage.channelStore.activeAppChannelId,
+    storage,
+  );
   const defundingState = protocolStateWithSharedData.protocolState;
   return { state: waitForDefund({ ...state, defundingState }), storage };
 }

--- a/packages/wallet/src/redux/protocols/concluding/states.ts
+++ b/packages/wallet/src/redux/protocols/concluding/states.ts
@@ -1,5 +1,5 @@
 import { Constructor } from '../../utils';
-
+import { DefundingState } from '../defunding';
 export type ConcludingState = NonTerminalState | PreTerminalState | TerminalState;
 export type ConcludingStateType = ConcludingState['type'];
 
@@ -48,6 +48,7 @@ export interface AcknowledgeConcludeReceived {
 export interface WaitForDefund {
   type: 'WaitForDefund';
   processId: string;
+  defundingState: DefundingState;
 }
 
 export interface Failure {
@@ -105,8 +106,8 @@ export const acknowledgeFailure: Constructor<AcknowledgeFailure> = p => {
 };
 
 export const waitForDefund: Constructor<WaitForDefund> = p => {
-  const { processId } = p;
-  return { type: 'WaitForDefund', processId };
+  const { processId, defundingState } = p;
+  return { type: 'WaitForDefund', processId, defundingState };
 };
 
 export function success(): Success {

--- a/packages/wallet/src/redux/protocols/concluding/states.ts
+++ b/packages/wallet/src/redux/protocols/concluding/states.ts
@@ -11,7 +11,7 @@ export type NonTerminalState =
   | AcknowledgeSuccess
   | WaitForDefund;
 
-export type PreTerminalState = AcknowledgeFailure;
+export type PreTerminalState = AcknowledgeSuccess | AcknowledgeFailure;
 
 export type TerminalState = Success | Failure;
 

--- a/packages/wallet/src/redux/protocols/concluding/states.ts
+++ b/packages/wallet/src/redux/protocols/concluding/states.ts
@@ -24,30 +24,36 @@ export type FailureReason =
 export interface AcknowledgeSuccess {
   type: 'AcknowledgeSuccess';
   processId: string;
+  channelId: string;
 }
 export interface AcknowledgeFailure {
   type: 'AcknowledgeFailure';
   reason: FailureReason;
   processId: string;
+  channelId: string;
 }
 export interface ApproveConcluding {
   type: 'ApproveConcluding';
   processId: string;
+  channelId: string;
 }
 
 export interface WaitForOpponentConclude {
   type: 'WaitForOpponentConclude';
   processId: string;
+  channelId: string;
 }
 
 export interface AcknowledgeConcludeReceived {
   type: 'AcknowledgeConcludeReceived';
   processId: string;
+  channelId: string;
 }
 
 export interface WaitForDefund {
   type: 'WaitForDefund';
   processId: string;
+  channelId: string;
   defundingState: DefundingState;
 }
 
@@ -81,33 +87,33 @@ export function isFailure(state: ConcludingState): state is Failure {
 // ------------
 
 export const approveConcluding: Constructor<ApproveConcluding> = p => {
-  const { processId } = p;
-  return { type: 'ApproveConcluding', processId };
+  const { processId, channelId } = p;
+  return { type: 'ApproveConcluding', processId, channelId };
 };
 
 export const waitForOpponentConclude: Constructor<WaitForOpponentConclude> = p => {
-  const { processId } = p;
-  return { type: 'WaitForOpponentConclude', processId };
+  const { processId, channelId } = p;
+  return { type: 'WaitForOpponentConclude', processId, channelId };
 };
 
 export const acknowledgeConcludeReceived: Constructor<AcknowledgeConcludeReceived> = p => {
-  const { processId } = p;
-  return { type: 'AcknowledgeConcludeReceived', processId };
+  const { processId, channelId } = p;
+  return { type: 'AcknowledgeConcludeReceived', processId, channelId };
 };
 
 export const acknowledgeSuccess: Constructor<AcknowledgeSuccess> = p => {
-  const { processId, reason } = p;
-  return { type: 'AcknowledgeSuccess', processId, reason };
+  const { processId, channelId } = p;
+  return { type: 'AcknowledgeSuccess', processId, channelId };
 };
 
 export const acknowledgeFailure: Constructor<AcknowledgeFailure> = p => {
-  const { processId, reason } = p;
-  return { type: 'AcknowledgeFailure', processId, reason };
+  const { processId, channelId, reason } = p;
+  return { type: 'AcknowledgeFailure', processId, channelId, reason };
 };
 
 export const waitForDefund: Constructor<WaitForDefund> = p => {
-  const { processId, defundingState } = p;
-  return { type: 'WaitForDefund', processId, defundingState };
+  const { processId, channelId, defundingState } = p;
+  return { type: 'WaitForDefund', processId, channelId, defundingState };
 };
 
 export function success(): Success {

--- a/packages/wallet/src/redux/protocols/concluding/states.ts
+++ b/packages/wallet/src/redux/protocols/concluding/states.ts
@@ -4,21 +4,14 @@ export type ConcludingState = NonTerminalState | PreTerminalState | TerminalStat
 export type ConcludingStateType = ConcludingState['type'];
 
 export type NonTerminalState =
-  | AcknowledgeConcludingImpossible
   | ApproveConcluding
   | WaitForOpponentConclude
-  | AcknowledgeChannelConcluded
-  | AcknowledgeChannelDoesntExist
-  | AcknowledgeDefundFailed
-  | WaitForDefund
-  | AcknowledgeChannelDoesntExist
-  | AcknowledgeDefundFailed
-  | AcknowledgeConcludingImpossible;
+  | AcknowledgeConcludeReceived
+  | AcknowledgeFailure
+  | AcknowledgeSuccess
+  | WaitForDefund;
 
-export type PreTerminalState =
-  | AcknowledgeChannelDoesntExist
-  | AcknowledgeDefundFailed
-  | AcknowledgeConcludingImpossible;
+export type PreTerminalState = AcknowledgeFailure;
 
 export type TerminalState = Success | Failure;
 
@@ -28,8 +21,13 @@ export type FailureReason =
   | 'ConcludeCancelled'
   | 'DefundFailed';
 
-export interface AcknowledgeConcludingImpossible {
-  type: 'AcknowledgeConcludingImpossible';
+export interface AcknowledgeSuccess {
+  type: 'AcknowledgeSuccess';
+  processId: string;
+}
+export interface AcknowledgeFailure {
+  type: 'AcknowledgeFailure';
+  reason: FailureReason;
   processId: string;
 }
 export interface ApproveConcluding {
@@ -42,18 +40,8 @@ export interface WaitForOpponentConclude {
   processId: string;
 }
 
-export interface AcknowledgeChannelConcluded {
-  type: 'AcknowledgeChannelConcluded';
-  processId: string;
-}
-
-export interface AcknowledgeChannelDoesntExist {
-  type: 'AcknowledgeChannelDoesntExist';
-  processId: string;
-}
-
-export interface AcknowledgeDefundFailed {
-  type: 'AcknowledgeDefundFailed';
+export interface AcknowledgeConcludeReceived {
+  type: 'AcknowledgeConcludeReceived';
   processId: string;
 }
 
@@ -90,10 +78,6 @@ export function isFailure(state: ConcludingState): state is Failure {
 // ------------
 // Constructors
 // ------------
-export const acknowledgeConcludingImpossible: Constructor<AcknowledgeConcludingImpossible> = p => {
-  const { processId } = p;
-  return { type: 'AcknowledgeConcludingImpossible', processId };
-};
 
 export const approveConcluding: Constructor<ApproveConcluding> = p => {
   const { processId } = p;
@@ -105,19 +89,19 @@ export const waitForOpponentConclude: Constructor<WaitForOpponentConclude> = p =
   return { type: 'WaitForOpponentConclude', processId };
 };
 
-export const acknowledgeChannelConcluded: Constructor<AcknowledgeChannelConcluded> = p => {
+export const AcknowledgeConcludeReceived: Constructor<AcknowledgeConcludeReceived> = p => {
   const { processId } = p;
-  return { type: 'AcknowledgeChannelConcluded', processId };
+  return { type: 'AcknowledgeConcludeReceived', processId };
 };
 
-export const acknowledgeChannelDoesntExist: Constructor<AcknowledgeChannelDoesntExist> = p => {
-  const { processId } = p;
-  return { type: 'AcknowledgeChannelDoesntExist', processId };
+export const acknowledgeSuccess: Constructor<AcknowledgeSuccess> = p => {
+  const { processId, reason } = p;
+  return { type: 'AcknowledgeSuccess', processId, reason };
 };
 
-export const acknowledgeDefundFailed: Constructor<AcknowledgeDefundFailed> = p => {
-  const { processId } = p;
-  return { type: 'AcknowledgeDefundFailed', processId };
+export const acknowledgeFailure: Constructor<AcknowledgeFailure> = p => {
+  const { processId, reason } = p;
+  return { type: 'AcknowledgeFailure', processId, reason };
 };
 
 export const waitForDefund: Constructor<WaitForDefund> = p => {

--- a/packages/wallet/src/redux/protocols/concluding/states.ts
+++ b/packages/wallet/src/redux/protocols/concluding/states.ts
@@ -89,7 +89,7 @@ export const waitForOpponentConclude: Constructor<WaitForOpponentConclude> = p =
   return { type: 'WaitForOpponentConclude', processId };
 };
 
-export const AcknowledgeConcludeReceived: Constructor<AcknowledgeConcludeReceived> = p => {
+export const acknowledgeConcludeReceived: Constructor<AcknowledgeConcludeReceived> = p => {
   const { processId } = p;
   return { type: 'AcknowledgeConcludeReceived', processId };
 };

--- a/packages/wallet/src/redux/protocols/defunding/__tests__/index.ts
+++ b/packages/wallet/src/redux/protocols/defunding/__tests__/index.ts
@@ -1,0 +1,7 @@
+import { directlyFundingChannelHappyPath, directlyFundingFailure } from './scenarios';
+
+export const preSuccessState = directlyFundingChannelHappyPath.waitForWithdrawal;
+export const successTrigger = directlyFundingChannelHappyPath.withdrawalSuccessAction;
+
+export const preFailureState = directlyFundingFailure.waitForWithdrawal;
+export const failureTrigger = directlyFundingFailure.withdrawalFailureAction;

--- a/packages/wallet/src/redux/protocols/defunding/__tests__/reducer.test.ts
+++ b/packages/wallet/src/redux/protocols/defunding/__tests__/reducer.test.ts
@@ -1,4 +1,4 @@
-import * as states from '../state';
+import * as states from '../states';
 import { initialize, defundingReducer } from '../reducer';
 import * as scenarios from './scenarios';
 

--- a/packages/wallet/src/redux/protocols/defunding/__tests__/scenarios.ts
+++ b/packages/wallet/src/redux/protocols/defunding/__tests__/scenarios.ts
@@ -1,4 +1,4 @@
-import * as states from '../state';
+import * as states from '../states';
 import * as withdrawalScenarios from '../../withdrawing/__tests__/scenarios';
 import * as testScenarios from '../../../__tests__/test-scenarios';
 import { ChannelState, ChannelStore } from '../../../channel-store';

--- a/packages/wallet/src/redux/protocols/defunding/actions.ts
+++ b/packages/wallet/src/redux/protocols/defunding/actions.ts
@@ -1,5 +1,20 @@
-import { WithdrawalAction } from '../withdrawing/actions';
-import { TransactionConfirmed } from '../transaction-submission/actions';
+import { WalletAction } from '../../actions';
+import {
+  WithdrawalAction,
+  WITHDRAWAL_APPROVED,
+  WITHDRAWAL_REJECTED,
+  WITHDRAWAL_SUCCESS_ACKNOWLEDGED,
+} from '../withdrawing/actions';
+import { TransactionConfirmed, TRANSACTION_CONFIRMED } from '../transaction-submission/actions';
 // TODO: Replace once ledger defunding actions are defined
 type LedgerDefundingAction = TransactionConfirmed;
 export type DefundingAction = WithdrawalAction | LedgerDefundingAction;
+
+export const isDefundingAction = (action: WalletAction): action is DefundingAction => {
+  return (
+    action.type === WITHDRAWAL_APPROVED ||
+    action.type === WITHDRAWAL_SUCCESS_ACKNOWLEDGED ||
+    action.type === WITHDRAWAL_REJECTED ||
+    action.type === TRANSACTION_CONFIRMED
+  );
+};

--- a/packages/wallet/src/redux/protocols/defunding/container.tsx
+++ b/packages/wallet/src/redux/protocols/defunding/container.tsx
@@ -1,4 +1,4 @@
-import * as states from './state';
+import * as states from './states';
 import { PureComponent } from 'react';
 import { Withdrawal } from '../withdrawing/container';
 import React from 'react';

--- a/packages/wallet/src/redux/protocols/defunding/index.ts
+++ b/packages/wallet/src/redux/protocols/defunding/index.ts
@@ -1,0 +1,5 @@
+export { initialize, defundingReducer } from './reducer';
+
+export { Defunding } from './container';
+
+export { DefundingState, NonTerminalDefundingState } from './states';

--- a/packages/wallet/src/redux/protocols/defunding/readme.md
+++ b/packages/wallet/src/redux/protocols/defunding/readme.md
@@ -21,6 +21,34 @@ graph TD
   LDP-->|Ledger de-funding protocol success|Su((success))
   WP-->|Withdrawal protocol failure|F((failure))
   LDP-->|Ledger de-funding protocol failure|F((failure))
+
+  style S  fill:#efdd20
+  style ICC  fill:#efdd20
+  style ID fill:#efdd20
+  style Su fill:#58ef21
+  style F  fill:#f45941
+  style WP stroke:#333,stroke-width:4px
+  style LDP stroke:#333,stroke-width:4px
+```
+
+Key:
+
+```mermaid
+  graph TD
+  St((Start))-->L
+  L{Flow Logic} --> NT1(Non-Terminal States)
+  NT1 -->|ACTION| C
+  C(Call child reducer) -->|child return status| NT2
+  NT2(More Non-Terminal States) --> |SUCCESS_TRIGGER| Su
+  Su((Success))
+  NT2(More Non-Terminal States) --> |FAILURE_TRIGGER| F
+  F((Failure))
+
+  style St  fill:#efdd20
+  style L fill:#efdd20
+  style C stroke:#333,stroke-width:4px
+  style Su fill:#58ef21
+  style F  fill:#f45941
 ```
 
 ## Notes

--- a/packages/wallet/src/redux/protocols/defunding/reducer.ts
+++ b/packages/wallet/src/redux/protocols/defunding/reducer.ts
@@ -1,6 +1,6 @@
 import { SharedData } from '../../state';
 import { ProtocolStateWithSharedData } from '..';
-import * as states from './state';
+import * as states from './states';
 import { DefundingAction } from './actions';
 import * as helpers from '../reducer-helpers';
 import { withdrawalReducer, initialize as withdrawalInitialize } from './../withdrawing/reducer';

--- a/packages/wallet/src/redux/protocols/defunding/states.ts
+++ b/packages/wallet/src/redux/protocols/defunding/states.ts
@@ -6,6 +6,7 @@ export const WAIT_FOR_LEDGER_DEFUNDING = 'WaitForLedgerDefunding';
 export const FAILURE = 'Failure';
 export const SUCCESS = 'Success';
 
+export type NonTerminalDefundingState = WaitForWithdrawal | WaitForLedgerDefunding;
 export type DefundingState = WaitForWithdrawal | WaitForLedgerDefunding | Failure | Success;
 
 export type FailureReason =
@@ -41,6 +42,14 @@ export interface Success {
 
 export function isTerminal(state: DefundingState): state is Failure | Success {
   return state.type === FAILURE || state.type === SUCCESS;
+}
+
+export function isSuccess(state: DefundingState): state is Success {
+  return state.type === SUCCESS;
+}
+
+export function isFailure(state: DefundingState): state is Failure {
+  return state.type === FAILURE;
 }
 
 // -------

--- a/packages/wallet/src/redux/protocols/index.ts
+++ b/packages/wallet/src/redux/protocols/index.ts
@@ -1,7 +1,6 @@
 import { SharedData } from '../state';
 import { ChallengingState } from './challenging/states';
 import { ConcludingState } from './concluding/states';
-import { DefundingState } from './defunding/state';
 import { DirectFundingState } from './direct-funding/state';
 import { FundingState } from './funding/states';
 import { IndirectFundingState } from './indirect-funding/state';
@@ -9,6 +8,7 @@ import { RespondingState } from './responding/state';
 import { WithdrawalState } from './withdrawing/states';
 import { ApplicationState } from './application/states';
 import { IndirectDefundingState } from './indirect-defunding/state';
+import { DefundingState } from './defunding/states';
 
 export type ProtocolState =
   | ApplicationState

--- a/packages/wallet/src/utils/commitment-utils.ts
+++ b/packages/wallet/src/utils/commitment-utils.ts
@@ -121,7 +121,7 @@ export const composeConcludeCommitment = (channelState: ChannelState) => {
     {
       processId: channelState.channelId,
       data: {
-        concludeCommitment,
+        commitment: concludeCommitment,
         commitmentSignature,
       },
     },

--- a/packages/wallet/src/utils/commitment-utils.ts
+++ b/packages/wallet/src/utils/commitment-utils.ts
@@ -109,7 +109,7 @@ export const composeConcludeCommitment = (channelState: ChannelState) => {
 
   const concludeCommitment: Commitment = {
     ...channelState.lastCommitment.commitment,
-    appAttributes: '',
+    appAttributes: '0x0',
     commitmentType: CommitmentType.Conclude,
     turnNum: channelState.lastCommitment.commitment.turnNum + 1,
     commitmentCount,


### PR DESCRIPTION
Will close #407.

Conclude commitment
- [x] actually craft and send
- [x] test this^
Reference: `channel-states/closing/*`

`Defund` sub-protocol
- [x] Actually spool up the protocol at the appropriate point
- [x] Parent reducer needs to handle actions of child protocol
- [x] `DEFUND_SUCCEEDED` and `DEFUND_FAILED` should not be actions
Reference: `challenging` protocol
- [x] fixup scenarios, tests
- [x] fix final test, consider storing `channelId` on certain concluding states.

Cleaning up
- [x] Unify the various 'Acknowledge' states
- [x] Furnish with data that is displayed to user
- [x] Differentiate actions from non-actions in readme diagram (caps/non-caps?)

They conclude, not me
- [ ] Consider new protocol for this
Reference: `channel-states/closing/*`