### PR TITLE
Use channelSubscriptions

### DIFF
--- a/packages/wallet/src/redux/__tests__/selectors.test.ts
+++ b/packages/wallet/src/redux/__tests__/selectors.test.ts
@@ -1,27 +1,25 @@
 import * as walletStates from '../state';
 import * as selectors from '../selectors';
-import { WalletProtocol } from '../types';
 
 describe('getAdjudicatorWatcherProcessesForChannel', () => {
   const createWatcherState = (
     processIds: string[],
     channelId?: string,
   ): walletStates.Initialized => {
-    const processStore: walletStates.ProcessStore = {};
-    const channelsToMonitor = channelId ? [channelId] : [];
-    for (const processId of processIds) {
-      processStore[processId] = {
-        protocolState: {},
-        processId,
-        channelsToMonitor,
-        protocol: WalletProtocol.TransactionSubmission,
-      };
-    }
+    const channelSubscriptions: walletStates.ChannelSubscriptions = {};
+    processIds.forEach(processId => {
+      if (channelId) {
+        channelSubscriptions[processId] = [channelId];
+      } else {
+        channelSubscriptions[processId] = [];
+      }
+    });
     return walletStates.initialized({
       ...walletStates.EMPTY_SHARED_DATA,
       uid: '',
-      processStore,
+      processStore: {},
       adjudicatorStore: {},
+      channelSubscriptions,
     });
   };
 

--- a/packages/wallet/src/redux/__tests__/selectors.test.ts
+++ b/packages/wallet/src/redux/__tests__/selectors.test.ts
@@ -23,6 +23,17 @@ describe('getAdjudicatorWatcherProcessesForChannel', () => {
     });
   };
 
+  it('should return an empty array when channelSubscriptions is empty', () => {
+    const state = walletStates.initialized({
+      ...walletStates.EMPTY_SHARED_DATA,
+      uid: '',
+      processStore: {},
+      adjudicatorStore: {},
+      channelSubscriptions: {},
+    });
+    expect(selectors.getAdjudicatorWatcherProcessesForChannel(state, '0x0')).toEqual([]);
+  });
+
   it('should return an array of processIds that are registered for a channel', () => {
     const processIds = ['p1', 'p2'];
     const channelId = '0x0';

--- a/packages/wallet/src/redux/protocols/direct-funding/__tests__/scenarios.ts
+++ b/packages/wallet/src/redux/protocols/direct-funding/__tests__/scenarios.ts
@@ -32,6 +32,7 @@ const constructWalletState = (
       fundingState: {},
       channelStore: channelState,
       adjudicatorState: {},
+      channelSubscriptions: {},
     },
   };
 };

--- a/packages/wallet/src/redux/protocols/indirect-funding/player-a/reducer.ts
+++ b/packages/wallet/src/redux/protocols/indirect-funding/player-a/reducer.ts
@@ -31,7 +31,6 @@ import { addHex } from '../../../../utils/hex-utils';
 import { UpdateType } from 'fmg-nitro-adjudicator/lib/consensus-app';
 import { proposeNewConsensus } from '../../../../domain/two-player-consensus-game';
 import { unreachable } from '../../../../utils/reducer-utils';
-import { AdjudicatorChannelState } from '../../../adjudicator-state/state';
 
 type ReturnVal = ProtocolStateWithSharedData<IndirectFundingState>;
 type IDFAction = actions.indirectFunding.Action;
@@ -60,14 +59,8 @@ export function initialize(
     throw new Error('Could not store new ledger channel commitment.');
   }
   sharedData = signResult.store;
-
   const ledgerId = getChannelId(ourCommitment);
-  const emptyAdjudicatorChannelState: AdjudicatorChannelState = {
-    channelId: ledgerId,
-    balance: '',
-    finalized: false,
-  };
-  sharedData.adjudicatorState[ledgerId] = emptyAdjudicatorChannelState;
+  sharedData = { ...sharedData, channelSubscriptions: { ledgerId: [processId] } };
 
   // just need to put our message in the outbox
   const messageRelay = sendCommitmentReceived(

--- a/packages/wallet/src/redux/protocols/indirect-funding/player-a/reducer.ts
+++ b/packages/wallet/src/redux/protocols/indirect-funding/player-a/reducer.ts
@@ -9,6 +9,7 @@ import {
   queueMessage,
   checkAndStore,
   signAndStore,
+  registerChannelToMonitor,
 } from '../../../state';
 import { IndirectFundingState, failure, success } from '../state';
 import { ProtocolStateWithSharedData } from '../..';
@@ -60,7 +61,7 @@ export function initialize(
   }
   sharedData = signResult.store;
   const ledgerId = getChannelId(ourCommitment);
-  sharedData = { ...sharedData, channelSubscriptions: { ledgerId: [processId] } };
+  sharedData = registerChannelToMonitor(sharedData, processId, ledgerId);
 
   // just need to put our message in the outbox
   const messageRelay = sendCommitmentReceived(

--- a/packages/wallet/src/redux/protocols/indirect-funding/player-a/reducer.ts
+++ b/packages/wallet/src/redux/protocols/indirect-funding/player-a/reducer.ts
@@ -31,6 +31,7 @@ import { addHex } from '../../../../utils/hex-utils';
 import { UpdateType } from 'fmg-nitro-adjudicator/lib/consensus-app';
 import { proposeNewConsensus } from '../../../../domain/two-player-consensus-game';
 import { unreachable } from '../../../../utils/reducer-utils';
+import { AdjudicatorChannelState } from '../../../adjudicator-state/state';
 
 type ReturnVal = ProtocolStateWithSharedData<IndirectFundingState>;
 type IDFAction = actions.indirectFunding.Action;
@@ -61,6 +62,12 @@ export function initialize(
   sharedData = signResult.store;
 
   const ledgerId = getChannelId(ourCommitment);
+  const emptyAdjudicatorChannelState: AdjudicatorChannelState = {
+    channelId: ledgerId,
+    balance: '',
+    finalized: false,
+  };
+  sharedData.adjudicatorState[ledgerId] = emptyAdjudicatorChannelState;
 
   // just need to put our message in the outbox
   const messageRelay = sendCommitmentReceived(

--- a/packages/wallet/src/redux/protocols/indirect-funding/player-b/reducer.ts
+++ b/packages/wallet/src/redux/protocols/indirect-funding/player-b/reducer.ts
@@ -12,6 +12,7 @@ import {
   queueMessage,
   checkAndInitialize,
   getAddressAndPrivateKey,
+  registerChannelToMonitor,
 } from '../../../state';
 import { IndirectFundingState, failure, success } from '../state';
 import { unreachable } from '../../../../utils/reducer-utils';
@@ -119,6 +120,8 @@ function handleWaitForPreFundSetup(
     return unchangedState;
   }
   sharedData = signResult.store;
+
+  sharedData = registerChannelToMonitor(sharedData, protocolState.processId, ledgerId);
 
   // just need to put our message in the outbox
   const messageRelay = sendCommitmentReceived(

--- a/packages/wallet/src/redux/selectors.ts
+++ b/packages/wallet/src/redux/selectors.ts
@@ -19,19 +19,14 @@ export const getChannelState = (state: SharedData, channelId: string): ChannelSt
   return channelStatus;
 };
 
-// TODO alter this function to pull watcher processes out of adjudicatoState[channelId].registeredProcesses
 export const getAdjudicatorWatcherProcessesForChannel = (
   state: walletStates.Initialized,
   channelId: string,
 ): string[] => {
   const processIds: string[] = [];
 
-  if (!state.channelSubscriptions) {
-    return processIds;
-  }
-  for (const processId of Object.keys(state.channelSubscriptions[channelId])) {
-    const { channelsToMonitor } = state.processStore[processId];
-
+  for (const processId of Object.keys(state.channelSubscriptions)) {
+    const channelsToMonitor = state.channelSubscriptions[processId];
     if (channelsToMonitor.indexOf(channelId) > -1) {
       processIds.push(processId);
     }

--- a/packages/wallet/src/redux/selectors.ts
+++ b/packages/wallet/src/redux/selectors.ts
@@ -19,16 +19,17 @@ export const getChannelState = (state: SharedData, channelId: string): ChannelSt
   return channelStatus;
 };
 
+// TODO alter this function to pull watcher processes out of adjudicatoState[channelId].registeredProcesses
 export const getAdjudicatorWatcherProcessesForChannel = (
   state: walletStates.Initialized,
   channelId: string,
 ): string[] => {
   const processIds: string[] = [];
 
-  if (!state.processStore) {
+  if (!state.channelSubscriptions) {
     return processIds;
   }
-  for (const processId of Object.keys(state.processStore)) {
+  for (const processId of Object.keys(state.channelSubscriptions[channelId])) {
     const { channelsToMonitor } = state.processStore[processId];
 
     if (channelsToMonitor.indexOf(channelId) > -1) {

--- a/packages/wallet/src/redux/state.ts
+++ b/packages/wallet/src/redux/state.ts
@@ -43,11 +43,15 @@ export const WALLET_INITIALIZED = 'WALLET.INITIALIZED';
 export interface SharedData {
   channelStore: ChannelStore;
   outboxState: OutboxState;
+  channelSubscriptions?: ChannelSubscriptions;
   adjudicatorState: AdjudicatorState;
   fundingState: FundingState;
   activeAppChannelId?: string;
 }
 
+export interface ChannelSubscriptions {
+  [channelId: string]: string[];
+}
 export interface WaitForLogin extends SharedData {
   type: typeof WAIT_FOR_LOGIN;
 }
@@ -90,6 +94,7 @@ export interface ChannelFundingState {
 export const EMPTY_SHARED_DATA: SharedData = {
   outboxState: emptyDisplayOutboxState(),
   channelStore: emptyChannelStore(),
+  channelSubscriptions: {},
   adjudicatorState: {},
   fundingState: {},
 };
@@ -101,6 +106,7 @@ export function sharedData(params: SharedData): SharedData {
     adjudicatorState,
     fundingState,
     activeAppChannelId,
+    channelSubscriptions,
   } = params;
   return {
     outboxState,
@@ -108,6 +114,7 @@ export function sharedData(params: SharedData): SharedData {
     adjudicatorState,
     fundingState,
     activeAppChannelId,
+    channelSubscriptions,
   };
 }
 

--- a/packages/wallet/src/redux/state.ts
+++ b/packages/wallet/src/redux/state.ts
@@ -43,14 +43,14 @@ export const WALLET_INITIALIZED = 'WALLET.INITIALIZED';
 export interface SharedData {
   channelStore: ChannelStore;
   outboxState: OutboxState;
-  channelSubscriptions?: ChannelSubscriptions;
+  channelSubscriptions: ChannelSubscriptions;
   adjudicatorState: AdjudicatorState;
   fundingState: FundingState;
   activeAppChannelId?: string;
 }
 
 export interface ChannelSubscriptions {
-  [channelId: string]: string[];
+  [processId: string]: string[];
 }
 export interface WaitForLogin extends SharedData {
   type: typeof WAIT_FOR_LOGIN;
@@ -69,6 +69,25 @@ export interface Initialized extends SharedData {
 }
 
 // TODO: Once these are fleshed out they should be moved to their own file.
+export function registerChannelToMonitor(
+  data: SharedData,
+  processId: string,
+  channelId: string,
+): SharedData {
+  const channelsToMonitor = data.channelSubscriptions[processId] || [];
+  return {
+    ...data,
+    channelSubscriptions: {
+      ...data.channelSubscriptions,
+      [processId]: channelsToMonitor.concat(channelId),
+    },
+  };
+}
+
+export function unregisterAllChannelToMonitor(data: SharedData, processId: string): SharedData {
+  return { ...data, channelSubscriptions: { ...data.channelSubscriptions, [processId]: [] } };
+}
+
 export interface ProcessStore {
   [processId: string]: ProcessState;
 }


### PR DESCRIPTION
Here is a sketch of a way forward, such that protocol reducers can update some `sharedData` representing which channels we are interested in, which the adjudicator watcher can then use to filter the on chain state that it should mirror. 

This is work towards progressing `indirect-funding` past the funding of the ledger channel, which it cannot currently progress beyond due to a lack of such a mechanism. 