### PR TITLE
Funding protocol fixes

### DIFF
--- a/packages/rps/src/core/rps-commitment-helper.ts
+++ b/packages/rps/src/core/rps-commitment-helper.ts
@@ -109,7 +109,10 @@ export function propose(obj: ProposeParams): RPSCommitment {
 }
 
 export function hashCommitment(play: Weapon, salt: string) {
-  return soliditySha3({ type: 'uint256', value: play }, { type: 'bytes32', value: salt });
+  return soliditySha3(
+    { type: 'uint256', value: play.toString() },
+    { type: 'bytes32', value: salt },
+  );
 }
 
 interface ProposeWithWeaponAndSaltParams extends BaseWithBuyInParams {

--- a/packages/server/src/app/services/rps-commitment.ts
+++ b/packages/server/src/app/services/rps-commitment.ts
@@ -113,5 +113,8 @@ export function generateSalt(): Bytes32 {
 }
 
 export function hashCommitment(weapon: Weapon, salt: string) {
-  return soliditySha3({ type: 'uint256', value: weapon }, { type: 'bytes32', value: salt });
+  return soliditySha3(
+    { type: 'uint256', value: weapon.toString() },
+    { type: 'bytes32', value: salt },
+  );
 }

--- a/packages/wallet/src/redux/protocols/actions.ts
+++ b/packages/wallet/src/redux/protocols/actions.ts
@@ -15,7 +15,7 @@ export const fundingRequested = (channelId: string, playerIndex: PlayerIndex) =>
   type: FUNDING_REQUESTED as typeof FUNDING_REQUESTED,
   channelId,
   playerIndex,
-  protocol: WalletProtocol.IndirectFunding,
+  protocol: WalletProtocol.Funding,
 });
 export type FundingRequested = ReturnType<typeof fundingRequested>;
 

--- a/packages/wallet/src/redux/protocols/funding/player-a/container.tsx
+++ b/packages/wallet/src/redux/protocols/funding/player-a/container.tsx
@@ -23,17 +23,15 @@ interface Props {
 
 class FundingContainer extends PureComponent<Props> {
   render() {
-    const { state } = this.props;
+    const { state, strategyChosen, cancelled } = this.props;
     const { processId } = state;
 
     switch (state.type) {
       case states.WAIT_FOR_STRATEGY_CHOICE:
         return (
           <ChooseStrategy
-            strategyChosen={(strategy: FundingStrategy) =>
-              actions.strategyChosen(processId, strategy)
-            }
-            cancelled={() => actions.cancelled(processId, PlayerIndex.B)}
+            strategyChosen={(strategy: FundingStrategy) => strategyChosen(processId, strategy)}
+            cancelled={() => cancelled(processId, PlayerIndex.B)}
           />
         );
       case states.WAIT_FOR_STRATEGY_RESPONSE:

--- a/packages/wallet/src/redux/protocols/funding/player-b/container.tsx
+++ b/packages/wallet/src/redux/protocols/funding/player-b/container.tsx
@@ -14,7 +14,6 @@ import { FundingStrategy } from '..';
 
 interface Props {
   state: states.OngoingFundingState;
-  strategyChosen: (processId: string, strategy: FundingStrategy) => void;
   strategyApproved: (processId: string, strategy: FundingStrategy) => void;
   strategyRejected: (processId: string) => void;
   fundingSuccessAcknowledged: (processId: string) => void;
@@ -23,7 +22,7 @@ interface Props {
 
 class FundingContainer extends PureComponent<Props> {
   render() {
-    const { state } = this.props;
+    const { state, strategyApproved, cancelled } = this.props;
     const { processId } = state;
 
     switch (state.type) {
@@ -32,10 +31,8 @@ class FundingContainer extends PureComponent<Props> {
       case states.WAIT_FOR_STRATEGY_APPROVAL:
         return (
           <ApproveStrategy
-            strategyChosen={(strategy: FundingStrategy) =>
-              actions.strategyApproved(processId, strategy)
-            }
-            cancelled={() => actions.cancelled(processId, PlayerIndex.B)}
+            strategyChosen={(strategy: FundingStrategy) => strategyApproved(processId, strategy)}
+            cancelled={() => cancelled(processId, PlayerIndex.B)}
           />
         );
       case states.WAIT_FOR_FUNDING:

--- a/packages/wallet/src/redux/protocols/funding/reducer.ts
+++ b/packages/wallet/src/redux/protocols/funding/reducer.ts
@@ -9,6 +9,7 @@ import { unreachable } from '../../../utils/reducer-utils';
 import { Action as IndirectFundingAction } from '../indirect-funding/actions';
 import * as playerAStates from './player-a/states';
 import * as selectors from '../../selectors';
+import { getOpponentAddress } from '../reducer-helpers';
 
 export function initialize(
   sharedData: SharedData,
@@ -16,10 +17,8 @@ export function initialize(
   processId: string,
   playerIndex: PlayerIndex,
 ): ProtocolStateWithSharedData<states.FundingState> {
-  // TODO: We probably want to handle this in the root reducer
   const channelState = selectors.getChannelState(sharedData, channelId);
-  const { participants } = channelState;
-  const opponentAddress = participants[playerIndex + (1 % participants.length)];
+  const opponentAddress = getOpponentAddress(channelState, playerIndex);
   switch (playerIndex) {
     case PlayerIndex.A:
       return initializeA(sharedData, processId, channelId, opponentAddress);

--- a/packages/wallet/src/redux/protocols/funding/reducer.ts
+++ b/packages/wallet/src/redux/protocols/funding/reducer.ts
@@ -18,7 +18,8 @@ export function initialize(
 ): ProtocolStateWithSharedData<states.FundingState> {
   // TODO: We probably want to handle this in the root reducer
   const channelState = selectors.getChannelState(sharedData, channelId);
-  const opponentAddress = channelState.participants[playerIndex];
+  const { participants } = channelState;
+  const opponentAddress = participants[playerIndex + (1 % participants.length)];
   switch (playerIndex) {
     case PlayerIndex.A:
       return initializeA(sharedData, processId, channelId, opponentAddress);

--- a/packages/wallet/src/redux/protocols/reducer-helpers.ts
+++ b/packages/wallet/src/redux/protocols/reducer-helpers.ts
@@ -9,6 +9,7 @@ import * as selectors from '../selectors';
 import { PlayerIndex } from '../types';
 import { CommitmentType } from 'fmg-core/lib/commitment';
 import * as magmoWalletClient from 'magmo-wallet-client';
+import { ChannelState } from '../channel-store';
 
 export const updateChannelState = (
   sharedData: SharedData,
@@ -104,3 +105,9 @@ export const isFirstPlayer = (channelId: string, sharedData: SharedData) => {
   const channelState = selectors.getChannelState(sharedData, channelId);
   return channelState.ourIndex === PlayerIndex.A;
 };
+
+export function getOpponentAddress(channelState: ChannelState, playerIndex: PlayerIndex) {
+  const { participants } = channelState;
+  const opponentAddress = participants[playerIndex + (1 % participants.length)];
+  return opponentAddress;
+}


### PR DESCRIPTION
- The `FUNDING_REQUESTED` action starts the `'Funding'` protocol, not the `'IndirectFunding'` protocol
- The actions that choose and accept a strategy are correctly modified
- The `opponentAddress` is correctly set on the funding state