### PR TITLE
Create communication module

### DIFF
--- a/packages/wallet/src/communication/__tests__/test-scenarios.ts
+++ b/packages/wallet/src/communication/__tests__/test-scenarios.ts
@@ -1,0 +1,83 @@
+import { messageRelayRequested } from 'magmo-wallet-client';
+import { strategyProposed, strategyApproved, Strategy } from '../';
+
+export const asAddress = '0x5409ED021D9299bf6814279A6A1411A7e866A631';
+export const bsAddress = '0x6Ecbe1DB9EF729CBe972C83Fb886247691Fb6beb';
+
+const fundingProcessId = 'Funding';
+const concludeProcessId = 'Conclude';
+
+const indirectStrategyChosen = messageRelayRequested(bsAddress, {
+  processId: fundingProcessId,
+  data: strategyProposed(fundingProcessId, Strategy.IndirectFunding),
+});
+
+const indirectStrategyApproved = messageRelayRequested(asAddress, {
+  processId: fundingProcessId,
+  data: strategyApproved(fundingProcessId),
+});
+
+const sendLedgerPrefundSetup = messageRelayRequested(bsAddress, {
+  processId: fundingProcessId,
+  data: '',
+});
+
+const respondToLedgerPreFundSetup = messageRelayRequested(asAddress, {
+  processId: fundingProcessId,
+  data: '',
+});
+
+const sendLedgerPostfundSetup = messageRelayRequested(bsAddress, {
+  processId: fundingProcessId,
+  data: '',
+});
+
+const respondToLedgerPostFundSetup = messageRelayRequested(asAddress, {
+  processId: fundingProcessId,
+  data: '',
+});
+
+const sendLedgerUpdate = messageRelayRequested(bsAddress, {
+  processId: fundingProcessId,
+  data: '',
+});
+
+const respondToLedgerUpdate = messageRelayRequested(asAddress, {
+  processId: fundingProcessId,
+  data: '',
+});
+
+const sendAppPostFundSetup = messageRelayRequested(bsAddress, {
+  processId: fundingProcessId,
+  data: '',
+});
+
+const respondToAppPostFundSetup = messageRelayRequested(asAddress, {
+  processId: fundingProcessId,
+  data: '',
+});
+
+const concludeGame = messageRelayRequested(bsAddress, {
+  processId: concludeProcessId,
+  data: '',
+});
+
+const respondToConclude = messageRelayRequested(asAddress, {
+  processId: concludeProcessId,
+  data: '',
+});
+
+export default {
+  indirectStrategyChosen,
+  indirectStrategyApproved,
+  sendLedgerPrefundSetup,
+  respondToLedgerPreFundSetup,
+  sendLedgerPostfundSetup,
+  respondToLedgerPostFundSetup,
+  sendLedgerUpdate,
+  respondToLedgerUpdate,
+  sendAppPostFundSetup,
+  respondToAppPostFundSetup,
+  concludeGame,
+  respondToConclude,
+};

--- a/packages/wallet/src/communication/__tests__/test-scenarios.ts
+++ b/packages/wallet/src/communication/__tests__/test-scenarios.ts
@@ -1,5 +1,5 @@
 import { messageRelayRequested } from 'magmo-wallet-client';
-import { strategyProposed, strategyApproved, Strategy } from '../';
+import { strategyProposed, strategyApproved } from '../';
 
 export const asAddress = '0x5409ED021D9299bf6814279A6A1411A7e866A631';
 export const bsAddress = '0x6Ecbe1DB9EF729CBe972C83Fb886247691Fb6beb';
