### PR TITLE
Add Indirect Funding Sub-protocol to funding protocol

### DIFF
--- a/packages/wallet/src/redux/protocols/funding/player-a/__tests__/reducer.test.ts
+++ b/packages/wallet/src/redux/protocols/funding/player-a/__tests__/reducer.test.ts
@@ -13,9 +13,9 @@ describe('happyPath', () => {
   const scenario = scenarios.happyPath;
 
   describe(whenIn(states.WAIT_FOR_STRATEGY_CHOICE), () => {
-    const state = scenario.states.waitForStrategyChoice;
+    const { state, store } = scenario.states.waitForStrategyChoice;
     const action = scenario.actions.strategyChosen;
-    const result = reducer(state.state, state.store, action);
+    const result = reducer(state, store, action);
 
     itTransitionsTo(result, states.WAIT_FOR_STRATEGY_RESPONSE);
     const { processId, strategy, opponentAddress } = scenario;
@@ -23,25 +23,25 @@ describe('happyPath', () => {
   });
 
   describe(whenIn(states.WAIT_FOR_STRATEGY_RESPONSE), () => {
-    const state = scenario.states.waitForStrategyResponse;
+    const { state, store } = scenario.states.waitForStrategyResponse;
     const action = scenario.actions.strategyApproved;
-    const result = reducer(state.state, state.store, action);
+    const result = reducer(state, store, action);
 
     itTransitionsTo(result, states.WAIT_FOR_FUNDING);
   });
 
   describe(whenIn(states.WAIT_FOR_FUNDING), () => {
-    const state = scenario.states.waitForFunding;
+    const { state, store } = scenario.states.waitForFunding;
     const action = scenario.actions.fundingSuccess;
-    const result = reducer(state.state, state.store, action);
+    const result = reducer(state, store, action);
 
     itTransitionsTo(result, states.WAIT_FOR_SUCCESS_CONFIRMATION);
   });
 
   describe(whenIn(states.WAIT_FOR_SUCCESS_CONFIRMATION), () => {
-    const state = scenario.states.waitForSuccessConfirmation;
+    const { state, store } = scenario.states.waitForSuccessConfirmation;
     const action = scenario.actions.successConfirmed;
-    const result = reducer(state.state, state.store, action);
+    const result = reducer(state, store, action);
 
     itTransitionsTo(result, states.SUCCESS);
   });
@@ -51,9 +51,9 @@ describe('When a strategy is rejected', () => {
   const scenario = scenarios.rejectedStrategy;
 
   describe(whenIn(states.WAIT_FOR_STRATEGY_RESPONSE), () => {
-    const state = scenario.states.waitForStrategyResponse;
+    const { state, store } = scenario.states.waitForStrategyResponse;
     const action = scenario.actions.strategyRejected;
-    const result = reducer(state.state, state.store, action);
+    const result = reducer(state, store, action);
 
     itTransitionsTo(result, states.WAIT_FOR_STRATEGY_CHOICE);
   });
@@ -63,18 +63,18 @@ describe('when cancelled by the opponent', () => {
   const scenario = scenarios.cancelledByOpponent;
 
   describe(whenIn(states.WAIT_FOR_STRATEGY_CHOICE), () => {
-    const state = scenario.states.waitForStrategyChoice;
+    const { state, store } = scenario.states.waitForStrategyChoice;
     const action = scenario.actions.cancelledByB;
-    const result = reducer(state.state, state.store, action);
+    const result = reducer(state, store, action);
 
     itTransitionsTo(result, states.FAILURE);
     itSendsThisMessage(result, 'WALLET.FUNDING.FAILURE');
   });
 
   describe(whenIn(states.WAIT_FOR_STRATEGY_RESPONSE), () => {
-    const state = scenario.states.waitForStrategyResponse;
+    const { state, store } = scenario.states.waitForStrategyResponse;
     const action = scenario.actions.cancelledByB;
-    const result = reducer(state.state, state.store, action);
+    const result = reducer(state, store, action);
 
     itTransitionsTo(result, states.FAILURE);
     itSendsThisMessage(result, 'WALLET.FUNDING.FAILURE');
@@ -84,18 +84,18 @@ describe('when cancelled by the opponent', () => {
 describe('when cancelled by the user', () => {
   const scenario = scenarios.cancelledByUser;
   describe(whenIn(states.WAIT_FOR_STRATEGY_CHOICE), () => {
-    const state = scenario.states.waitForStrategyChoice;
+    const { state, store } = scenario.states.waitForStrategyChoice;
     const action = scenario.actions.cancelledByA;
-    const result = reducer(state.state, state.store, action);
+    const result = reducer(state, store, action);
 
     itTransitionsTo(result, states.FAILURE);
     itSendsThisMessage(result, 'WALLET.FUNDING.FAILURE');
   });
 
   describe(whenIn(states.WAIT_FOR_STRATEGY_RESPONSE), () => {
-    const state = scenario.states.waitForStrategyResponse;
+    const { state, store } = scenario.states.waitForStrategyResponse;
     const action = scenario.actions.cancelledByA;
-    const result = reducer(state.state, state.store, action);
+    const result = reducer(state, store, action);
 
     itTransitionsTo(result, states.FAILURE);
     itSendsThisMessage(result, 'WALLET.FUNDING.FAILURE');

--- a/packages/wallet/src/redux/protocols/funding/player-a/__tests__/reducer.test.ts
+++ b/packages/wallet/src/redux/protocols/funding/player-a/__tests__/reducer.test.ts
@@ -11,12 +11,11 @@ function whenIn(state) {
 
 describe('happyPath', () => {
   const scenario = scenarios.happyPath;
-  const sharedData = scenario.sharedData;
 
   describe(whenIn(states.WAIT_FOR_STRATEGY_CHOICE), () => {
     const state = scenario.states.waitForStrategyChoice;
     const action = scenario.actions.strategyChosen;
-    const result = reducer(state, sharedData, action);
+    const result = reducer(state.state, state.store, action);
 
     itTransitionsTo(result, states.WAIT_FOR_STRATEGY_RESPONSE);
     const { processId, strategy, opponentAddress } = scenario;
@@ -26,23 +25,23 @@ describe('happyPath', () => {
   describe(whenIn(states.WAIT_FOR_STRATEGY_RESPONSE), () => {
     const state = scenario.states.waitForStrategyResponse;
     const action = scenario.actions.strategyApproved;
-    const result = reducer(state, sharedData, action);
+    const result = reducer(state.state, state.store, action);
 
     itTransitionsTo(result, states.WAIT_FOR_FUNDING);
   });
 
   describe(whenIn(states.WAIT_FOR_FUNDING), () => {
-    // TODO: This test depends on updating the indirect funding protocol
-    // const state = scenario.states.waitForFunding;
-    // const action = scenario.actions.indirectFundingSuccess;
-    // const result = reducer(state, sharedData, action);
-    // itTransitionsTo(result, states.WAIT_FOR_SUCCESS_CONFIRMATION);
+    const state = scenario.states.waitForFunding;
+    const action = scenario.actions.fundingSuccess;
+    const result = reducer(state.state, state.store, action);
+
+    itTransitionsTo(result, states.WAIT_FOR_SUCCESS_CONFIRMATION);
   });
 
   describe(whenIn(states.WAIT_FOR_SUCCESS_CONFIRMATION), () => {
     const state = scenario.states.waitForSuccessConfirmation;
     const action = scenario.actions.successConfirmed;
-    const result = reducer(state, sharedData, action);
+    const result = reducer(state.state, state.store, action);
 
     itTransitionsTo(result, states.SUCCESS);
   });
@@ -50,12 +49,11 @@ describe('happyPath', () => {
 
 describe('When a strategy is rejected', () => {
   const scenario = scenarios.rejectedStrategy;
-  const sharedData = scenario.sharedData;
 
   describe(whenIn(states.WAIT_FOR_STRATEGY_RESPONSE), () => {
     const state = scenario.states.waitForStrategyResponse;
     const action = scenario.actions.strategyRejected;
-    const result = reducer(state, sharedData, action);
+    const result = reducer(state.state, state.store, action);
 
     itTransitionsTo(result, states.WAIT_FOR_STRATEGY_CHOICE);
   });
@@ -63,12 +61,11 @@ describe('When a strategy is rejected', () => {
 
 describe('when cancelled by the opponent', () => {
   const scenario = scenarios.cancelledByOpponent;
-  const sharedData = scenario.sharedData;
 
   describe(whenIn(states.WAIT_FOR_STRATEGY_CHOICE), () => {
     const state = scenario.states.waitForStrategyChoice;
     const action = scenario.actions.cancelledByB;
-    const result = reducer(state, sharedData, action);
+    const result = reducer(state.state, state.store, action);
 
     itTransitionsTo(result, states.FAILURE);
     itSendsThisMessage(result, 'WALLET.FUNDING.FAILURE');
@@ -77,7 +74,7 @@ describe('when cancelled by the opponent', () => {
   describe(whenIn(states.WAIT_FOR_STRATEGY_RESPONSE), () => {
     const state = scenario.states.waitForStrategyResponse;
     const action = scenario.actions.cancelledByB;
-    const result = reducer(state, sharedData, action);
+    const result = reducer(state.state, state.store, action);
 
     itTransitionsTo(result, states.FAILURE);
     itSendsThisMessage(result, 'WALLET.FUNDING.FAILURE');
@@ -86,12 +83,10 @@ describe('when cancelled by the opponent', () => {
 
 describe('when cancelled by the user', () => {
   const scenario = scenarios.cancelledByUser;
-  const sharedData = scenario.sharedData;
-
   describe(whenIn(states.WAIT_FOR_STRATEGY_CHOICE), () => {
     const state = scenario.states.waitForStrategyChoice;
     const action = scenario.actions.cancelledByA;
-    const result = reducer(state, sharedData, action);
+    const result = reducer(state.state, state.store, action);
 
     itTransitionsTo(result, states.FAILURE);
     itSendsThisMessage(result, 'WALLET.FUNDING.FAILURE');
@@ -100,7 +95,7 @@ describe('when cancelled by the user', () => {
   describe(whenIn(states.WAIT_FOR_STRATEGY_RESPONSE), () => {
     const state = scenario.states.waitForStrategyResponse;
     const action = scenario.actions.cancelledByA;
-    const result = reducer(state, sharedData, action);
+    const result = reducer(state.state, state.store, action);
 
     itTransitionsTo(result, states.FAILURE);
     itSendsThisMessage(result, 'WALLET.FUNDING.FAILURE');

--- a/packages/wallet/src/redux/protocols/funding/player-a/__tests__/scenarios.ts
+++ b/packages/wallet/src/redux/protocols/funding/player-a/__tests__/scenarios.ts
@@ -4,6 +4,8 @@ import { PlayerIndex } from '../../../../types';
 
 import { EMPTY_SHARED_DATA } from '../../../../state';
 import { FundingStrategy } from '../..';
+import * as indirectFundingTests from '../../../indirect-funding/player-a/__tests__';
+import { channelId, bsAddress } from '../../../../../domain/commitments/__tests__';
 
 // To test all paths through the state machine we will use 4 different scenarios:
 //
@@ -22,15 +24,12 @@ import { FundingStrategy } from '../..';
 // Test data
 // ---------
 const processId = 'process-id.123';
-const sharedData = EMPTY_SHARED_DATA;
 const strategy: FundingStrategy = 'IndirectFundingStrategy';
-const targetChannelId = '0x123';
-const opponentAddress = '0xf00';
+const targetChannelId = channelId;
+const opponentAddress = bsAddress;
 
 const props = {
   processId,
-  sharedData,
-  fundingState: 'funding state' as 'funding state',
   targetChannelId,
   opponentAddress,
   strategy,
@@ -39,10 +38,26 @@ const props = {
 // ----
 // States
 // ------
-const waitForStrategyChoice = states.waitForStrategyChoice(props);
-const waitForStrategyResponse = states.waitForStrategyResponse(props);
-const waitForFunding = states.waitForFunding(props);
-const waitForSuccessConfirmation = states.waitForSuccessConfirmation(props);
+const waitForStrategyChoice = {
+  state: states.waitForStrategyChoice(props),
+  store: EMPTY_SHARED_DATA,
+};
+const waitForStrategyResponse = {
+  state: states.waitForStrategyResponse(props),
+  store: indirectFundingTests.preSuccessState.store,
+};
+const waitForFunding = {
+  state: states.waitForFunding({
+    ...props,
+    fundingState: indirectFundingTests.preSuccessState.state,
+  }),
+  store: indirectFundingTests.preSuccessState.store,
+};
+
+const waitForSuccessConfirmation = {
+  state: states.waitForSuccessConfirmation(props),
+  store: indirectFundingTests.preSuccessState.store,
+};
 const success = states.success();
 const failure = states.failure('User refused');
 const failure2 = states.failure('Opponent refused');
@@ -53,7 +68,7 @@ const failure2 = states.failure('Opponent refused');
 const strategyChosen = actions.strategyChosen(processId, strategy);
 const strategyApproved = actions.strategyApproved(processId);
 const successConfirmed = actions.fundingSuccessAcknowledged(processId);
-
+const fundingSuccess = indirectFundingTests.successTrigger;
 const strategyRejected = actions.strategyRejected(processId);
 const cancelledByA = actions.cancelled(processId, PlayerIndex.A);
 const cancelledByB = actions.cancelled(processId, PlayerIndex.B);
@@ -73,6 +88,7 @@ export const happyPath = {
   actions: {
     strategyChosen,
     strategyApproved,
+    fundingSuccess,
     successConfirmed,
   },
 };

--- a/packages/wallet/src/redux/protocols/funding/player-a/container.tsx
+++ b/packages/wallet/src/redux/protocols/funding/player-a/container.tsx
@@ -11,6 +11,8 @@ import { FundingStrategy } from '..';
 import ChooseStrategy from '../../../../components/funding/choose-strategy';
 import WaitForOtherPlayer from '../../../../components/wait-for-other-player';
 import AcknowledgeX from '../../../../components/acknowledge-x';
+import { IndirectFunding } from '../../indirect-funding/container';
+import { isTerminal } from '../../indirect-funding/state';
 
 interface Props {
   state: states.OngoingFundingState;
@@ -37,8 +39,11 @@ class FundingContainer extends PureComponent<Props> {
       case states.WAIT_FOR_STRATEGY_RESPONSE:
         return <WaitForOtherPlayer name={'strategy response'} />;
       case states.WAIT_FOR_FUNDING:
-        // TODO: embed the funding container
-        return <div />;
+        if (isTerminal(state.fundingState)) {
+          console.error('Funding state is terminal');
+          return <div />;
+        }
+        return <IndirectFunding state={state.fundingState} />;
       case states.WAIT_FOR_SUCCESS_CONFIRMATION:
         return (
           <AcknowledgeX

--- a/packages/wallet/src/redux/protocols/funding/player-a/container.tsx
+++ b/packages/wallet/src/redux/protocols/funding/player-a/container.tsx
@@ -12,7 +12,6 @@ import ChooseStrategy from '../../../../components/funding/choose-strategy';
 import WaitForOtherPlayer from '../../../../components/wait-for-other-player';
 import AcknowledgeX from '../../../../components/acknowledge-x';
 import { IndirectFunding } from '../../indirect-funding/container';
-import { isTerminal } from '../../indirect-funding/state';
 
 interface Props {
   state: states.OngoingFundingState;
@@ -39,10 +38,6 @@ class FundingContainer extends PureComponent<Props> {
       case states.WAIT_FOR_STRATEGY_RESPONSE:
         return <WaitForOtherPlayer name={'strategy response'} />;
       case states.WAIT_FOR_FUNDING:
-        if (isTerminal(state.fundingState)) {
-          console.error('Funding state is terminal');
-          return <div />;
-        }
         return <IndirectFunding state={state.fundingState} />;
       case states.WAIT_FOR_SUCCESS_CONFIRMATION:
         return (

--- a/packages/wallet/src/redux/protocols/funding/player-a/reducer.ts
+++ b/packages/wallet/src/redux/protocols/funding/player-a/reducer.ts
@@ -80,7 +80,7 @@ function handleIndirectFundingAction(
     sharedData,
     action,
   );
-  if (!indirectFundingStates.isTerminal(newProtocolState.fundingState)) {
+  if (indirectFundingStates.isTerminal(newProtocolState.fundingState)) {
     return { protocolState: handleFundingComplete(newProtocolState), sharedData: newSharedData };
   } else {
     return { protocolState: newProtocolState, sharedData: newSharedData };

--- a/packages/wallet/src/redux/protocols/funding/player-a/reducer.ts
+++ b/packages/wallet/src/redux/protocols/funding/player-a/reducer.ts
@@ -112,8 +112,15 @@ function strategyApproved(
   if (state.type !== states.WAIT_FOR_STRATEGY_RESPONSE) {
     return { protocolState: state, sharedData };
   }
-
-  return initializeFunding(state, sharedData);
+  const channelState = selectors.getChannelState(sharedData, state.targetChannelId);
+  const { protocolState: fundingState, sharedData: newSharedData } = initializeIndirectFunding(
+    channelState,
+    sharedData,
+  );
+  return {
+    protocolState: states.waitForFunding({ ...state, fundingState }),
+    sharedData: newSharedData,
+  };
 }
 
 function strategyRejected(
@@ -165,25 +172,6 @@ function cancelled(state: states.FundingState, sharedData: SharedData, action: a
     default:
       return unreachable(action.by);
   }
-}
-
-// Helper Functions
-function initializeFunding(
-  protocolState: states.WaitForStrategyResponse,
-  sharedData: SharedData,
-): ProtocolStateWithSharedData<states.WaitForFunding> {
-  const channelState = selectors.getChannelState(sharedData, protocolState.targetChannelId);
-  const { protocolState: fundingState, sharedData: newSharedData } = initializeIndirectFunding(
-    channelState,
-    sharedData,
-  );
-  return {
-    protocolState: states.waitForFunding({
-      ...protocolState,
-      fundingState,
-    }),
-    sharedData: newSharedData,
-  };
 }
 
 function handleFundingComplete(

--- a/packages/wallet/src/redux/protocols/funding/player-a/reducer.ts
+++ b/packages/wallet/src/redux/protocols/funding/player-a/reducer.ts
@@ -18,6 +18,7 @@ import {
 } from '../../indirect-funding/reducer';
 import * as indirectFundingStates from '../../indirect-funding/state';
 import * as selectors from '../../../selectors';
+import { Properties } from '../../../utils';
 type EmbeddedAction = IndirectFundingAction;
 
 export function initialize(
@@ -75,15 +76,18 @@ function handleIndirectFundingAction(
     return { protocolState, sharedData };
   }
 
-  const { protocolState: newProtocolState, sharedData: newSharedData } = updateFundingState(
-    protocolState,
-    sharedData,
-    action,
-  );
-  if (indirectFundingStates.isTerminal(newProtocolState.fundingState)) {
-    return { protocolState: handleFundingComplete(newProtocolState), sharedData: newSharedData };
+  const {
+    protocolState: updatedFundingState,
+    sharedData: updatedSharedData,
+  } = indirectFundingReducer(protocolState.fundingState, sharedData, action);
+
+  if (!indirectFundingStates.isTerminal(updatedFundingState)) {
+    return {
+      protocolState: states.waitForFunding({ ...protocolState, fundingState: updatedFundingState }),
+      sharedData: updatedSharedData,
+    };
   } else {
-    return { protocolState: newProtocolState, sharedData: newSharedData };
+    return handleFundingComplete(protocolState, updatedFundingState, updatedSharedData);
   }
 }
 
@@ -117,6 +121,10 @@ function strategyApproved(
     channelState,
     sharedData,
   );
+  if (indirectFundingStates.isTerminal(fundingState)) {
+    console.error('Indirect funding strate initialized to terminal state.');
+    return handleFundingComplete(state, fundingState, newSharedData);
+  }
   return {
     protocolState: states.waitForFunding({ ...state, fundingState }),
     sharedData: newSharedData,
@@ -175,36 +183,20 @@ function cancelled(state: states.FundingState, sharedData: SharedData, action: a
 }
 
 function handleFundingComplete(
-  protocolState: states.WaitForFunding,
-): states.WaitForSuccessConfirmation | states.Failure {
-  if (protocolState.fundingState.type === 'Success') {
-    return states.waitForSuccessConfirmation(protocolState);
+  protocolState: Properties<states.WaitForSuccessConfirmation>,
+  fundingState: indirectFundingStates.IndirectFundingState,
+  sharedData: SharedData,
+) {
+  if (fundingState.type === 'Success') {
+    return {
+      protocolState: states.waitForSuccessConfirmation(protocolState),
+      sharedData,
+    };
   } else {
     // TODO: Indirect funding should return a proper error to pass to our failure state
-    return states.failure('Funding Failure');
+    return {
+      protocolState: states.failure('Indirect Funding Failure'),
+      sharedData,
+    };
   }
-}
-function updateFundingState(
-  protocolState: states.WaitForFunding,
-  sharedData: SharedData,
-  action: IndirectFundingAction,
-): ProtocolStateWithSharedData<states.WaitForFunding> {
-  if (indirectFundingStates.isTerminal(protocolState.fundingState)) {
-    console.error(
-      `Funding reducer received indirect funding action ${
-        action.type
-      } but indirect funding is in terminal state ${protocolState.type}`,
-    );
-    return { protocolState, sharedData };
-  }
-
-  const {
-    protocolState: updatedFundingState,
-    sharedData: updatedSharedData,
-  } = indirectFundingReducer(protocolState.fundingState, sharedData, action);
-
-  return {
-    protocolState: states.waitForFunding({ ...protocolState, fundingState: updatedFundingState }),
-    sharedData: updatedSharedData,
-  };
 }

--- a/packages/wallet/src/redux/protocols/funding/player-a/states.ts
+++ b/packages/wallet/src/redux/protocols/funding/player-a/states.ts
@@ -1,6 +1,7 @@
 import { Properties as P } from '../../../utils';
 import { ProtocolState } from '../..';
 import { FundingStrategy } from '..';
+import { IndirectFundingState } from '../../indirect-funding/state';
 
 export type OngoingFundingState =
   | WaitForStrategyChoice
@@ -36,7 +37,9 @@ export interface WaitForStrategyResponse extends BaseState {
 
 export interface WaitForFunding extends BaseState {
   type: typeof WAIT_FOR_FUNDING;
-  fundingState: 'funding state';
+  // TODO: Currently we are limited to indirect funding
+  // In the future this could support other funding states
+  fundingState: IndirectFundingState;
 }
 
 export interface WaitForSuccessConfirmation extends BaseState {

--- a/packages/wallet/src/redux/protocols/funding/player-a/states.ts
+++ b/packages/wallet/src/redux/protocols/funding/player-a/states.ts
@@ -1,7 +1,7 @@
 import { Properties as P } from '../../../utils';
 import { ProtocolState } from '../..';
 import { FundingStrategy } from '..';
-import { IndirectFundingState } from '../../indirect-funding/state';
+import { NonTerminalIndirectFundingState } from '../../indirect-funding/state';
 
 export type OngoingFundingState =
   | WaitForStrategyChoice
@@ -39,7 +39,7 @@ export interface WaitForFunding extends BaseState {
   type: typeof WAIT_FOR_FUNDING;
   // TODO: Currently we are limited to indirect funding
   // In the future this could support other funding states
-  fundingState: IndirectFundingState;
+  fundingState: NonTerminalIndirectFundingState;
 }
 
 export interface WaitForSuccessConfirmation extends BaseState {

--- a/packages/wallet/src/redux/protocols/funding/player-b/__tests__/reducer.test.ts
+++ b/packages/wallet/src/redux/protocols/funding/player-b/__tests__/reducer.test.ts
@@ -11,12 +11,11 @@ function whenIn(state) {
 
 describe('happyPath', () => {
   const scenario = scenarios.happyPath;
-  const sharedData = scenario.sharedData;
 
   describe(whenIn(states.WAIT_FOR_STRATEGY_PROPOSAL), () => {
     const state = scenario.states.waitForStrategyProposal;
     const action = scenario.actions.strategyProposed;
-    const result = reducer(state, sharedData, action);
+    const result = reducer(state.state, state.store, action);
 
     itTransitionsTo(result, states.WAIT_FOR_STRATEGY_APPROVAL);
   });
@@ -24,7 +23,7 @@ describe('happyPath', () => {
   describe(whenIn(states.WAIT_FOR_STRATEGY_APPROVAL), () => {
     const state = scenario.states.waitForStrategyApproval;
     const action = scenario.actions.strategyApproved;
-    const result = reducer(state, sharedData, action);
+    const result = reducer(state.state, state.store, action);
 
     itTransitionsTo(result, states.WAIT_FOR_FUNDING);
 
@@ -33,17 +32,16 @@ describe('happyPath', () => {
   });
 
   describe(whenIn(states.WAIT_FOR_FUNDING), () => {
-    // TODO: This test depends on updating the indirect funding protocol
-    // const state = scenario.states.waitForFunding;
-    // const action = scenario.actions.indirectFundingSuccess;
-    // const result = reducer(state, sharedData, action);
-    // itTransitionsTo(result, states.WAIT_FOR_SUCCESS_CONFIRMATION);
+    const state = scenario.states.waitForFunding;
+    const action = scenario.actions.fundingSuccess;
+    const result = reducer(state.state, state.store, action);
+    itTransitionsTo(result, states.WAIT_FOR_SUCCESS_CONFIRMATION);
   });
 
   describe(whenIn(states.WAIT_FOR_SUCCESS_CONFIRMATION), () => {
     const state = scenario.states.waitForSuccessConfirmation;
     const action = scenario.actions.successConfirmed;
-    const result = reducer(state, sharedData, action);
+    const result = reducer(state.state, state.store, action);
 
     itTransitionsTo(result, states.SUCCESS);
   });
@@ -51,12 +49,11 @@ describe('happyPath', () => {
 
 describe('When a strategy is rejected', () => {
   const scenario = scenarios.rejectedStrategy;
-  const sharedData = scenario.sharedData;
 
   describe(whenIn(states.WAIT_FOR_STRATEGY_APPROVAL), () => {
     const state = scenario.states.waitForStrategyApproval;
     const action = scenario.actions.strategyRejected;
-    const result = reducer(state, sharedData, action);
+    const result = reducer(state.state, state.store, action);
 
     itTransitionsTo(result, states.WAIT_FOR_STRATEGY_PROPOSAL);
   });
@@ -64,12 +61,11 @@ describe('When a strategy is rejected', () => {
 
 describe('when cancelled by the opponent', () => {
   const scenario = scenarios.cancelledByOpponent;
-  const sharedData = scenario.sharedData;
 
   describe(whenIn(states.WAIT_FOR_STRATEGY_PROPOSAL), () => {
     const state = scenario.states.waitForStrategyProposal;
     const action = scenario.actions.cancelledByA;
-    const result = reducer(state, sharedData, action);
+    const result = reducer(state.state, state.store, action);
 
     itTransitionsTo(result, states.FAILURE);
     itSendsThisMessage(result, 'WALLET.FUNDING.FAILURE');
@@ -78,7 +74,7 @@ describe('when cancelled by the opponent', () => {
   describe(whenIn(states.WAIT_FOR_STRATEGY_APPROVAL), () => {
     const state = scenario.states.waitForStrategyApproval;
     const action = scenario.actions.cancelledByA;
-    const result = reducer(state, sharedData, action);
+    const result = reducer(state.state, state.store, action);
 
     itTransitionsTo(result, states.FAILURE);
     itSendsThisMessage(result, 'WALLET.FUNDING.FAILURE');
@@ -87,12 +83,11 @@ describe('when cancelled by the opponent', () => {
 
 describe('when cancelled by the user', () => {
   const scenario = scenarios.cancelledByUser;
-  const sharedData = scenario.sharedData;
 
   describe(whenIn(states.WAIT_FOR_STRATEGY_PROPOSAL), () => {
     const state = scenario.states.waitForStrategyProposal;
     const action = scenario.actions.cancelledByB;
-    const result = reducer(state, sharedData, action);
+    const result = reducer(state.state, state.store, action);
 
     itTransitionsTo(result, states.FAILURE);
     itSendsThisMessage(result, 'WALLET.FUNDING.FAILURE');
@@ -101,7 +96,7 @@ describe('when cancelled by the user', () => {
   describe(whenIn(states.WAIT_FOR_STRATEGY_APPROVAL), () => {
     const state = scenario.states.waitForStrategyApproval;
     const action = scenario.actions.cancelledByB;
-    const result = reducer(state, sharedData, action);
+    const result = reducer(state.state, state.store, action);
 
     itTransitionsTo(result, states.FAILURE);
     itSendsThisMessage(result, 'WALLET.FUNDING.FAILURE');

--- a/packages/wallet/src/redux/protocols/funding/player-b/__tests__/reducer.test.ts
+++ b/packages/wallet/src/redux/protocols/funding/player-b/__tests__/reducer.test.ts
@@ -13,17 +13,17 @@ describe('happyPath', () => {
   const scenario = scenarios.happyPath;
 
   describe(whenIn(states.WAIT_FOR_STRATEGY_PROPOSAL), () => {
-    const state = scenario.states.waitForStrategyProposal;
+    const { state, store } = scenario.states.waitForStrategyProposal;
     const action = scenario.actions.strategyProposed;
-    const result = reducer(state.state, state.store, action);
+    const result = reducer(state, store, action);
 
     itTransitionsTo(result, states.WAIT_FOR_STRATEGY_APPROVAL);
   });
 
   describe(whenIn(states.WAIT_FOR_STRATEGY_APPROVAL), () => {
-    const state = scenario.states.waitForStrategyApproval;
+    const { state, store } = scenario.states.waitForStrategyApproval;
     const action = scenario.actions.strategyApproved;
-    const result = reducer(state.state, state.store, action);
+    const result = reducer(state, store, action);
 
     itTransitionsTo(result, states.WAIT_FOR_FUNDING);
 
@@ -32,16 +32,16 @@ describe('happyPath', () => {
   });
 
   describe(whenIn(states.WAIT_FOR_FUNDING), () => {
-    const state = scenario.states.waitForFunding;
+    const { state, store } = scenario.states.waitForFunding;
     const action = scenario.actions.fundingSuccess;
-    const result = reducer(state.state, state.store, action);
+    const result = reducer(state, store, action);
     itTransitionsTo(result, states.WAIT_FOR_SUCCESS_CONFIRMATION);
   });
 
   describe(whenIn(states.WAIT_FOR_SUCCESS_CONFIRMATION), () => {
-    const state = scenario.states.waitForSuccessConfirmation;
+    const { state, store } = scenario.states.waitForSuccessConfirmation;
     const action = scenario.actions.successConfirmed;
-    const result = reducer(state.state, state.store, action);
+    const result = reducer(state, store, action);
 
     itTransitionsTo(result, states.SUCCESS);
   });
@@ -51,9 +51,9 @@ describe('When a strategy is rejected', () => {
   const scenario = scenarios.rejectedStrategy;
 
   describe(whenIn(states.WAIT_FOR_STRATEGY_APPROVAL), () => {
-    const state = scenario.states.waitForStrategyApproval;
+    const { state, store } = scenario.states.waitForStrategyApproval;
     const action = scenario.actions.strategyRejected;
-    const result = reducer(state.state, state.store, action);
+    const result = reducer(state, store, action);
 
     itTransitionsTo(result, states.WAIT_FOR_STRATEGY_PROPOSAL);
   });
@@ -63,18 +63,18 @@ describe('when cancelled by the opponent', () => {
   const scenario = scenarios.cancelledByOpponent;
 
   describe(whenIn(states.WAIT_FOR_STRATEGY_PROPOSAL), () => {
-    const state = scenario.states.waitForStrategyProposal;
+    const { state, store } = scenario.states.waitForStrategyProposal;
     const action = scenario.actions.cancelledByA;
-    const result = reducer(state.state, state.store, action);
+    const result = reducer(state, store, action);
 
     itTransitionsTo(result, states.FAILURE);
     itSendsThisMessage(result, 'WALLET.FUNDING.FAILURE');
   });
 
   describe(whenIn(states.WAIT_FOR_STRATEGY_APPROVAL), () => {
-    const state = scenario.states.waitForStrategyApproval;
+    const { state, store } = scenario.states.waitForStrategyApproval;
     const action = scenario.actions.cancelledByA;
-    const result = reducer(state.state, state.store, action);
+    const result = reducer(state, store, action);
 
     itTransitionsTo(result, states.FAILURE);
     itSendsThisMessage(result, 'WALLET.FUNDING.FAILURE');
@@ -85,18 +85,18 @@ describe('when cancelled by the user', () => {
   const scenario = scenarios.cancelledByUser;
 
   describe(whenIn(states.WAIT_FOR_STRATEGY_PROPOSAL), () => {
-    const state = scenario.states.waitForStrategyProposal;
+    const { state, store } = scenario.states.waitForStrategyProposal;
     const action = scenario.actions.cancelledByB;
-    const result = reducer(state.state, state.store, action);
+    const result = reducer(state, store, action);
 
     itTransitionsTo(result, states.FAILURE);
     itSendsThisMessage(result, 'WALLET.FUNDING.FAILURE');
   });
 
   describe(whenIn(states.WAIT_FOR_STRATEGY_APPROVAL), () => {
-    const state = scenario.states.waitForStrategyApproval;
+    const { state, store } = scenario.states.waitForStrategyApproval;
     const action = scenario.actions.cancelledByB;
-    const result = reducer(state.state, state.store, action);
+    const result = reducer(state, store, action);
 
     itTransitionsTo(result, states.FAILURE);
     itSendsThisMessage(result, 'WALLET.FUNDING.FAILURE');

--- a/packages/wallet/src/redux/protocols/funding/player-b/__tests__/scenarios.ts
+++ b/packages/wallet/src/redux/protocols/funding/player-b/__tests__/scenarios.ts
@@ -4,6 +4,8 @@ import { PlayerIndex } from '../../../../types';
 
 import { EMPTY_SHARED_DATA } from '../../../../state';
 import { FundingStrategy } from '../../../../../communication';
+import * as indirectFundingTests from '../../../indirect-funding/player-b/__tests__';
+import { channelId, asAddress } from '../../../../../domain/commitments/__tests__';
 
 // To test all paths through the state machine we will use 4 different scenarios:
 //
@@ -22,16 +24,13 @@ import { FundingStrategy } from '../../../../../communication';
 // Test data
 // ---------
 const processId = 'process-id.123';
-const sharedData = EMPTY_SHARED_DATA;
-const targetChannelId = '0x1324';
-const opponentAddress = '0xf00';
+const targetChannelId = channelId;
+const opponentAddress = asAddress;
 const strategy: FundingStrategy = 'IndirectFundingStrategy';
 
 const props = {
-  processId,
-  sharedData,
-  fundingState: 'funding state' as 'funding state',
   targetChannelId,
+  processId,
   opponentAddress,
   strategy,
 };
@@ -39,10 +38,25 @@ const props = {
 // ------
 // States
 // ------
-const waitForStrategyProposal = states.waitForStrategyProposal(props);
-const waitForStrategyApproval = states.waitForStrategyApproval(props);
-const waitForFunding = states.waitForFunding(props);
-const waitForSuccessConfirmation = states.waitForSuccessConfirmation(props);
+const waitForStrategyProposal = {
+  state: states.waitForStrategyProposal(props),
+  store: EMPTY_SHARED_DATA,
+};
+const waitForStrategyApproval = {
+  state: states.waitForStrategyApproval(props),
+  store: indirectFundingTests.preSuccessState.store,
+};
+const waitForFunding = {
+  state: states.waitForFunding({
+    ...props,
+    fundingState: indirectFundingTests.preSuccessState.state,
+  }),
+  store: indirectFundingTests.preSuccessState.store,
+};
+const waitForSuccessConfirmation = {
+  state: states.waitForSuccessConfirmation(props),
+  store: EMPTY_SHARED_DATA,
+};
 const success = states.success();
 const failure = states.failure('User refused');
 const failure2 = states.failure('Opponent refused');
@@ -53,6 +67,7 @@ const failure2 = states.failure('Opponent refused');
 const strategyProposed = actions.strategyProposed(processId, strategy);
 const strategyApproved = actions.strategyApproved(processId, strategy);
 const successConfirmed = actions.fundingSuccessAcknowledged(processId);
+const fundingSuccess = indirectFundingTests.successTrigger;
 const strategyRejected = actions.strategyRejected(processId);
 const cancelledByB = actions.cancelled(processId, PlayerIndex.B);
 const cancelledByA = actions.cancelled(processId, PlayerIndex.A);
@@ -72,6 +87,7 @@ export const happyPath = {
   actions: {
     strategyProposed,
     strategyApproved,
+    fundingSuccess,
     successConfirmed,
   },
 };

--- a/packages/wallet/src/redux/protocols/funding/player-b/container.tsx
+++ b/packages/wallet/src/redux/protocols/funding/player-b/container.tsx
@@ -11,6 +11,8 @@ import ApproveStrategy from '../../../../components/funding/approve-strategy';
 import WaitForOtherPlayer from '../../../../components/wait-for-other-player';
 import AcknowledgeX from '../../../../components/acknowledge-x';
 import { FundingStrategy } from '..';
+import { IndirectFunding } from '../../indirect-funding/container';
+import { isTerminal } from '../../indirect-funding/state';
 
 interface Props {
   state: states.OngoingFundingState;
@@ -36,8 +38,11 @@ class FundingContainer extends PureComponent<Props> {
           />
         );
       case states.WAIT_FOR_FUNDING:
-        // TODO: embed the funding container
-        return <div />;
+        if (isTerminal(state.fundingState)) {
+          console.error('Funding state is terminal');
+          return <div />;
+        }
+        return <IndirectFunding state={state.fundingState} />;
       case states.WAIT_FOR_SUCCESS_CONFIRMATION:
         return (
           <AcknowledgeX

--- a/packages/wallet/src/redux/protocols/funding/player-b/container.tsx
+++ b/packages/wallet/src/redux/protocols/funding/player-b/container.tsx
@@ -12,8 +12,6 @@ import WaitForOtherPlayer from '../../../../components/wait-for-other-player';
 import AcknowledgeX from '../../../../components/acknowledge-x';
 import { FundingStrategy } from '..';
 import { IndirectFunding } from '../../indirect-funding/container';
-import { isTerminal } from '../../indirect-funding/state';
-
 interface Props {
   state: states.OngoingFundingState;
   strategyApproved: (processId: string, strategy: FundingStrategy) => void;
@@ -38,10 +36,6 @@ class FundingContainer extends PureComponent<Props> {
           />
         );
       case states.WAIT_FOR_FUNDING:
-        if (isTerminal(state.fundingState)) {
-          console.error('Funding state is terminal');
-          return <div />;
-        }
         return <IndirectFunding state={state.fundingState} />;
       case states.WAIT_FOR_SUCCESS_CONFIRMATION:
         return (

--- a/packages/wallet/src/redux/protocols/funding/player-b/reducer.ts
+++ b/packages/wallet/src/redux/protocols/funding/player-b/reducer.ts
@@ -81,7 +81,7 @@ function handleIndirectFundingAction(
     sharedData,
     action,
   );
-  if (!indirectFundingStates.isTerminal(newProtocolState.fundingState)) {
+  if (indirectFundingStates.isTerminal(newProtocolState.fundingState)) {
     return { protocolState: handleFundingComplete(newProtocolState), sharedData: newSharedData };
   } else {
     return { protocolState: newProtocolState, sharedData: newSharedData };

--- a/packages/wallet/src/redux/protocols/funding/player-b/states.ts
+++ b/packages/wallet/src/redux/protocols/funding/player-b/states.ts
@@ -1,6 +1,7 @@
 import { Properties as P } from '../../../utils';
 import { ProtocolState } from '../..';
 import { FundingStrategy } from '..';
+import { IndirectFundingState } from '../../indirect-funding/state';
 
 export type OngoingFundingState =
   | WaitForStrategyProposal
@@ -36,7 +37,7 @@ export interface WaitForStrategyApproval extends BaseState {
 
 export interface WaitForFunding extends BaseState {
   type: typeof WAIT_FOR_FUNDING;
-  fundingState: 'funding state';
+  fundingState: IndirectFundingState;
 }
 
 export interface WaitForSuccessConfirmation extends BaseState {

--- a/packages/wallet/src/redux/protocols/funding/player-b/states.ts
+++ b/packages/wallet/src/redux/protocols/funding/player-b/states.ts
@@ -1,7 +1,7 @@
 import { Properties as P } from '../../../utils';
 import { ProtocolState } from '../..';
 import { FundingStrategy } from '..';
-import { IndirectFundingState } from '../../indirect-funding/state';
+import { NonTerminalIndirectFundingState } from '../../indirect-funding/state';
 
 export type OngoingFundingState =
   | WaitForStrategyProposal
@@ -37,7 +37,7 @@ export interface WaitForStrategyApproval extends BaseState {
 
 export interface WaitForFunding extends BaseState {
   type: typeof WAIT_FOR_FUNDING;
-  fundingState: IndirectFundingState;
+  fundingState: NonTerminalIndirectFundingState;
 }
 
 export interface WaitForSuccessConfirmation extends BaseState {

--- a/packages/wallet/src/redux/protocols/indirect-funding/player-a/__tests__/index.ts
+++ b/packages/wallet/src/redux/protocols/indirect-funding/player-a/__tests__/index.ts
@@ -1,0 +1,9 @@
+import { happyPath, ledgerFundingFails } from './scenarios';
+
+export const initialState = happyPath.waitForPreFundL1.state;
+
+export const preSuccessState = happyPath.waitForPostFund1.state;
+export const successTrigger = happyPath.waitForPostFund1.action;
+
+export const preFailureState = ledgerFundingFails.waitForDirectFunding.state;
+export const failureTrigger = ledgerFundingFails.waitForDirectFunding.action;

--- a/packages/wallet/src/redux/protocols/indirect-funding/player-a/__tests__/scenarios.ts
+++ b/packages/wallet/src/redux/protocols/indirect-funding/player-a/__tests__/scenarios.ts
@@ -81,7 +81,7 @@ const waitForLedgerUpdate1 = {
 const waitForPostFund1 = {
   state: aWaitForPostFundSetup1(props),
   store: setChannels(EMPTY_SHARED_DATA, [
-    channelFromCommitments(app0, app1, asAddress, asPrivateKey),
+    channelFromCommitments(app1, app2, asAddress, asPrivateKey),
     channelFromCommitments(ledger4, ledger5, asAddress, asPrivateKey),
   ]),
 };

--- a/packages/wallet/src/redux/protocols/indirect-funding/player-b/__tests__/index.ts
+++ b/packages/wallet/src/redux/protocols/indirect-funding/player-b/__tests__/index.ts
@@ -1,0 +1,9 @@
+import { happyPath, ledgerFundingFails } from './scenarios';
+
+export const initialState = happyPath.waitForPreFundSetup0.state;
+
+export const preSuccessState = happyPath.waitForPostFund0.state;
+export const successTrigger = happyPath.waitForPostFund0.action;
+
+export const preFailureState = ledgerFundingFails.waitForDirectFunding.state;
+export const failureTrigger = ledgerFundingFails.waitForDirectFunding.action;

--- a/packages/wallet/src/redux/protocols/indirect-funding/state.ts
+++ b/packages/wallet/src/redux/protocols/indirect-funding/state.ts
@@ -22,3 +22,7 @@ export function success(): Success {
 export function failure(): Failure {
   return { type: 'Failure' };
 }
+
+export function isTerminal(state: IndirectFundingState): state is Failure | Success {
+  return state.type === 'Failure' || state.type === 'Success';
+}

--- a/packages/wallet/src/redux/protocols/reducer-helpers.ts
+++ b/packages/wallet/src/redux/protocols/reducer-helpers.ts
@@ -94,6 +94,6 @@ export const isFirstPlayer = (channelId: string, sharedData: SharedData) => {
 
 export function getOpponentAddress(channelState: ChannelState, playerIndex: PlayerIndex) {
   const { participants } = channelState;
-  const opponentAddress = participants[playerIndex + (1 % participants.length)];
+  const opponentAddress = participants[(playerIndex + 1) % participants.length];
   return opponentAddress;
 }


### PR DESCRIPTION
Simple change so the funding protocol properly initializes the indirect funding sub-protocol and delegates appropriate actions to it.