### PR TITLE
Update shared data before protocol reducers

### DIFF
--- a/packages/wallet/src/redux/__tests__/initialized.test.ts
+++ b/packages/wallet/src/redux/__tests__/initialized.test.ts
@@ -6,7 +6,7 @@ import * as scenarios from './test-scenarios';
 import { PlayerIndex, WalletProtocol } from '../types';
 import * as fundProtocol from '../protocols/funding';
 import { fundingRequested } from '../protocols/actions';
-
+import * as adjudicatorState from '../adjudicator-state/reducer';
 const { channelId } = scenarios;
 
 const defaults = {
@@ -72,5 +72,18 @@ describe('when a ProcessAction arrives', () => {
       states.EMPTY_SHARED_DATA,
       action,
     );
+  });
+});
+
+describe('when a updateSharedData action arrives', () => {
+  const reducer = jest.fn(() => ({}));
+  Object.defineProperty(adjudicatorState, 'adjudicatorStateReducer', { value: reducer });
+
+  const action = actions.challengeExpiredEvent('123', '123', 1);
+  const state = { ...initializedState, adjudicatorState: {} };
+  walletReducer(initializedState, action);
+
+  it('passes the action to the adjudicator state reducer', () => {
+    expect(reducer).toHaveBeenCalledWith(state.adjudicatorState, action);
   });
 });

--- a/packages/wallet/src/redux/actions.ts
+++ b/packages/wallet/src/redux/actions.ts
@@ -193,3 +193,20 @@ export {
   isCommonAction,
   application,
 };
+
+// These are any actions that update shared data directly without any protocol
+export type SharedDataUpdateAction = AdjudicatorEventAction;
+
+export function isSharedDataUpdateAction(action: WalletAction): action is SharedDataUpdateAction {
+  return isAdjudicatorEventAction(action);
+}
+
+export function isAdjudicatorEventAction(action: WalletAction): action is AdjudicatorEventAction {
+  return (
+    action.type === CONCLUDED_EVENT ||
+    action.type === REFUTED_EVENT ||
+    action.type === RESPOND_WITH_MOVE_EVENT ||
+    action.type === FUNDING_RECEIVED_EVENT ||
+    action.type === CHALLENGE_EXPIRED_EVENT
+  );
+}

--- a/packages/wallet/src/redux/adjudicator-state/reducer.ts
+++ b/packages/wallet/src/redux/adjudicator-state/reducer.ts
@@ -11,7 +11,7 @@ import { unreachable } from '../../utils/reducer-utils';
 export const adjudicatorStateReducer = (
   state: AdjudicatorState,
   action: actions.AdjudicatorEventAction | actions.ChallengeCreatedEvent,
-) => {
+): AdjudicatorState => {
   switch (action.type) {
     case actions.CHALLENGE_EXPIRED_EVENT:
       return challengeExpiredReducer(state, action);
@@ -54,7 +54,7 @@ const fundingReceivedEventReducer = (
   action: actions.FundingReceivedEvent,
 ) => {
   const { channelId } = action;
-  addToBalance(state, channelId, action.amount);
+  return addToBalance(state, channelId, action.amount);
 };
 
 const challengeExpiredReducer = (

--- a/packages/wallet/src/redux/reducer.ts
+++ b/packages/wallet/src/redux/reducer.ts
@@ -13,6 +13,7 @@ import * as challengeResponseProtocol from './protocols/responding';
 import * as states from './state';
 import { WalletProtocol } from './types';
 import { APPLICATION_PROCESS_ID } from './protocols/application/reducer';
+import { adjudicatorStateReducer } from './adjudicator-state/reducer';
 
 const initialState = states.waitForLogin();
 
@@ -40,15 +41,28 @@ export function initializedReducer(
   state: states.Initialized,
   action: actions.WalletAction,
 ): states.WalletState {
-  // TODO: We will need to update SharedData here first
+  let newState = { ...state };
+  if (actions.isSharedDataUpdateAction(action)) {
+    newState = updateSharedData(newState, action);
+  }
 
   if (isNewProcessAction(action)) {
-    return routeToNewProcessInitializer(state, action);
+    return routeToNewProcessInitializer(newState, action);
   } else if (isProtocolAction(action)) {
-    return routeToProtocolReducer(state, action);
+    return routeToProtocolReducer(newState, action);
   }
 
   return state;
+}
+function updateSharedData(
+  state: states.Initialized,
+  action: actions.SharedDataUpdateAction,
+): states.Initialized {
+  if (actions.isAdjudicatorEventAction(action)) {
+    return { ...state, adjudicatorState: adjudicatorStateReducer(state.adjudicatorState, action) };
+  } else {
+    return state;
+  }
 }
 
 function routeToProtocolReducer(


### PR DESCRIPTION
Added some simple logic so that we update the shared data before calling the protocol reducers.

Right now this only handles `AdjudicatorEventAction`s.

Fixes #435 