### PR TITLE
Indirect Funding Work

### DIFF
--- a/packages/wallet/src/domain/commitments/index.ts
+++ b/packages/wallet/src/domain/commitments/index.ts
@@ -94,7 +94,7 @@ export function nextSetupCommitment(commitment: Commitment): Commitment | 'NotAS
   if (turnNum < numParticipants) {
     commitmentType = CommitmentType.PreFundSetup;
     commitmentCount = turnNum;
-  } else if (turnNum < 2 * numParticipants - 1) {
+  } else if (turnNum <= 2 * numParticipants - 1) {
     commitmentType = CommitmentType.PostFundSetup;
     commitmentCount = turnNum - numParticipants;
   } else {

--- a/packages/wallet/src/domain/commitments/index.ts
+++ b/packages/wallet/src/domain/commitments/index.ts
@@ -94,7 +94,7 @@ export function nextSetupCommitment(commitment: Commitment): Commitment | 'NotAS
   if (turnNum < numParticipants) {
     commitmentType = CommitmentType.PreFundSetup;
     commitmentCount = turnNum;
-  } else if (turnNum <= 2 * numParticipants - 1) {
+  } else if (turnNum < 2 * numParticipants - 1) {
     commitmentType = CommitmentType.PostFundSetup;
     commitmentCount = turnNum - numParticipants;
   } else {

--- a/packages/wallet/src/domain/commitments/index.ts
+++ b/packages/wallet/src/domain/commitments/index.ts
@@ -49,7 +49,9 @@ export function constructConclude(commitment: Commitment): Commitment {
 export function nextLedgerUpdateCommitment(
   commitment: Commitment,
 ): Commitment | 'NotAnUpdateCommitment' {
-  if (commitment.commitmentType !== CommitmentType.App || commitment.turnNum > 4) {
+  const numParticipants = commitment.channel.participants.length;
+  const turnNum = commitment.turnNum + 1;
+  if (commitment.commitmentType !== CommitmentType.App || turnNum <= 2 * numParticipants - 1) {
     return 'NotAnUpdateCommitment';
   }
   const appAttributes = appAttributesFromBytes(commitment.appAttributes);
@@ -59,7 +61,7 @@ export function nextLedgerUpdateCommitment(
     allocation: appAttributes.proposedAllocation,
     destination: appAttributes.proposedDestination,
     appAttributes: updatedAppAttributes,
-    turnNum: commitment.turnNum + 1,
+    turnNum,
     commitmentCount: 0,
   };
 }
@@ -72,7 +74,7 @@ export function nextSetupCommitment(commitment: Commitment): Commitment | 'NotAS
   if (turnNum < numParticipants) {
     commitmentType = CommitmentType.PreFundSetup;
     commitmentCount = turnNum;
-  } else if (turnNum < 2 * numParticipants - 1) {
+  } else if (turnNum <= 2 * numParticipants - 1) {
     commitmentType = CommitmentType.PostFundSetup;
     commitmentCount = turnNum - numParticipants;
   } else {

--- a/packages/wallet/src/redux/protocols/indirect-funding/player-a/__tests__/scenarios.ts
+++ b/packages/wallet/src/redux/protocols/indirect-funding/player-a/__tests__/scenarios.ts
@@ -11,9 +11,10 @@ import { EMPTY_SHARED_DATA, setChannels } from '../../../../state';
 
 import {
   preSuccessStateB,
-  successTriggerB,
   preFailureState,
   failureTrigger,
+  successTriggerA,
+  preSuccessStateA,
 } from '../../../direct-funding/__tests__';
 import {
   appCommitment,
@@ -44,6 +45,7 @@ const app3 = appCommitment({ turnNum: 3, balances: twoThree });
 
 const ledger0 = ledgerCommitment({ turnNum: 0, balances: twoThree });
 const ledger1 = ledgerCommitment({ turnNum: 1, balances: twoThree });
+const ledger2 = ledgerCommitment({ turnNum: 2, balances: twoThree });
 const ledger3 = ledgerCommitment({ turnNum: 3, balances: twoThree });
 const ledger4 = ledgerCommitment({ turnNum: 4, balances: twoThree, proposedBalances: fiveToApp });
 const ledger5 = ledgerCommitment({ turnNum: 5, balances: fiveToApp });
@@ -63,10 +65,10 @@ const waitForPreFundL1 = {
   ]),
 };
 const waitForDirectFunding = {
-  state: aWaitForDirectFunding({ ...props, directFundingState: preSuccessStateB.protocolState }), //
+  state: aWaitForDirectFunding({ ...props, directFundingState: preSuccessStateA.protocolState }), //
   store: setChannels(preSuccessStateB.sharedData, [
-    channelFromCommitments(app0, app1, asAddress, asPrivateKey),
-    channelFromCommitments(ledger0, ledger1, asAddress, asPrivateKey),
+    channelFromCommitments(app1, app2, asAddress, asPrivateKey),
+    channelFromCommitments(ledger2, ledger3, asAddress, asPrivateKey),
   ]),
 };
 const waitForLedgerUpdate1 = {
@@ -102,7 +104,7 @@ const postFund1Received = globalActions.commitmentReceived(processId, app3);
 export const happyPath = {
   initialParams: { store: waitForPreFundL1.store, channelId, reply: ledger0 },
   waitForPreFundL1: { state: waitForPreFundL1, action: preFundL1Received },
-  waitForDirectFunding: { state: waitForDirectFunding, action: successTriggerB, reply: ledger4 },
+  waitForDirectFunding: { state: waitForDirectFunding, action: successTriggerA, reply: ledger4 },
   waitForLedgerUpdate1: {
     state: waitForLedgerUpdate1,
     action: ledgerUpdate1Received,

--- a/packages/wallet/src/redux/protocols/indirect-funding/player-a/reducer.ts
+++ b/packages/wallet/src/redux/protocols/indirect-funding/player-a/reducer.ts
@@ -2,16 +2,58 @@ import * as states from './state';
 
 import * as actions from '../../../actions';
 
-import { SharedData } from '../../../state';
+import {
+  SharedData,
+  signAndInitialize,
+  getAddressAndPrivateKey,
+  queueMessage,
+} from '../../../state';
 import { IndirectFundingState } from '../state';
 import { ProtocolStateWithSharedData } from '../..';
+import { bytesFromAppAttributes } from 'fmg-nitro-adjudicator';
+import { CommitmentType, Commitment, getChannelId } from '../../../../domain';
+import { Channel } from 'fmg-core/lib/channel';
+import { CONSENSUS_LIBRARY_ADDRESS } from '../../../../constants';
+import { getChannel, theirAddress } from '../../../channel-store';
+import { createCommitmentMessageRelay } from '../../reducer-helpers';
 
 type ReturnVal = ProtocolStateWithSharedData<IndirectFundingState>;
 
 export function initialize(channelId: string, sharedData: SharedData): ReturnVal {
+  const channel = getChannel(sharedData.channelStore, channelId);
+  if (!channel) {
+    throw new Error(`Could not find existing application channel ${channelId}`);
+  }
+  // TODO: Should we have to pull these of the commitment or should they just be arguments to initialize?
+  const { allocation, destination } = channel.lastCommitment.commitment;
+  const ourCommitment = createInitialSetupCommitment(allocation, destination);
+
+  const addressAndPrivateKey = getAddressAndPrivateKey(sharedData, channelId);
+  if (!addressAndPrivateKey) {
+    throw new Error(`Could not find address and private key for existing channel ${channelId}`);
+  }
+
+  const { address, privateKey } = addressAndPrivateKey;
+  const signResult = signAndInitialize(sharedData, ourCommitment, address, privateKey);
+  if (!signResult.isSuccess) {
+    throw new Error('Could not store new ledger channel commitment.');
+  }
+  sharedData = signResult.store;
+
+  const ledgerId = getChannelId(ourCommitment);
+
+  // just need to put our message in the outbox
+  const messageRelay = createCommitmentMessageRelay(
+    theirAddress(channel),
+    'processId', // TODO don't use dummy values
+    signResult.signedCommitment.commitment,
+    signResult.signedCommitment.signature,
+  );
+  sharedData = queueMessage(sharedData, messageRelay);
+
   const protocolState = states.aWaitForPreFundSetup1({
     channelId,
-    ledgerId: 'ledgerid',
+    ledgerId,
   });
   return { protocolState, sharedData };
 }
@@ -22,4 +64,29 @@ export function playerAReducer(
   action: actions.indirectFunding.Action,
 ): ReturnVal {
   return { protocolState, sharedData };
+}
+
+function createInitialSetupCommitment(allocation: string[], destination: string[]): Commitment {
+  const appAttributes = {
+    proposedAllocation: allocation,
+    proposedDestination: destination,
+    consensusCounter: 0,
+  };
+  // TODO: We'll run into collisions if we reuse the same nonce
+  const nonce = 0;
+  console.log(nonce);
+  const channel: Channel = {
+    nonce,
+    participants: destination,
+    channelType: CONSENSUS_LIBRARY_ADDRESS,
+  };
+  return {
+    turnNum: 0,
+    commitmentCount: 0,
+    commitmentType: CommitmentType.PreFundSetup,
+    appAttributes: bytesFromAppAttributes(appAttributes),
+    allocation,
+    destination,
+    channel,
+  };
 }

--- a/packages/wallet/src/redux/protocols/indirect-funding/player-b/__tests__/scenarios.ts
+++ b/packages/wallet/src/redux/protocols/indirect-funding/player-b/__tests__/scenarios.ts
@@ -39,8 +39,6 @@ const fiveToApp = [{ address: channelId, wei: bigNumberify(5).toHexString() }];
 
 const app0 = appCommitment({ turnNum: 0, balances: twoThree });
 const app1 = appCommitment({ turnNum: 1, balances: twoThree });
-const app2 = appCommitment({ turnNum: 2, balances: twoThree });
-const app3 = appCommitment({ turnNum: 3, balances: twoThree });
 
 const ledger0 = ledgerCommitment({ turnNum: 0, balances: twoThree });
 const ledger1 = ledgerCommitment({ turnNum: 1, balances: twoThree });
@@ -80,7 +78,7 @@ const waitForPostFund0 = {
   state: bWaitForPostFundSetup0(props),
   store: setChannels(EMPTY_SHARED_DATA, [
     channelFromCommitments(app0, app1, bsAddress, bsPrivateKey),
-    channelFromCommitments(ledger4, ledger5, bsAddress, bsPrivateKey),
+    channelFromCommitments(ledger0, ledger1, bsAddress, bsPrivateKey),
   ]),
 };
 
@@ -97,7 +95,7 @@ const waitForDirectFundingFailure = {
 // -------
 const preFundSetup0Received = globalActions.commitmentReceived(processId, ledger0);
 const ledgerUpdate0Received = globalActions.commitmentReceived(processId, ledger4);
-const postFund0Received = globalActions.commitmentReceived(processId, app2);
+const postFund0Received = globalActions.commitmentReceived(processId, ledger2);
 
 export const happyPath = {
   initialParams: { store: waitForPreFundSetup0.store, channelId },
@@ -112,7 +110,7 @@ export const happyPath = {
     action: ledgerUpdate0Received,
     reply: ledger5,
   },
-  waitForPostFund0: { state: waitForPostFund0, action: postFund0Received, reply: app3 },
+  waitForPostFund0: { state: waitForPostFund0, action: postFund0Received, reply: ledger3 },
 };
 
 export const ledgerFundingFails = {

--- a/packages/wallet/src/redux/protocols/indirect-funding/player-b/__tests__/scenarios.ts
+++ b/packages/wallet/src/redux/protocols/indirect-funding/player-b/__tests__/scenarios.ts
@@ -39,6 +39,8 @@ const fiveToApp = [{ address: channelId, wei: bigNumberify(5).toHexString() }];
 
 const app0 = appCommitment({ turnNum: 0, balances: twoThree });
 const app1 = appCommitment({ turnNum: 1, balances: twoThree });
+const app2 = appCommitment({ turnNum: 2, balances: twoThree });
+const app3 = appCommitment({ turnNum: 3, balances: twoThree });
 
 const ledger0 = ledgerCommitment({ turnNum: 0, balances: twoThree });
 const ledger1 = ledgerCommitment({ turnNum: 1, balances: twoThree });
@@ -95,7 +97,7 @@ const waitForDirectFundingFailure = {
 // -------
 const preFundSetup0Received = globalActions.commitmentReceived(processId, ledger0);
 const ledgerUpdate0Received = globalActions.commitmentReceived(processId, ledger4);
-const postFund0Received = globalActions.commitmentReceived(processId, ledger2);
+const postFund0Received = globalActions.commitmentReceived(processId, app2);
 
 export const happyPath = {
   initialParams: { store: waitForPreFundSetup0.store, channelId },
@@ -110,7 +112,7 @@ export const happyPath = {
     action: ledgerUpdate0Received,
     reply: ledger5,
   },
-  waitForPostFund0: { state: waitForPostFund0, action: postFund0Received, reply: ledger3 },
+  waitForPostFund0: { state: waitForPostFund0, action: postFund0Received, reply: app3 },
 };
 
 export const ledgerFundingFails = {

--- a/packages/wallet/src/redux/protocols/indirect-funding/player-b/__tests__/scenarios.ts
+++ b/packages/wallet/src/redux/protocols/indirect-funding/player-b/__tests__/scenarios.ts
@@ -80,7 +80,7 @@ const waitForPostFund0 = {
   state: bWaitForPostFundSetup0(props),
   store: setChannels(EMPTY_SHARED_DATA, [
     channelFromCommitments(app0, app1, bsAddress, bsPrivateKey),
-    channelFromCommitments(ledger0, ledger1, bsAddress, bsPrivateKey),
+    channelFromCommitments(ledger4, ledger5, bsAddress, bsPrivateKey),
   ]),
 };
 

--- a/packages/wallet/src/redux/protocols/indirect-funding/player-b/reducer.ts
+++ b/packages/wallet/src/redux/protocols/indirect-funding/player-b/reducer.ts
@@ -253,7 +253,7 @@ export function handleWaitForPostFundSetup(
   sharedData = signResult.store;
   const ledgerId = getChannelId(theirCommitment);
   let channel = getChannel(sharedData, ledgerId);
-  if (!channel || channel.libraryAddress !== CONSENSUS_LIBRARY_ADDRESS) {
+  if (!channel || channel.libraryAddress === CONSENSUS_LIBRARY_ADDRESS) {
     // todo: this could be more robust somehow.
     // Maybe we should generate what we were expecting and compare.
     throw new Error('Bad channel');

--- a/packages/wallet/src/redux/protocols/indirect-funding/player-b/reducer.ts
+++ b/packages/wallet/src/redux/protocols/indirect-funding/player-b/reducer.ts
@@ -152,22 +152,23 @@ function handleWaitForDirectFunding(
     return { protocolState, sharedData };
   }
 
-  const directFundingState1 = protocolState.directFundingState;
+  const existingDirectFundingState = protocolState.directFundingState;
   const protocolStateWithSharedData = directFundingStateReducer(
-    directFundingState1,
+    existingDirectFundingState,
     sharedData,
     action,
   );
-  const directFundingState2 = protocolStateWithSharedData.protocolState;
-  // TODO: We need to update the direct funding state on our protocol state
-  // Otherwise we'll never progress from the initial direct funding state.
-  if (isSuccess(directFundingState2)) {
-    return { protocolState: bWaitForLedgerUpdate0(protocolState), sharedData };
-  } else if (isFailure(directFundingState2)) {
+  // Update direct funding state on our protocol state
+  const newDirectFundingState = protocolStateWithSharedData.protocolState;
+  const newProtocolState = { ...protocolState, directFundingState: newDirectFundingState };
+
+  if (isSuccess(newDirectFundingState)) {
+    return { protocolState: bWaitForLedgerUpdate0(newProtocolState), sharedData };
+  } else if (isFailure(newDirectFundingState)) {
     return { protocolState: failure(), sharedData };
   }
 
-  return { protocolState, sharedData };
+  return { protocolState: newProtocolState, sharedData };
 }
 
 function handleWaitForLedgerUpdate(

--- a/packages/wallet/src/redux/protocols/indirect-funding/player-b/reducer.ts
+++ b/packages/wallet/src/redux/protocols/indirect-funding/player-b/reducer.ts
@@ -159,7 +159,8 @@ function handleWaitForDirectFunding(
     action,
   );
   const directFundingState2 = protocolStateWithSharedData.protocolState;
-
+  // TODO: We need to update the direct funding state on our protocol state
+  // Otherwise we'll never progress from the initial direct funding state.
   if (isSuccess(directFundingState2)) {
     return { protocolState: bWaitForLedgerUpdate0(protocolState), sharedData };
   } else if (isFailure(directFundingState2)) {

--- a/packages/wallet/src/redux/protocols/indirect-funding/player-b/reducer.ts
+++ b/packages/wallet/src/redux/protocols/indirect-funding/player-b/reducer.ts
@@ -251,8 +251,9 @@ export function handleWaitForPostFundSetup(
     return unchangedState;
   }
   sharedData = signResult.store;
-  const ledgerId = getChannelId(theirCommitment);
-  let channel = getChannel(sharedData, ledgerId);
+  // We expect this to be a application post fund setup
+  const appId = getChannelId(theirCommitment);
+  let channel = getChannel(sharedData, appId);
   if (!channel || channel.libraryAddress === CONSENSUS_LIBRARY_ADDRESS) {
     // todo: this could be more robust somehow.
     // Maybe we should generate what we were expecting and compare.
@@ -266,7 +267,7 @@ export function handleWaitForPostFundSetup(
     signResult.signedCommitment.signature,
   );
   sharedData = queueMessage(sharedData, messageRelay);
-  channel = getChannel(sharedData, ledgerId); // refresh channel
+  channel = getChannel(sharedData, appId); // refresh channel
 
   const newProtocolState = success();
   const newReturnVal = { protocolState: newProtocolState, sharedData };

--- a/packages/wallet/src/redux/state.ts
+++ b/packages/wallet/src/redux/state.ts
@@ -14,6 +14,7 @@ import {
   checkAndStore as checkAndStoreChannelStore,
   checkAndInitialize as checkAndInitializeChannelStore,
   signAndStore as signAndStoreChannelStore,
+  signAndInitialize as signAndInitializeChannelStore,
   emptyChannelStore,
   SignFailureReason,
 } from './channel-store';
@@ -173,6 +174,20 @@ export function getAddressAndPrivateKey(
   } else {
     const { address, privateKey } = channel;
     return { address, privateKey };
+  }
+}
+
+export function signAndInitialize(
+  state: SharedData,
+  commitment: Commitment,
+  address: string,
+  privateKey: string,
+): SignResult {
+  const result = signAndInitializeChannelStore(state.channelStore, commitment, address, privateKey);
+  if (result.isSuccess) {
+    return { ...result, store: setChannelStore(state, result.store) };
+  } else {
+    return result;
   }
 }
 

--- a/packages/wallet/src/redux/state.ts
+++ b/packages/wallet/src/redux/state.ts
@@ -12,6 +12,7 @@ import {
   setChannel as setChannelInStore,
   setChannels as setChannelsInStore,
   checkAndStore as checkAndStoreChannelStore,
+  checkAndInitialize as checkAndInitializeChannelStore,
   signAndStore as signAndStoreChannelStore,
   emptyChannelStore,
   SignFailureReason,
@@ -23,7 +24,7 @@ import { WalletEvent } from 'magmo-wallet-client';
 import { TransactionRequest } from 'ethers/providers';
 import { WalletProtocol } from './types';
 import { AdjudicatorState } from './adjudicator-state/state';
-import { SignedCommitment, Commitment } from 'src/domain';
+import { SignedCommitment, Commitment } from '../domain';
 
 export type WalletState = WaitForLogin | MetaMaskError | Initialized;
 
@@ -160,6 +161,38 @@ export function setChannelStore(state: SharedData, channelStore: ChannelStore): 
 
 export function getLastMessage(state: SharedData): WalletEvent | undefined {
   return getLastMessageFromOutbox(state.outboxState);
+}
+
+export function getAddressAndPrivateKey(
+  state: SharedData,
+  channelId: string,
+): { address: string; privateKey: string } | undefined {
+  const channel = getChannel(state, channelId);
+  if (!channel) {
+    return undefined;
+  } else {
+    const { address, privateKey } = channel;
+    return { address, privateKey };
+  }
+}
+
+export function checkAndInitialize(
+  state: SharedData,
+  signedCommitment: SignedCommitment,
+  address: string,
+  privateKey: string,
+): CheckResult {
+  const result = checkAndInitializeChannelStore(
+    state.channelStore,
+    signedCommitment,
+    address,
+    privateKey,
+  );
+  if (result.isSuccess) {
+    return { ...result, store: setChannelStore(state, result.store) };
+  } else {
+    return result;
+  }
 }
 
 export function checkAndStore(state: SharedData, signedCommitment: SignedCommitment): CheckResult {


### PR DESCRIPTION
Work done on indirect funding.

Here's a brief summary of the changes:
- Changed Player B reducer to call `checkAndInitialize` to initialize the state in the `waitForPrefundSetup`
- Finished up the `handleWaitForPostFundSetup1` in player B reducer.
- Updated player B reducer to update funding state on `protocolState` when in the `waitForDirectFunding` state. (Might be worth creating a test that would catch this)
- Various other changes in the player B reducer to get tests passing.
- Start on player A reducer to get some of the tests passing. `Initialize`, `handlePreFundSetup1`, and `handleWaitForDirectFunding` are now written and passing tests. 