### PR TITLE
Indirect Funding Updates

### DIFF
--- a/packages/rps/src/redux/message-service/saga.ts
+++ b/packages/rps/src/redux/message-service/saga.ts
@@ -68,8 +68,6 @@ export function* sendWalletMessageSaga() {
     } else {
       yield call(reduxSagaFirebase.database.create, `/messages/${to.toLowerCase()}`, messageToSend);
     }
-    yield call(reduxSagaFirebase.database.create, `/messages/${to.toLowerCase()}`, messageToSend);
-    break;
   }
 }
 

--- a/packages/wallet/src/contract-tests/test-utils.ts
+++ b/packages/wallet/src/contract-tests/test-utils.ts
@@ -42,7 +42,7 @@ export async function depositContract(
   participant: string,
   amount = defaultDepositAmount,
 ) {
-  const deployTransaction = createDepositTransaction(participant, amount);
+  const deployTransaction = createDepositTransaction(participant, amount, '0x0');
   const transactionReceipt = await sendTransaction(provider, deployTransaction);
   await transactionReceipt.wait();
 }

--- a/packages/wallet/src/contract-tests/transactions.test.ts
+++ b/packages/wallet/src/contract-tests/transactions.test.ts
@@ -77,7 +77,7 @@ describe('transactions', () => {
   });
 
   it('should deposit into the contract', async () => {
-    const depositTransaction = createDepositTransaction(participantA.address, '0x5');
+    const depositTransaction = createDepositTransaction(participantA.address, '0x5', '0x0');
     await testTransactionSender(depositTransaction);
   });
 

