### PR TITLE
 Only test packages changed since master

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -50,4 +50,4 @@ jobs:
             echo Failed waiting for Postgres && exit 1
 
       # run tests!
-      - run: npx lerna run test:ci --stream --concurrency 2
+      - run: npx lerna run test:ci --stream --concurrency 2 --since origin/master

--- a/packages/rps/notes/readme.md
+++ b/packages/rps/notes/readme.md
@@ -8,6 +8,7 @@
 
 The Game Engine is responsible for storing the current state of the game and providing that information to the application controller.
 
-The Application Controller is responsible for taking the next steps according to the state provided by the Game Engine and reporting back with the results. This could involve communicating with the opponent and/or the blockchain and/or rendering UI to get input from the user.
+The Application Controller is responsible for taking the next steps according to the state provided by the Game Engine and reporting back with the results.
+This could involve communicating with the opponent and/or the blockchain and/or rendering UI to get input from the user.
 
 ![Architecture diagram](./architecture.png)


### PR DESCRIPTION
This is slightly dangerous if we don't properly use semantic versioning,
since:
A. if rps depends on wallet version 1.0.*
B. and we update the wallet package to version 1.0.1, which includes
a breaking change

then rps tests would fail, but they won't be run on circle.

Note that lerna filters on packages changed since origin/master. For
some reason, circle's `checkout` command fast-forwards the `master`
branch to the branch being tested, and thus no packages are changed
since `master`.