@@ -9,7 +9,7 @@ const concludeProcessId = 'Conclude';
 
 const indirectStrategyChosen = messageRelayRequested(bsAddress, {
   processId: fundingProcessId,
-  data: strategyProposed(fundingProcessId, Strategy.IndirectFunding),
+  data: strategyProposed(fundingProcessId, 'IndirectFundingStrategy'),
 });
 
 const indirectStrategyApproved = messageRelayRequested(asAddress, {

--- a/packages/wallet/src/communication/index.ts
+++ b/packages/wallet/src/communication/index.ts
@@ -1,4 +1,5 @@
 import { Commitment } from '../domain';
+import { messageRelayRequested } from 'magmo-wallet-client';
 
 export enum Strategy {
   IndirectFunding = 'IndirectFunding',
@@ -31,7 +32,6 @@ export const strategyApproved = (processId: string): StrategyApproved => ({
 });
 
 // CONCLUDING
-
 export const CONCLUDE_CHANNEL = 'WALLET.CONCLUDING.CONCLUDE_CHANNEL';
 export interface ConcludeChannel extends BaseProcessAction {
   type: typeof CONCLUDE_CHANNEL;
@@ -48,3 +48,9 @@ export const concludeChannel = (
   commitment,
   signature,
 });
+
+export type Message = StrategyProposed | StrategyApproved | ConcludeChannel;
+export function sendMessage(to: string, message: Message) {
+  const { processId } = message;
+  return messageRelayRequested(to, { processId, data: message });
+}

--- a/packages/wallet/src/communication/index.ts
+++ b/packages/wallet/src/communication/index.ts
@@ -1,0 +1,8 @@
+export enum Strategy {
+  IndirectFunding = 'IndirectFunding',
+}
+
+export interface BaseProcessAction {
+  processId: string;
+  type: string;
+}

--- a/packages/wallet/src/communication/index.ts
+++ b/packages/wallet/src/communication/index.ts
@@ -51,7 +51,19 @@ export const concludeChannel = (
 });
 
 export type Message = StrategyProposed | StrategyApproved | ConcludeChannel;
-export function sendMessage(to: string, message: Message) {
+function sendMessage(to: string, message: Message) {
   const { processId } = message;
   return messageRelayRequested(to, { processId, data: message });
+}
+
+export function sendStrategyProposed(to: string, processId: string, strategy: FundingStrategy) {
+  return sendMessage(to, strategyProposed(processId, strategy));
+}
+
+export function sendStrategyApproved(to: string, processId: string) {
+  return sendMessage(to, strategyApproved(processId));
+}
+
+export function sendConcludeChannel(to: string, processId, commitment, signature) {
+  return sendMessage(to, concludeChannel(processId, commitment, signature));
 }

--- a/packages/wallet/src/communication/index.ts
+++ b/packages/wallet/src/communication/index.ts
@@ -1,9 +1,7 @@
 import { Commitment } from '../domain';
 import { messageRelayRequested } from 'magmo-wallet-client';
 
-export enum Strategy {
-  IndirectFunding = 'IndirectFunding',
-}
+export type FundingStrategy = 'IndirectFundingStrategy';
 
 export interface BaseProcessAction {
   processId: string;
@@ -14,9 +12,12 @@ export interface BaseProcessAction {
 export const STRATEGY_PROPOSED = 'WALLET.FUNDING.STRATEGY_PROPOSED';
 export interface StrategyProposed extends BaseProcessAction {
   type: typeof STRATEGY_PROPOSED;
-  strategy: Strategy;
+  strategy: FundingStrategy;
 }
-export const strategyProposed = (processId: string, strategy): StrategyProposed => ({
+export const strategyProposed = (
+  processId: string,
+  strategy: FundingStrategy,
+): StrategyProposed => ({
   type: STRATEGY_PROPOSED,
   processId,
   strategy,

--- a/packages/wallet/src/communication/index.ts
+++ b/packages/wallet/src/communication/index.ts
@@ -1,3 +1,5 @@
+import { Commitment } from '../domain';
+
 export enum Strategy {
   IndirectFunding = 'IndirectFunding',
 }
@@ -7,6 +9,7 @@ export interface BaseProcessAction {
   type: string;
 }
 
+// FUNDING
 export const STRATEGY_PROPOSED = 'WALLET.FUNDING.STRATEGY_PROPOSED';
 export interface StrategyProposed extends BaseProcessAction {
   type: typeof STRATEGY_PROPOSED;
@@ -25,4 +28,23 @@ export interface StrategyApproved extends BaseProcessAction {
 export const strategyApproved = (processId: string): StrategyApproved => ({
   type: STRATEGY_APPROVED,
   processId,
+});
+
+// CONCLUDING
+
+export const CONCLUDE_CHANNEL = 'WALLET.CONCLUDING.CONCLUDE_CHANNEL';
+export interface ConcludeChannel extends BaseProcessAction {
+  type: typeof CONCLUDE_CHANNEL;
+  commitment: Commitment;
+  signature: string;
+}
+export const concludeChannel = (
+  processId: string,
+  commitment: Commitment,
+  signature: string,
+): ConcludeChannel => ({
+  type: CONCLUDE_CHANNEL,
+  processId,
+  commitment,
+  signature,
 });

--- a/packages/wallet/src/communication/index.ts
+++ b/packages/wallet/src/communication/index.ts
@@ -6,3 +6,23 @@ export interface BaseProcessAction {
   processId: string;
   type: string;
 }
+
+export const STRATEGY_PROPOSED = 'WALLET.FUNDING.STRATEGY_PROPOSED';
+export interface StrategyProposed extends BaseProcessAction {
+  type: typeof STRATEGY_PROPOSED;
+  strategy: Strategy;
+}
+export const strategyProposed = (processId: string, strategy): StrategyProposed => ({
+  type: STRATEGY_PROPOSED,
+  processId,
+  strategy,
+});
+
+export const STRATEGY_APPROVED = 'WALLET.FUNDING.STRATEGY_APPROVED';
+export interface StrategyApproved extends BaseProcessAction {
+  type: typeof STRATEGY_APPROVED;
+}
+export const strategyApproved = (processId: string): StrategyApproved => ({
+  type: STRATEGY_APPROVED,
+  processId,
+});

--- a/packages/wallet/src/components/funding/approve-strategy.tsx
+++ b/packages/wallet/src/components/funding/approve-strategy.tsx
@@ -1,9 +1,9 @@
 import React from 'react';
 import ApproveX from '../approve-x';
-import { Strategy } from '../../redux/protocols/funding';
+import { FundingStrategy } from '../../redux/protocols/funding';
 
 interface Props {
-  strategyChosen: (strategy: Strategy) => void;
+  strategyChosen: (strategy: FundingStrategy) => void;
   cancelled: () => void;
 }
 
@@ -16,7 +16,7 @@ export default class ApproveStrategy extends React.PureComponent<Props> {
         description="Do you want to fund this state channel with a re-usable ledger channel?"
         yesMessage="Fund Channel"
         noMessage="Cancel"
-        approvalAction={() => strategyChosen(Strategy.IndirectFunding)}
+        approvalAction={() => strategyChosen('IndirectFundingStrategy')}
         rejectionAction={cancelled}
       >
         <React.Fragment>This site wants you to fund a new state channel.</React.Fragment>

--- a/packages/wallet/src/components/funding/choose-strategy.tsx
+++ b/packages/wallet/src/components/funding/choose-strategy.tsx
@@ -1,9 +1,9 @@
 import React from 'react';
 import ApproveX from '../approve-x';
-import { Strategy } from '../../redux/protocols/funding';
+import { FundingStrategy } from '../../redux/protocols/funding';
 
 interface Props {
-  strategyChosen: (strategy: Strategy) => void;
+  strategyChosen: (strategy: FundingStrategy) => void;
   cancelled: () => void;
 }
 
@@ -16,7 +16,7 @@ export default class ChooseStrategy extends React.PureComponent<Props> {
         description="Do you want to fund this state channel with a re-usable ledger channel?"
         yesMessage="Fund Channel"
         noMessage="Cancel"
-        approvalAction={() => strategyChosen(Strategy.IndirectFunding)}
+        approvalAction={() => strategyChosen('IndirectFundingStrategy')}
         rejectionAction={cancelled}
       >
         <React.Fragment>This site wants you to fund a new state channel.</React.Fragment>

--- a/packages/wallet/src/redux/__tests__/test-scenarios.ts
+++ b/packages/wallet/src/redux/__tests__/test-scenarios.ts
@@ -227,6 +227,7 @@ const allocatesToChannelAttrs = {
 };
 
 export const ledgerId = channelID(ledgerChannel);
+
 export const ledgerCommitments = {
   preFundCommitment0: {
     ...ledgerChannelAttrs,
@@ -298,6 +299,7 @@ export const ledgerCommitments = {
     turnNum: 10,
   },
 };
+
 export const signedLedgerCommitments = {
   signedLedgerCommitment0: {
     commitment: ledgerCommitments.preFundCommitment0,

--- a/packages/wallet/src/redux/protocols/actions.ts
+++ b/packages/wallet/src/redux/protocols/actions.ts
@@ -1,6 +1,7 @@
 import { Commitment } from 'magmo-wallet-client/node_modules/fmg-core';
 import { ProtocolAction, WalletAction } from '../actions';
 import { PlayerIndex, WalletProtocol } from '../types';
+export { BaseProcessAction } from '../../communication';
 
 export const INITIALIZE_CHANNEL = 'WALLET.NEW_PROCESS.INITIALIZE_CHANNEL';
 export const initializeChannel = () => ({
@@ -59,11 +60,6 @@ export function isNewProcessAction(action: WalletAction): action is NewProcessAc
     action.type === CREATE_CHALLENGE_REQUESTED ||
     action.type === RESPOND_TO_CHALLENGE_REQUESTED
   );
-}
-
-export interface BaseProcessAction {
-  processId: string;
-  type: string;
 }
 
 export function isProtocolAction(action: WalletAction): action is ProtocolAction {

--- a/packages/wallet/src/redux/protocols/funding/index.ts
+++ b/packages/wallet/src/redux/protocols/funding/index.ts
@@ -1,2 +1,2 @@
-export { Strategy } from '../../../communication';
+export { FundingStrategy } from '../../../communication';
 export { initialize, fundingReducer as reducer } from './reducer';

--- a/packages/wallet/src/redux/protocols/funding/index.ts
+++ b/packages/wallet/src/redux/protocols/funding/index.ts
@@ -1,5 +1,2 @@
-export enum Strategy {
-  IndirectFunding = 'IndirectFunding',
-}
-
+export { Strategy } from '../../../communication';
 export { initialize, fundingReducer as reducer } from './reducer';

--- a/packages/wallet/src/redux/protocols/funding/player-a/__tests__/reducer.test.ts
+++ b/packages/wallet/src/redux/protocols/funding/player-a/__tests__/reducer.test.ts
@@ -24,7 +24,7 @@ describe('happyPath', () => {
     const sentAction = strategyProposed(processId, strategy);
     itSendsThisMessage(
       result,
-      messageRelayRequested(opponentAddress, { processId, data: { sentAction } }),
+      messageRelayRequested(opponentAddress, { processId, data: sentAction }),
     );
   });
 

--- a/packages/wallet/src/redux/protocols/funding/player-a/__tests__/scenarios.ts
+++ b/packages/wallet/src/redux/protocols/funding/player-a/__tests__/scenarios.ts
@@ -3,7 +3,7 @@ import * as actions from '../actions';
 import { PlayerIndex } from '../../../../types';
 
 import { EMPTY_SHARED_DATA } from '../../../../state';
-import { Strategy } from '../..';
+import { FundingStrategy } from '../..';
 
 // To test all paths through the state machine we will use 4 different scenarios:
 //
@@ -23,7 +23,7 @@ import { Strategy } from '../..';
 // ---------
 const processId = 'process-id.123';
 const sharedData = EMPTY_SHARED_DATA;
-const strategy = Strategy.IndirectFunding;
+const strategy: FundingStrategy = 'IndirectFundingStrategy';
 const targetChannelId = '0x123';
 const opponentAddress = '0xf00';
 

--- a/packages/wallet/src/redux/protocols/funding/player-a/actions.ts
+++ b/packages/wallet/src/redux/protocols/funding/player-a/actions.ts
@@ -1,6 +1,8 @@
 import { BaseProcessAction } from '../../actions';
 import { PlayerIndex } from '../../../types';
 import { Strategy } from '..';
+import { strategyApproved, StrategyApproved, STRATEGY_APPROVED } from '../../../../communication';
+export { strategyApproved, StrategyApproved, STRATEGY_APPROVED };
 
 export type FundingAction =
   | StrategyChosen
@@ -10,7 +12,6 @@ export type FundingAction =
   | Cancelled;
 
 export const STRATEGY_CHOSEN = 'WALLET.FUNDING.STRATEGY_CHOSEN';
-export const STRATEGY_APPROVED = 'WALLET.FUNDING.STRATEGY_APPROVED';
 export const FUNDING_SUCCESS_ACKNOWLEDGED = 'WALLET.FUNDING.FUNDING_SUCCESS_ACKNOWLEDGED';
 export const STRATEGY_REJECTED = 'WALLET.FUNDING.STRATEGY_REJECTED';
 export const CANCELLED = 'WALLET.FUNDING.CANCELLED';
@@ -19,10 +20,6 @@ export const CANCELLED_BY_OPPONENT = 'WALLET.FUNDING.CANCELLED_BY_OPPONENT';
 export interface StrategyChosen extends BaseProcessAction {
   type: typeof STRATEGY_CHOSEN;
   strategy: Strategy;
-}
-
-export interface StrategyApproved extends BaseProcessAction {
-  type: typeof STRATEGY_APPROVED;
 }
 
 export interface FundingSuccessAcknowledged extends BaseProcessAction {
@@ -46,11 +43,6 @@ export const strategyChosen = (processId: string, strategy): StrategyChosen => (
   type: STRATEGY_CHOSEN,
   processId,
   strategy,
-});
-
-export const strategyApproved = (processId: string): StrategyApproved => ({
-  type: STRATEGY_APPROVED,
-  processId,
 });
 
 export const fundingSuccessAcknowledged = (processId: string): FundingSuccessAcknowledged => ({

--- a/packages/wallet/src/redux/protocols/funding/player-a/actions.ts
+++ b/packages/wallet/src/redux/protocols/funding/player-a/actions.ts
@@ -1,7 +1,11 @@
 import { BaseProcessAction } from '../../actions';
 import { PlayerIndex } from '../../../types';
-import { Strategy } from '..';
-import { strategyApproved, StrategyApproved, STRATEGY_APPROVED } from '../../../../communication';
+import {
+  strategyApproved,
+  StrategyApproved,
+  STRATEGY_APPROVED,
+  FundingStrategy,
+} from '../../../../communication';
 export { strategyApproved, StrategyApproved, STRATEGY_APPROVED };
 
 export type FundingAction =
@@ -19,7 +23,7 @@ export const CANCELLED_BY_OPPONENT = 'WALLET.FUNDING.CANCELLED_BY_OPPONENT';
 
 export interface StrategyChosen extends BaseProcessAction {
   type: typeof STRATEGY_CHOSEN;
-  strategy: Strategy;
+  strategy: FundingStrategy;
 }
 
 export interface FundingSuccessAcknowledged extends BaseProcessAction {

--- a/packages/wallet/src/redux/protocols/funding/player-a/container.tsx
+++ b/packages/wallet/src/redux/protocols/funding/player-a/container.tsx
@@ -7,15 +7,15 @@ import * as states from './states';
 
 import { unreachable } from '../../../../utils/reducer-utils';
 import { PlayerIndex } from '../../../types';
-import { Strategy } from '..';
+import { FundingStrategy } from '..';
 import ChooseStrategy from '../../../../components/funding/choose-strategy';
 import WaitForOtherPlayer from '../../../../components/wait-for-other-player';
 import AcknowledgeX from '../../../../components/acknowledge-x';
 
 interface Props {
   state: states.OngoingFundingState;
-  strategyChosen: (processId: string, strategy: Strategy) => void;
-  strategyApproved: (processId: string, strategy: Strategy) => void;
+  strategyChosen: (processId: string, strategy: FundingStrategy) => void;
+  strategyApproved: (processId: string, strategy: FundingStrategy) => void;
   strategyRejected: (processId: string) => void;
   fundingSuccessAcknowledged: (processId: string) => void;
   cancelled: (processId: string, by: PlayerIndex) => void;
@@ -30,7 +30,9 @@ class FundingContainer extends PureComponent<Props> {
       case states.WAIT_FOR_STRATEGY_CHOICE:
         return (
           <ChooseStrategy
-            strategyChosen={(strategy: Strategy) => actions.strategyChosen(processId, strategy)}
+            strategyChosen={(strategy: FundingStrategy) =>
+              actions.strategyChosen(processId, strategy)
+            }
             cancelled={() => actions.cancelled(processId, PlayerIndex.B)}
           />
         );

--- a/packages/wallet/src/redux/protocols/funding/player-a/reducer.ts
+++ b/packages/wallet/src/redux/protocols/funding/player-a/reducer.ts
@@ -11,8 +11,7 @@ import { unreachable } from '../../../../utils/reducer-utils';
 import { PlayerIndex } from '../../../types';
 import { showWallet } from '../../reducer-helpers';
 import { fundingFailure } from 'magmo-wallet-client';
-import { strategyProposed } from '../player-b/actions';
-import { sendMessage } from '../../../../communication';
+import { sendStrategyProposed } from '../../../../communication';
 type EmbeddedAction = IndirectFundingAction;
 
 export function initialize(
@@ -73,7 +72,7 @@ function strategyChosen(
   }
   const { processId, opponentAddress } = state;
   const { strategy } = action;
-  const message = sendMessage(opponentAddress, strategyProposed(processId, strategy));
+  const message = sendStrategyProposed(opponentAddress, processId, strategy);
   return {
     protocolState: states.waitForStrategyResponse({ ...state, strategy }),
     sharedData: queueMessage(sharedData, message),

--- a/packages/wallet/src/redux/protocols/funding/player-a/reducer.ts
+++ b/packages/wallet/src/redux/protocols/funding/player-a/reducer.ts
@@ -10,8 +10,9 @@ import { ProtocolStateWithSharedData } from '../..';
 import { unreachable } from '../../../../utils/reducer-utils';
 import { PlayerIndex } from '../../../types';
 import { showWallet } from '../../reducer-helpers';
-import { fundingFailure, messageRelayRequested } from 'magmo-wallet-client';
+import { fundingFailure } from 'magmo-wallet-client';
 import { strategyProposed } from '../player-b/actions';
+import { sendMessage } from '../../../../communication';
 type EmbeddedAction = IndirectFundingAction;
 
 export function initialize(
@@ -72,9 +73,7 @@ function strategyChosen(
   }
   const { processId, opponentAddress } = state;
   const { strategy } = action;
-  const sentAction = strategyProposed(processId, strategy);
-  const payload = { processId, data: { sentAction } };
-  const message = messageRelayRequested(opponentAddress, payload);
+  const message = sendMessage(opponentAddress, strategyProposed(processId, strategy));
   return {
     protocolState: states.waitForStrategyResponse({ ...state, strategy }),
     sharedData: queueMessage(sharedData, message),

--- a/packages/wallet/src/redux/protocols/funding/player-a/states.ts
+++ b/packages/wallet/src/redux/protocols/funding/player-a/states.ts
@@ -1,6 +1,6 @@
 import { Properties as P } from '../../../utils';
 import { ProtocolState } from '../..';
-import { Strategy } from '..';
+import { FundingStrategy } from '..';
 
 export type OngoingFundingState =
   | WaitForStrategyChoice
@@ -31,7 +31,7 @@ export interface WaitForStrategyChoice extends BaseState {
 export interface WaitForStrategyResponse extends BaseState {
   type: typeof WAIT_FOR_STRATEGY_RESPONSE;
   targetChannelId: string;
-  strategy: Strategy;
+  strategy: FundingStrategy;
 }
 
 export interface WaitForFunding extends BaseState {

--- a/packages/wallet/src/redux/protocols/funding/player-b/__tests__/reducer.test.ts
+++ b/packages/wallet/src/redux/protocols/funding/player-b/__tests__/reducer.test.ts
@@ -33,7 +33,7 @@ describe('happyPath', () => {
     const sentAction = strategyApproved(processId);
     itSendsThisMessage(
       result,
-      messageRelayRequested(opponentAddress, { processId, data: { sentAction } }),
+      messageRelayRequested(opponentAddress, { processId, data: sentAction }),
     );
   });
 

--- a/packages/wallet/src/redux/protocols/funding/player-b/__tests__/scenarios.ts
+++ b/packages/wallet/src/redux/protocols/funding/player-b/__tests__/scenarios.ts
@@ -3,7 +3,7 @@ import * as actions from '../actions';
 import { PlayerIndex } from '../../../../types';
 
 import { EMPTY_SHARED_DATA } from '../../../../state';
-import { Strategy } from '../..';
+import { FundingStrategy } from '../../../../../communication';
 
 // To test all paths through the state machine we will use 4 different scenarios:
 //
@@ -25,7 +25,7 @@ const processId = 'process-id.123';
 const sharedData = EMPTY_SHARED_DATA;
 const targetChannelId = '0x1324';
 const opponentAddress = '0xf00';
-const strategy = Strategy.IndirectFunding;
+const strategy: FundingStrategy = 'IndirectFundingStrategy';
 
 const props = {
   processId,

--- a/packages/wallet/src/redux/protocols/funding/player-b/actions.ts
+++ b/packages/wallet/src/redux/protocols/funding/player-b/actions.ts
@@ -1,6 +1,8 @@
 import { BaseProcessAction } from '../../actions';
 import { PlayerIndex } from '../../../types';
 import { Strategy } from '..';
+import { strategyProposed, StrategyProposed, STRATEGY_PROPOSED } from '../../../../communication';
+export { strategyProposed, StrategyProposed, STRATEGY_PROPOSED };
 
 export type FundingAction =
   | StrategyProposed
@@ -9,17 +11,11 @@ export type FundingAction =
   | StrategyRejected
   | Cancelled;
 
-export const STRATEGY_PROPOSED = 'WALLET.FUNDING.STRATEGY_PROPOSED';
 export const STRATEGY_APPROVED = 'WALLET.FUNDING.STRATEGY_APPROVED';
 export const FUNDING_SUCCESS_ACKNOWLEDGED = 'WALLET.FUNDING.FUNDING_SUCCESS_ACKNOWLEDGED';
 export const STRATEGY_REJECTED = 'WALLET.FUNDING.STRATEGY_REJECTED';
 export const CANCELLED = 'WALLET.FUNDING.CANCELLED';
 export const CANCELLED_BY_OPPONENT = 'WALLET.FUNDING.CANCELLED_BY_OPPONENT';
-
-export interface StrategyProposed extends BaseProcessAction {
-  type: typeof STRATEGY_PROPOSED;
-  strategy: Strategy;
-}
 
 export interface StrategyApproved extends BaseProcessAction {
   type: typeof STRATEGY_APPROVED;
@@ -42,12 +38,6 @@ export interface Cancelled extends BaseProcessAction {
 // --------
 // Creators
 // --------
-
-export const strategyProposed = (processId: string, strategy): StrategyProposed => ({
-  type: STRATEGY_PROPOSED,
-  processId,
-  strategy,
-});
 
 export const strategyApproved = (processId: string, strategy): StrategyApproved => ({
   type: STRATEGY_APPROVED,

--- a/packages/wallet/src/redux/protocols/funding/player-b/actions.ts
+++ b/packages/wallet/src/redux/protocols/funding/player-b/actions.ts
@@ -1,6 +1,6 @@
 import { BaseProcessAction } from '../../actions';
 import { PlayerIndex } from '../../../types';
-import { Strategy } from '..';
+import { FundingStrategy } from '..';
 import { strategyProposed, StrategyProposed, STRATEGY_PROPOSED } from '../../../../communication';
 export { strategyProposed, StrategyProposed, STRATEGY_PROPOSED };
 
@@ -19,7 +19,7 @@ export const CANCELLED_BY_OPPONENT = 'WALLET.FUNDING.CANCELLED_BY_OPPONENT';
 
 export interface StrategyApproved extends BaseProcessAction {
   type: typeof STRATEGY_APPROVED;
-  strategy: Strategy;
+  strategy: FundingStrategy;
 }
 
 export interface FundingSuccessAcknowledged extends BaseProcessAction {

--- a/packages/wallet/src/redux/protocols/funding/player-b/container.tsx
+++ b/packages/wallet/src/redux/protocols/funding/player-b/container.tsx
@@ -7,15 +7,15 @@ import * as states from './states';
 
 import { unreachable } from '../../../../utils/reducer-utils';
 import { PlayerIndex } from '../../../types';
-import { Strategy } from '..';
 import ApproveStrategy from '../../../../components/funding/approve-strategy';
 import WaitForOtherPlayer from '../../../../components/wait-for-other-player';
 import AcknowledgeX from '../../../../components/acknowledge-x';
+import { FundingStrategy } from '..';
 
 interface Props {
   state: states.OngoingFundingState;
-  strategyChosen: (processId: string, strategy: Strategy) => void;
-  strategyApproved: (processId: string, strategy: Strategy) => void;
+  strategyChosen: (processId: string, strategy: FundingStrategy) => void;
+  strategyApproved: (processId: string, strategy: FundingStrategy) => void;
   strategyRejected: (processId: string) => void;
   fundingSuccessAcknowledged: (processId: string) => void;
   cancelled: (processId: string, by: PlayerIndex) => void;
@@ -32,7 +32,9 @@ class FundingContainer extends PureComponent<Props> {
       case states.WAIT_FOR_STRATEGY_APPROVAL:
         return (
           <ApproveStrategy
-            strategyChosen={(strategy: Strategy) => actions.strategyApproved(processId, strategy)}
+            strategyChosen={(strategy: FundingStrategy) =>
+              actions.strategyApproved(processId, strategy)
+            }
             cancelled={() => actions.cancelled(processId, PlayerIndex.B)}
           />
         );

--- a/packages/wallet/src/redux/protocols/funding/player-b/reducer.ts
+++ b/packages/wallet/src/redux/protocols/funding/player-b/reducer.ts
@@ -11,7 +11,7 @@ import { unreachable } from '../../../../utils/reducer-utils';
 import { PlayerIndex } from '../../../types';
 import { showWallet } from '../../reducer-helpers';
 import { fundingFailure } from 'magmo-wallet-client';
-import { sendMessage } from '../../../../communication';
+import { sendStrategyApproved } from '../../../../communication';
 
 type EmbeddedAction = IndirectFundingAction;
 
@@ -86,8 +86,7 @@ function strategyApproved(
   }
 
   const { processId, opponentAddress } = state;
-  const { strategy } = action;
-  const message = sendMessage(opponentAddress, actions.strategyApproved(processId, strategy));
+  const message = sendStrategyApproved(opponentAddress, processId);
 
   return {
     protocolState: states.waitForFunding({ ...state, fundingState: 'funding state' }),

--- a/packages/wallet/src/redux/protocols/funding/player-b/reducer.ts
+++ b/packages/wallet/src/redux/protocols/funding/player-b/reducer.ts
@@ -10,7 +10,8 @@ import { ProtocolStateWithSharedData } from '../..';
 import { unreachable } from '../../../../utils/reducer-utils';
 import { PlayerIndex } from '../../../types';
 import { showWallet } from '../../reducer-helpers';
-import { fundingFailure, messageRelayRequested } from 'magmo-wallet-client';
+import { fundingFailure } from 'magmo-wallet-client';
+import { sendMessage } from '../../../../communication';
 
 type EmbeddedAction = IndirectFundingAction;
 
@@ -86,9 +87,7 @@ function strategyApproved(
 
   const { processId, opponentAddress } = state;
   const { strategy } = action;
-  const sentAction = actions.strategyApproved(processId, strategy);
-  const payload = { processId, data: { sentAction } };
-  const message = messageRelayRequested(opponentAddress, payload);
+  const message = sendMessage(opponentAddress, actions.strategyApproved(processId, strategy));
 
   return {
     protocolState: states.waitForFunding({ ...state, fundingState: 'funding state' }),

--- a/packages/wallet/src/redux/protocols/funding/player-b/states.ts
+++ b/packages/wallet/src/redux/protocols/funding/player-b/states.ts
@@ -1,6 +1,6 @@
 import { Properties as P } from '../../../utils';
 import { ProtocolState } from '../..';
-import { Strategy } from '..';
+import { FundingStrategy } from '..';
 
 export type OngoingFundingState =
   | WaitForStrategyProposal
@@ -31,7 +31,7 @@ export interface WaitForStrategyProposal extends BaseState {
 export interface WaitForStrategyApproval extends BaseState {
   type: typeof WAIT_FOR_STRATEGY_APPROVAL;
   targetChannelId: string;
-  strategy: Strategy;
+  strategy: FundingStrategy;
 }
 
 export interface WaitForFunding extends BaseState {

--- a/packages/wallet/src/redux/reducer.ts
+++ b/packages/wallet/src/redux/reducer.ts
@@ -54,6 +54,7 @@ export function initializedReducer(
 
   return state;
 }
+
 function updateSharedData(
   state: states.Initialized,
   action: actions.SharedDataUpdateAction,

--- a/packages/wallet/src/utils/commitment-utils.ts
+++ b/packages/wallet/src/utils/commitment-utils.ts
@@ -5,7 +5,7 @@ import { signCommitment } from '../domain';
 import { Channel } from 'fmg-core';
 import { SignedCommitment } from '../domain';
 import { ChannelState } from '../redux/channel-store';
-import { concludeChannel, sendMessage } from '../communication';
+import { sendConcludeChannel } from '../communication';
 
 export const hasConsensusBeenReached = (
   lastCommitment: Commitment,
@@ -115,11 +115,13 @@ export const composeConcludeCommitment = (channelState: ChannelState) => {
     commitmentCount,
   };
 
-  const commitmentSignature = signCommitment(concludeCommitment, channelState.privateKey);
+  const signature = signCommitment(concludeCommitment, channelState.privateKey);
   const processId = channelState.channelId;
-  const sendCommitmentAction = sendMessage(
+  const sendCommitmentAction = sendConcludeChannel(
     channelState.participants[1 - channelState.ourIndex],
-    concludeChannel(processId, concludeCommitment, commitmentSignature),
+    processId,
+    concludeCommitment,
+    signature,
   );
-  return { concludeCommitment, commitmentSignature, sendCommitmentAction };
+  return { concludeCommitment, signature, sendCommitmentAction };
 };

--- a/packages/wallet/src/utils/commitment-utils.ts
+++ b/packages/wallet/src/utils/commitment-utils.ts
@@ -4,9 +4,8 @@ import { PlayerIndex } from '../redux/types';
 import { signCommitment } from '../domain';
 import { Channel } from 'fmg-core';
 import { SignedCommitment } from '../domain';
-import { messageRelayRequested } from 'magmo-wallet-client/lib/wallet-events';
 import { ChannelState } from '../redux/channel-store';
-import { concludeChannel } from '../communication';
+import { concludeChannel, sendMessage } from '../communication';
 
 export const hasConsensusBeenReached = (
   lastCommitment: Commitment,
@@ -118,12 +117,9 @@ export const composeConcludeCommitment = (channelState: ChannelState) => {
 
   const commitmentSignature = signCommitment(concludeCommitment, channelState.privateKey);
   const processId = channelState.channelId;
-  const sendCommitmentAction = messageRelayRequested(
+  const sendCommitmentAction = sendMessage(
     channelState.participants[1 - channelState.ourIndex],
-    {
-      processId,
-      data: concludeChannel(processId, concludeCommitment, commitmentSignature),
-    },
+    concludeChannel(processId, concludeCommitment, commitmentSignature),
   );
   return { concludeCommitment, commitmentSignature, sendCommitmentAction };
 };

--- a/packages/wallet/src/utils/commitment-utils.ts
+++ b/packages/wallet/src/utils/commitment-utils.ts
@@ -6,6 +6,7 @@ import { Channel } from 'fmg-core';
 import { SignedCommitment } from '../domain';
 import { messageRelayRequested } from 'magmo-wallet-client/lib/wallet-events';
 import { ChannelState } from '../redux/channel-store';
+import { concludeChannel } from '../communication';
 
 export const hasConsensusBeenReached = (
   lastCommitment: Commitment,
@@ -116,14 +117,12 @@ export const composeConcludeCommitment = (channelState: ChannelState) => {
   };
 
   const commitmentSignature = signCommitment(concludeCommitment, channelState.privateKey);
+  const processId = channelState.channelId;
   const sendCommitmentAction = messageRelayRequested(
     channelState.participants[1 - channelState.ourIndex],
     {
-      processId: channelState.channelId,
-      data: {
-        commitment: concludeCommitment,
-        commitmentSignature,
-      },
+      processId,
+      data: concludeChannel(processId, concludeCommitment, commitmentSignature),
     },
   );
   return { concludeCommitment, commitmentSignature, sendCommitmentAction };


### PR DESCRIPTION
The communication module serves to define the messages that wallets can send to each other. This facilitates server development, which needs to understand.

I also propose that protocols use bespoke actions, like `concludeChannel`. This way, the wallet knows exactly how to route the action. Right now, it seems like the wallet would have to inspect a `CommitmentReceived` action, say "This commitment is a `CONCLUDE` commitment", check if a conclude process is running for the channel, and if not, create a new process running the `Conclude` protocol.

Once accepted, I would contain all referencers to `messageRelayRequested` by the communication module, and then write out the communication test scenarios.