--- a/packages/wallet/src/redux/protocols/direct-funding/reducer.ts
+++ b/packages/wallet/src/redux/protocols/direct-funding/reducer.ts
@@ -182,6 +182,7 @@ const notSafeToDepositReducer: DFReducer = (
         const depositTransaction = createDepositTransaction(
           state.channelId,
           state.requestedYourContribution,
+          state.safeToDepositLevel,
         );
 
         const {

--- a/packages/wallet/src/redux/protocols/direct-funding/state.ts
+++ b/packages/wallet/src/redux/protocols/direct-funding/state.ts
@@ -159,7 +159,11 @@ export function initialDirectFundingState(
   }
 
   if (alreadySafeToDeposit) {
-    const depositTransaction = createDepositTransaction(action.channelId, action.requiredDeposit);
+    const depositTransaction = createDepositTransaction(
+      action.channelId,
+      action.requiredDeposit,
+      action.safeToDepositLevel,
+    );
     const { storage: newSharedData, state: transactionSubmissionState } = initTransactionState(
       depositTransaction,
       action.processId,

--- a/packages/wallet/src/redux/protocols/funding/player-a/reducer.ts
+++ b/packages/wallet/src/redux/protocols/funding/player-a/reducer.ts
@@ -118,6 +118,7 @@ function strategyApproved(
   }
   const channelState = selectors.getChannelState(sharedData, state.targetChannelId);
   const { protocolState: fundingState, sharedData: newSharedData } = initializeIndirectFunding(
+    state.processId,
     channelState,
     sharedData,
   );

--- a/packages/wallet/src/redux/protocols/funding/player-b/reducer.ts
+++ b/packages/wallet/src/redux/protocols/funding/player-b/reducer.ts
@@ -119,6 +119,7 @@ function strategyApproved(
 
   const channelState = selectors.getChannelState(sharedData, state.targetChannelId);
   const { protocolState: fundingState, sharedData: newSharedData } = initializeIndirectFunding(
+    processId,
     channelState,
     sharedData,
   );

--- a/packages/wallet/src/redux/protocols/indirect-funding/player-a/__tests__/reducer.test.ts
+++ b/packages/wallet/src/redux/protocols/indirect-funding/player-a/__tests__/reducer.test.ts
@@ -68,17 +68,13 @@ function itTransitionsTo(state: ReturnVal, type: IndirectFundingState['type']) {
 function itSendsMessage(state: ReturnVal, message: SignedCommitment) {
   it('sends a message', () => {
     const lastMessage = getLastMessage(state.sharedData);
-
     if (lastMessage && 'messagePayload' in lastMessage) {
       const dataPayload = lastMessage.messagePayload.data;
       // This is yuk. The data in a message is currently of 'any' type..
-      if (!('commitment' in dataPayload)) {
-        fail('No commitment in the last message.');
+      if (!('signedCommitment' in dataPayload)) {
+        fail('No signedCommitment in the last message.');
       }
-      if (!('signature' in dataPayload)) {
-        fail('No signature in the last message.');
-      }
-      const { commitment, signature } = dataPayload;
+      const { commitment, signature } = dataPayload.signedCommitment;
       expect({ commitment, signature }).toEqual(message);
     } else {
       fail('No messages in the outbox.');

--- a/packages/wallet/src/redux/protocols/indirect-funding/player-a/__tests__/reducer.test.ts
+++ b/packages/wallet/src/redux/protocols/indirect-funding/player-a/__tests__/reducer.test.ts
@@ -8,8 +8,8 @@ import { getLastMessage } from '../../../../state';
 describe('happy-path scenario', () => {
   const scenario = scenarios.happyPath;
   describe('initializing', () => {
-    const { channelId, store, reply } = scenario.initialParams;
-    const initialState = initialize(channelId, store);
+    const { channelId, store, reply, processId } = scenario.initialParams;
+    const initialState = initialize(processId, channelId, store);
 
     itTransitionsTo(initialState, 'AWaitForPreFundSetup1');
     itSendsMessage(initialState, reply);

--- a/packages/wallet/src/redux/protocols/indirect-funding/player-a/__tests__/scenarios.ts
+++ b/packages/wallet/src/redux/protocols/indirect-funding/player-a/__tests__/scenarios.ts
@@ -52,7 +52,7 @@ const ledger5 = ledgerCommitment({ turnNum: 5, balances: fiveToApp });
 
 // Channels
 
-const props = { channelId, ledgerId };
+const props = { channelId, ledgerId, processId };
 
 // ------
 // States
@@ -102,7 +102,12 @@ const ledgerUpdate1Received = globalActions.commitmentReceived(processId, ledger
 const postFund1Received = globalActions.commitmentReceived(processId, app3);
 
 export const happyPath = {
-  initialParams: { store: waitForPreFundL1.store, channelId, reply: ledger0 },
+  initialParams: {
+    store: waitForPreFundL1.store,
+    channelId,
+    reply: ledger0,
+    processId: 'processId',
+  },
   waitForPreFundL1: { state: waitForPreFundL1, action: preFundL1Received },
   waitForDirectFunding: { state: waitForDirectFunding, action: successTriggerA, reply: ledger4 },
   waitForLedgerUpdate1: {

--- a/packages/wallet/src/redux/protocols/indirect-funding/player-a/reducer.ts
+++ b/packages/wallet/src/redux/protocols/indirect-funding/player-a/reducer.ts
@@ -145,7 +145,7 @@ function handleWaitForLedgerUpdate(
   sharedData = signResult.store;
 
   // just need to put our message in the outbox
-  const messageRelay = createCommitmentMessageRelay(
+  const messageRelay = sendCommitmentReceived(
     theirAddress(appChannel),
     'processId', // TODO don't use dummy values
     signResult.signedCommitment.commitment,

--- a/packages/wallet/src/redux/protocols/indirect-funding/player-a/reducer.ts
+++ b/packages/wallet/src/redux/protocols/indirect-funding/player-a/reducer.ts
@@ -35,7 +35,11 @@ import { unreachable } from '../../../../utils/reducer-utils';
 type ReturnVal = ProtocolStateWithSharedData<IndirectFundingState>;
 type IDFAction = actions.indirectFunding.Action;
 
-export function initialize(channelId: string, sharedData: SharedData): ReturnVal {
+export function initialize(
+  processId: string,
+  channelId: string,
+  sharedData: SharedData,
+): ReturnVal {
   const channel = getChannel(sharedData.channelStore, channelId);
   if (!channel) {
     throw new Error(`Could not find existing application channel ${channelId}`);
@@ -61,7 +65,7 @@ export function initialize(channelId: string, sharedData: SharedData): ReturnVal
   // just need to put our message in the outbox
   const messageRelay = sendCommitmentReceived(
     theirAddress(channel),
-    'processId', // TODO don't use dummy values
+    processId,
     signResult.signedCommitment.commitment,
     signResult.signedCommitment.signature,
   );
@@ -70,6 +74,7 @@ export function initialize(channelId: string, sharedData: SharedData): ReturnVal
   const protocolState = states.aWaitForPreFundSetup1({
     channelId,
     ledgerId,
+    processId,
   });
   return { protocolState, sharedData };
 }

--- a/packages/wallet/src/redux/protocols/indirect-funding/player-a/reducer.ts
+++ b/packages/wallet/src/redux/protocols/indirect-funding/player-a/reducer.ts
@@ -188,14 +188,17 @@ function handleWaitForPreFundSetup(
   // Do we really need to do that constantly or is it for debugging mostly?
   const theirCommitment = action.signedCommitment.commitment;
   const ledgerId = getChannelId(theirCommitment);
+
+  const total = theirCommitment.allocation.reduce(addHex);
+  const ourAmount = theirCommitment.allocation[0];
   // update the state
   const directFundingAction = directFundingRequested(
     protocolState.processId,
     ledgerId,
-    '0',
-    '0', // TODO don't use dummy values
-    '0',
-    1,
+    '0x0',
+    total,
+    ourAmount,
+    0,
   );
   const directFundingState = initialDirectFundingState(directFundingAction, sharedData);
   const newProtocolState = states.aWaitForDirectFunding({
@@ -203,6 +206,7 @@ function handleWaitForPreFundSetup(
     ledgerId,
     directFundingState: directFundingState.protocolState,
   });
+  sharedData = directFundingState.sharedData;
 
   return { protocolState: newProtocolState, sharedData };
 }

--- a/packages/wallet/src/redux/protocols/indirect-funding/player-a/reducer.ts
+++ b/packages/wallet/src/redux/protocols/indirect-funding/player-a/reducer.ts
@@ -152,7 +152,7 @@ function handleWaitForLedgerUpdate(
   // just need to put our message in the outbox
   const messageRelay = sendCommitmentReceived(
     theirAddress(appChannel),
-    'processId', // TODO don't use dummy values
+    protocolState.processId,
     signResult.signedCommitment.commitment,
     signResult.signedCommitment.signature,
   );
@@ -190,7 +190,7 @@ function handleWaitForPreFundSetup(
   const ledgerId = getChannelId(theirCommitment);
   // update the state
   const directFundingAction = directFundingRequested(
-    'processId',
+    protocolState.processId,
     ledgerId,
     '0',
     '0', // TODO don't use dummy values
@@ -245,7 +245,7 @@ function handleWaitForDirectFunding(
 
     const messageRelay = sendCommitmentReceived(
       theirAddress(channel),
-      'processId', // TODO don't use dummy values
+      protocolState.processId,
       signResult.signedCommitment.commitment,
       signResult.signedCommitment.signature,
     );

--- a/packages/wallet/src/redux/protocols/indirect-funding/player-a/state.ts
+++ b/packages/wallet/src/redux/protocols/indirect-funding/player-a/state.ts
@@ -12,23 +12,27 @@ export interface AWaitForPreFundSetup1 {
   type: 'AWaitForPreFundSetup1';
   channelId: string;
   ledgerId: string;
+  processId: string;
 }
 
 export interface AWaitForDirectFunding {
   type: 'AWaitForDirectFunding';
   channelId: string;
   ledgerId: string;
+  processId: string;
   directFundingState: DirectFundingState;
 }
 export interface AWaitForPostFundSetup1 {
   type: 'AWaitForPostFundSetup1';
   channelId: string;
   ledgerId: string;
+  processId: string;
 }
 export interface AWaitForLedgerUpdate1 {
   type: 'AWaitForLedgerUpdate1';
   channelId: string;
   ledgerId: string;
+  processId: string;
 }
 
 // -------
@@ -49,26 +53,27 @@ export function isPlayerAState(state: IndirectFundingState): state is PlayerASta
 // --------
 
 export function aWaitForPreFundSetup1(params: P<AWaitForPreFundSetup1>): AWaitForPreFundSetup1 {
-  const { channelId, ledgerId } = params;
-  return { type: 'AWaitForPreFundSetup1', channelId, ledgerId };
+  const { channelId, ledgerId, processId } = params;
+  return { type: 'AWaitForPreFundSetup1', channelId, ledgerId, processId };
 }
 
 export function aWaitForDirectFunding(params: P<AWaitForDirectFunding>): AWaitForDirectFunding {
-  const { channelId, ledgerId, directFundingState } = params;
+  const { channelId, ledgerId, directFundingState, processId } = params;
   return {
     type: 'AWaitForDirectFunding',
     channelId,
     ledgerId,
     directFundingState,
+    processId,
   };
 }
 
 export function aWaitForPostFundSetup1(params: P<AWaitForPostFundSetup1>): AWaitForPostFundSetup1 {
-  const { channelId, ledgerId } = params;
-  return { type: 'AWaitForPostFundSetup1', channelId, ledgerId };
+  const { channelId, ledgerId, processId } = params;
+  return { type: 'AWaitForPostFundSetup1', channelId, ledgerId, processId };
 }
 
 export function aWaitForLedgerUpdate1(params: P<AWaitForLedgerUpdate1>): AWaitForLedgerUpdate1 {
-  const { channelId, ledgerId } = params;
-  return { type: 'AWaitForLedgerUpdate1', channelId, ledgerId };
+  const { channelId, ledgerId, processId } = params;
+  return { type: 'AWaitForLedgerUpdate1', channelId, ledgerId, processId };
 }

--- a/packages/wallet/src/redux/protocols/indirect-funding/player-b/__tests__/reducer.test.ts
+++ b/packages/wallet/src/redux/protocols/indirect-funding/player-b/__tests__/reducer.test.ts
@@ -8,8 +8,8 @@ import { getLastMessage } from '../../../../state';
 describe('happy-path scenario', () => {
   const scenario = scenarios.happyPath;
   describe('initializing', () => {
-    const { channelId, store } = scenario.initialParams;
-    const initialState = initialize(channelId, store);
+    const { channelId, store, processId } = scenario.initialParams;
+    const initialState = initialize(processId, channelId, store);
 
     itTransitionsTo(initialState, 'BWaitForPreFundSetup0');
   });

--- a/packages/wallet/src/redux/protocols/indirect-funding/player-b/__tests__/scenarios.ts
+++ b/packages/wallet/src/redux/protocols/indirect-funding/player-b/__tests__/scenarios.ts
@@ -57,7 +57,7 @@ const ledger5 = ledgerCommitment({ turnNum: 5, balances: fiveToApp }); // Ledger
 
 // Channels
 
-const props = { channelId, ledgerId };
+const props = { channelId, ledgerId, processId };
 
 // ------
 // States
@@ -106,7 +106,7 @@ const ledgerUpdate0Received = globalActions.commitmentReceived(processId, ledger
 const postFund0Received = globalActions.commitmentReceived(processId, app2);
 
 export const happyPath = {
-  initialParams: { store: waitForPreFundSetup0.store, channelId },
+  initialParams: { store: waitForPreFundSetup0.store, channelId, processId: 'processId' },
   waitForPreFundSetup0: {
     state: waitForPreFundSetup0,
     action: preFundSetup0Received,

--- a/packages/wallet/src/redux/protocols/indirect-funding/player-b/reducer.ts
+++ b/packages/wallet/src/redux/protocols/indirect-funding/player-b/reducer.ts
@@ -35,6 +35,7 @@ import { directFundingStateReducer } from '../../direct-funding/reducer';
 import { isSuccess, isFailure } from '../../direct-funding/state';
 import { acceptConsensus } from '../../../../domain/two-player-consensus-game';
 import { sendCommitmentReceived } from '../../../../communication';
+import { addHex } from '../../../../utils/hex-utils';
 
 type ReturnVal = ProtocolStateWithSharedData<IndirectFundingState>;
 type IDFAction = actions.indirectFunding.Action;
@@ -129,13 +130,16 @@ function handleWaitForPreFundSetup(
   sharedData = queueMessage(sharedData, messageRelay);
   channel = getChannel(sharedData, ledgerId); // refresh channel
 
+  const total = theirCommitment.allocation.reduce(addHex);
+  const theirAmount = theirCommitment.allocation[0];
+  const ourAmount = theirCommitment.allocation[1];
   // update the state
   const directFundingAction = directFundingRequested(
     protocolState.processId,
     ledgerId,
-    '0',
-    '0', // TODO don't use dummy values
-    '0',
+    theirAmount,
+    total,
+    ourAmount,
     1,
   );
   const directFundingState = initialDirectFundingState(directFundingAction, sharedData);
@@ -144,7 +148,7 @@ function handleWaitForPreFundSetup(
     ledgerId,
     directFundingState: directFundingState.protocolState,
   });
-
+  sharedData = directFundingState.sharedData;
   return { protocolState: newProtocolState, sharedData };
 }
 

--- a/packages/wallet/src/redux/protocols/indirect-funding/player-b/reducer.ts
+++ b/packages/wallet/src/redux/protocols/indirect-funding/player-b/reducer.ts
@@ -209,7 +209,6 @@ function handleWaitForLedgerUpdate(
   // if so, we need to craft our reply
 
   const ourCommitment = acceptConsensus(theirCommitment);
-  // TODO this should happen automatically in the finalVote helper function
 
   const signResult = signAndStore(sharedData, ourCommitment);
   if (!signResult.isSuccess) {

--- a/packages/wallet/src/redux/protocols/indirect-funding/player-b/reducer.ts
+++ b/packages/wallet/src/redux/protocols/indirect-funding/player-b/reducer.ts
@@ -33,8 +33,7 @@ import { directFundingRequested } from '../../direct-funding/actions';
 import { DirectFundingAction } from '../../direct-funding';
 import { directFundingStateReducer } from '../../direct-funding/reducer';
 import { isSuccess, isFailure } from '../../direct-funding/state';
-import { finalVote, UpdateType } from 'fmg-nitro-adjudicator/lib/consensus-app';
-import { fromCoreCommitment, asCoreCommitment } from '../../../../domain/two-player-consensus-game';
+import { acceptConsensus } from '../../../../domain/two-player-consensus-game';
 import { sendCommitmentReceived } from '../../../../communication';
 
 type ReturnVal = ProtocolStateWithSharedData<IndirectFundingState>;
@@ -201,14 +200,8 @@ function handleWaitForLedgerUpdate(
   // are we happy that we have the ledger update?
   // if so, we need to craft our reply
 
-  const theirConsensusCommitment = fromCoreCommitment(theirCommitment);
-  if (theirConsensusCommitment.updateType !== UpdateType.Proposal) {
-    throw new Error('The received commitment was not a ledger proposal');
-  }
-  const ourConsensusCommitment = finalVote(theirConsensusCommitment);
+  const ourCommitment = acceptConsensus(theirCommitment);
   // TODO this should happen automatically in the finalVote helper function
-  ourConsensusCommitment.furtherVotesRequired = 0;
-  const ourCommitment = asCoreCommitment(ourConsensusCommitment);
 
   const signResult = signAndStore(sharedData, ourCommitment);
   if (!signResult.isSuccess) {

--- a/packages/wallet/src/redux/protocols/indirect-funding/player-b/reducer.ts
+++ b/packages/wallet/src/redux/protocols/indirect-funding/player-b/reducer.ts
@@ -122,7 +122,7 @@ function handleWaitForPreFundSetup(
   // just need to put our message in the outbox
   const messageRelay = sendCommitmentReceived(
     theirAddress(channel),
-    'processId', // TODO don't use dummy values
+    protocolState.processId,
     signResult.signedCommitment.commitment,
     signResult.signedCommitment.signature,
   );
@@ -131,7 +131,7 @@ function handleWaitForPreFundSetup(
 
   // update the state
   const directFundingAction = directFundingRequested(
-    'processId',
+    protocolState.processId,
     ledgerId,
     '0',
     '0', // TODO don't use dummy values
@@ -216,7 +216,7 @@ function handleWaitForLedgerUpdate(
   // just need to put our message in the outbox
   const messageRelay = sendCommitmentReceived(
     theirAddress(channel),
-    'processId', // TODO don't use dummy values
+    protocolState.processId,
     signResult.signedCommitment.commitment,
     signResult.signedCommitment.signature,
   );
@@ -267,7 +267,7 @@ export function handleWaitForPostFundSetup(
   // just need to put our message in the outbox
   const messageRelay = sendCommitmentReceived(
     theirAddress(channel),
-    'processId', // TODO don't use dummy values
+    protocolState.processId,
     signResult.signedCommitment.commitment,
     signResult.signedCommitment.signature,
   );

--- a/packages/wallet/src/redux/protocols/indirect-funding/player-b/reducer.ts
+++ b/packages/wallet/src/redux/protocols/indirect-funding/player-b/reducer.ts
@@ -39,9 +39,13 @@ import { sendCommitmentReceived } from '../../../../communication';
 type ReturnVal = ProtocolStateWithSharedData<IndirectFundingState>;
 type IDFAction = actions.indirectFunding.Action;
 
-export function initialize(channelId: string, sharedData: SharedData): ReturnVal {
+export function initialize(
+  processId: string,
+  channelId: string,
+  sharedData: SharedData,
+): ReturnVal {
   // todo: check that channel exists?
-  return { protocolState: states.bWaitForPreFundSetup0({ channelId }), sharedData };
+  return { protocolState: states.bWaitForPreFundSetup0({ processId, channelId }), sharedData };
 }
 
 export function playerBReducer(

--- a/packages/wallet/src/redux/protocols/indirect-funding/player-b/state.ts
+++ b/packages/wallet/src/redux/protocols/indirect-funding/player-b/state.ts
@@ -11,6 +11,7 @@ export type PlayerBState =
 export interface BWaitForPreFundSetup0 {
   type: 'BWaitForPreFundSetup0';
   channelId: string;
+  processId: string;
 }
 
 export interface BWaitForDirectFunding {
@@ -18,16 +19,19 @@ export interface BWaitForDirectFunding {
   channelId: string;
   ledgerId: string;
   directFundingState: DirectFundingState;
+  processId: string;
 }
 export interface BWaitForLedgerUpdate0 {
   type: 'BWaitForLedgerUpdate0';
   channelId: string;
   ledgerId: string;
+  processId: string;
 }
 export interface BWaitForPostFundSetup0 {
   type: 'BWaitForPostFundSetup0';
   channelId: string;
   ledgerId: string;
+  processId: string;
 }
 
 // -------
@@ -48,26 +52,27 @@ export function isPlayerBState(state: NonTerminalIndirectFundingState): state is
 // --------
 
 export function bWaitForPreFundSetup0(params: P<BWaitForPreFundSetup0>): BWaitForPreFundSetup0 {
-  const { channelId } = params;
-  return { type: 'BWaitForPreFundSetup0', channelId };
+  const { channelId, processId } = params;
+  return { type: 'BWaitForPreFundSetup0', channelId, processId };
 }
 
 export function bWaitForDirectFunding(params: P<BWaitForDirectFunding>): BWaitForDirectFunding {
-  const { channelId, ledgerId, directFundingState } = params;
+  const { channelId, ledgerId, directFundingState, processId } = params;
   return {
     type: 'BWaitForDirectFunding',
     channelId,
     ledgerId,
     directFundingState,
+    processId,
   };
 }
 
 export function bWaitForPostFundSetup0(params: P<BWaitForPostFundSetup0>): BWaitForPostFundSetup0 {
-  const { channelId, ledgerId } = params;
-  return { type: 'BWaitForPostFundSetup0', channelId, ledgerId };
+  const { channelId, ledgerId, processId } = params;
+  return { type: 'BWaitForPostFundSetup0', channelId, ledgerId, processId };
 }
 
 export function bWaitForLedgerUpdate0(params: P<BWaitForLedgerUpdate0>): BWaitForLedgerUpdate0 {
-  const { channelId, ledgerId } = params;
-  return { type: 'BWaitForLedgerUpdate0', channelId, ledgerId };
+  const { channelId, ledgerId, processId } = params;
+  return { type: 'BWaitForLedgerUpdate0', channelId, ledgerId, processId };
 }

--- a/packages/wallet/src/redux/protocols/indirect-funding/reducer.ts
+++ b/packages/wallet/src/redux/protocols/indirect-funding/reducer.ts
@@ -11,15 +11,19 @@ import { NonTerminalIndirectFundingState, IndirectFundingState } from './state';
 
 type ReturnVal = ProtocolStateWithSharedData<IndirectFundingState>;
 
-export function initialize(channel: ChannelState, sharedData: SharedData): ReturnVal {
+export function initialize(
+  processId: string,
+  channel: ChannelState,
+  sharedData: SharedData,
+): ReturnVal {
   // todo: would be nice to avoid casting here
   const ourIndex: PlayerIndex = channel.ourIndex;
 
   switch (ourIndex) {
     case PlayerIndex.A:
-      return initializeA(channel.channelId, sharedData);
+      return initializeA(processId, channel.channelId, sharedData);
     case PlayerIndex.B:
-      return initializeB(channel.channelId, sharedData);
+      return initializeB(processId, channel.channelId, sharedData);
     default:
       return unreachable(ourIndex);
   }

--- a/packages/wallet/src/redux/sagas/transaction-sender.ts
+++ b/packages/wallet/src/redux/sagas/transaction-sender.ts
@@ -14,7 +14,7 @@ export function* transactionSender(transaction: QueuedTransaction) {
   let transactionResult: TransactionResponse;
   try {
     transactionResult = yield call([signer, signer.sendTransaction], {
-      ...transaction,
+      ...transaction.transactionRequest,
       to: ADJUDICATOR_ADDRESS,
     });
   } catch (err) {

--- a/packages/wallet/src/utils/transaction-generator.ts
+++ b/packages/wallet/src/utils/transaction-generator.ts
@@ -165,11 +165,15 @@ export function createTransferAndWithdrawTransaction(
   };
 }
 
-export function createDepositTransaction(destination: string, DepositLevel: string) {
+export function createDepositTransaction(
+  destination: string,
+  depositAmount: string,
+  expectedHeld: string,
+) {
   const adjudicatorInterface = getAdjudicatorInterface();
-  const data = adjudicatorInterface.functions.deposit.encode([destination]);
+  const data = adjudicatorInterface.functions.deposit.encode([destination, expectedHeld]);
   return {
-    value: DepositLevel,
+    value: depositAmount,
     data,
   };
 }


### PR DESCRIPTION
This PR finishes up the player A reducer to get the player A tests passing.

I've also started working on the app to app funding. Currently I've gotten it to the point that the player A deposit gets sent to metamask.

TODO:

Currently the adjudicator watcher relies on `channelsToMonitor` to dispatch events. However there is no mechanism for a protocol reducer to update `channelsToMonitor`. `channelsToMonitor` gets initialized to an empty array which means no `FUNDING_RECEIVED_EVENT` gets dispatched by the adjudicator watcher. Which means the direct funding reducer gets stuck waiting for the `FUNDING_RECEIVED_EVENT`.

We need some way for the indirect funding reducer to update `channelsToMonitor` once we create the ledger channel, so `FUNDING_RECEIVED_EVENT`s get generated. That or we need the adjudicator watcher to always dispatch actions and rely on reducers to determine if a adjudicator action applies to one of its channels. 
