### PR TITLE
Happy Path: App to App funding

### DIFF
--- a/packages/wallet/src/redux/protocols/container.tsx
+++ b/packages/wallet/src/redux/protocols/container.tsx
@@ -4,6 +4,8 @@ import * as fundingStates from './funding/states';
 import React from 'react';
 import { Funding } from './funding/container';
 import { connect } from 'react-redux';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { faSpinner } from '@fortawesome/free-solid-svg-icons';
 
 interface Props {
   protocolState: ProtocolState;
@@ -18,7 +20,12 @@ class ProtocolContainer extends PureComponent<Props> {
     if (fundingStates.isFundingState(protocolState) && !fundingStates.isTerminal(protocolState)) {
       return <Funding state={protocolState} />;
     } else {
-      return <div>TODO</div>;
+      // TODO: We need a placeholder screen here when transitioning back to the app from a success state
+      return (
+        <div>
+          <FontAwesomeIcon icon={faSpinner} pulse={true} size="lg" />
+        </div>
+      );
     }
   }
 }

--- a/packages/wallet/src/redux/protocols/direct-funding/reducer.ts
+++ b/packages/wallet/src/redux/protocols/direct-funding/reducer.ts
@@ -64,6 +64,7 @@ const fundingReceiveEventReducer: DFReducer = (
   if (protocolState.ourIndex === PlayerIndex.A) {
     const sharedDataWithOwnCommitment = createAndSendPostFundCommitment(
       sharedData,
+      protocolState.processId,
       protocolState.channelId,
     );
     return {
@@ -83,6 +84,7 @@ const fundingReceiveEventReducer: DFReducer = (
   ) {
     const sharedDataWithOwnCommitment = createAndSendPostFundCommitment(
       sharedData,
+      protocolState.processId,
       protocolState.channelId,
     );
     return {
@@ -149,6 +151,7 @@ const commitmentReceivedReducer: DFReducer = (
     const sharedDataWithReceivedCommitment = setChannelStore(sharedData, checkResult.store);
     const sharedDataWithOwnCommitment = createAndSendPostFundCommitment(
       sharedDataWithReceivedCommitment,
+      protocolState.processId,
       protocolState.channelId,
     );
     return {
@@ -256,7 +259,11 @@ const channelFundedReducer: DFReducer = (
 };
 
 // Helpers
-const createAndSendPostFundCommitment = (sharedData: SharedData, channelId: string): SharedData => {
+const createAndSendPostFundCommitment = (
+  sharedData: SharedData,
+  processId: string,
+  channelId: string,
+): SharedData => {
   const channelState = selectors.getOpenedChannelState(sharedData, channelId);
 
   const commitment = composePostFundCommitment(
@@ -269,7 +276,7 @@ const createAndSendPostFundCommitment = (sharedData: SharedData, channelId: stri
     const sharedDataWithOwnCommitment = setChannelStore(sharedData, signResult.store);
     const messageRelay = sendCommitmentReceived(
       theirAddress(channelState),
-      channelId,
+      processId,
       signResult.signedCommitment.commitment,
       signResult.signedCommitment.signature,
     );

--- a/packages/wallet/src/redux/protocols/funding/player-a/__tests__/reducer.test.ts
+++ b/packages/wallet/src/redux/protocols/funding/player-a/__tests__/reducer.test.ts
@@ -2,8 +2,9 @@ import * as scenarios from './scenarios';
 import * as states from '../states';
 import { fundingReducer as reducer } from '../reducer';
 import { ProtocolStateWithSharedData } from '../../..';
-import { itSendsThisMessage } from '../../../../__tests__/helpers';
+import { itSendsThisMessage, itSendsThisDisplayEventType } from '../../../../__tests__/helpers';
 import { sendStrategyProposed } from '../../../../../communication';
+import { FUNDING_SUCCESS, HIDE_WALLET } from 'magmo-wallet-client';
 
 function whenIn(state) {
   return `when in ${state}`;
@@ -44,6 +45,8 @@ describe('happyPath', () => {
     const result = reducer(state, store, action);
 
     itTransitionsTo(result, states.SUCCESS);
+    itSendsThisMessage(result, FUNDING_SUCCESS);
+    itSendsThisDisplayEventType(result, HIDE_WALLET);
   });
 });
 

--- a/packages/wallet/src/redux/protocols/funding/player-a/__tests__/scenarios.ts
+++ b/packages/wallet/src/redux/protocols/funding/player-a/__tests__/scenarios.ts
@@ -56,7 +56,7 @@ const waitForFunding = {
 
 const waitForSuccessConfirmation = {
   state: states.waitForSuccessConfirmation(props),
-  store: indirectFundingTests.preSuccessState.store,
+  store: indirectFundingTests.successState.store,
 };
 const success = states.success();
 const failure = states.failure('User refused');

--- a/packages/wallet/src/redux/protocols/funding/player-a/container.tsx
+++ b/packages/wallet/src/redux/protocols/funding/player-a/container.tsx
@@ -24,7 +24,7 @@ interface Props {
 
 class FundingContainer extends PureComponent<Props> {
   render() {
-    const { state, strategyChosen, cancelled } = this.props;
+    const { state, strategyChosen, cancelled, fundingSuccessAcknowledged } = this.props;
     const { processId } = state;
 
     switch (state.type) {
@@ -43,7 +43,7 @@ class FundingContainer extends PureComponent<Props> {
         return (
           <AcknowledgeX
             title="Channel funded!"
-            action={() => actions.fundingSuccessAcknowledged(processId)}
+            action={() => fundingSuccessAcknowledged(processId)}
             description="You have successfully funded your channel"
             actionTitle="Ok!"
           />

--- a/packages/wallet/src/redux/protocols/funding/player-a/reducer.ts
+++ b/packages/wallet/src/redux/protocols/funding/player-a/reducer.ts
@@ -9,7 +9,7 @@ import { SharedData, queueMessage } from '../../../state';
 import { ProtocolStateWithSharedData } from '../..';
 import { unreachable } from '../../../../utils/reducer-utils';
 import { PlayerIndex } from '../../../types';
-import { showWallet } from '../../reducer-helpers';
+import { showWallet, hideWallet, sendFundingComplete } from '../../reducer-helpers';
 import { fundingFailure } from 'magmo-wallet-client';
 import { sendStrategyProposed } from '../../../../communication';
 import {
@@ -151,7 +151,8 @@ function fundingSuccessAcknowledged(
   if (state.type !== states.WAIT_FOR_SUCCESS_CONFIRMATION) {
     return { protocolState: state, sharedData };
   }
-  return { protocolState: states.success(), sharedData };
+  const updatedSharedData = sendFundingComplete(sharedData, state.targetChannelId);
+  return { protocolState: states.success(), sharedData: hideWallet(updatedSharedData) };
 }
 
 function cancelled(state: states.FundingState, sharedData: SharedData, action: actions.Cancelled) {

--- a/packages/wallet/src/redux/protocols/funding/player-a/states.ts
+++ b/packages/wallet/src/redux/protocols/funding/player-a/states.ts
@@ -37,6 +37,7 @@ export interface WaitForStrategyResponse extends BaseState {
 
 export interface WaitForFunding extends BaseState {
   type: typeof WAIT_FOR_FUNDING;
+  targetChannelId: string;
   // TODO: Currently we are limited to indirect funding
   // In the future this could support other funding states
   fundingState: NonTerminalIndirectFundingState;
@@ -44,6 +45,7 @@ export interface WaitForFunding extends BaseState {
 
 export interface WaitForSuccessConfirmation extends BaseState {
   type: typeof WAIT_FOR_SUCCESS_CONFIRMATION;
+  targetChannelId: string;
 }
 
 export interface Failure {
@@ -95,15 +97,15 @@ export function waitForStrategyResponse(p: P<WaitForStrategyResponse>): WaitForS
 }
 
 export function waitForFunding(p: P<WaitForFunding>): WaitForFunding {
-  const { processId, opponentAddress, fundingState } = p;
-  return { type: WAIT_FOR_FUNDING, processId, opponentAddress, fundingState };
+  const { processId, opponentAddress, fundingState, targetChannelId } = p;
+  return { type: WAIT_FOR_FUNDING, processId, opponentAddress, fundingState, targetChannelId };
 }
 
 export function waitForSuccessConfirmation(
   p: P<WaitForSuccessConfirmation>,
 ): WaitForSuccessConfirmation {
-  const { processId, opponentAddress } = p;
-  return { type: WAIT_FOR_SUCCESS_CONFIRMATION, processId, opponentAddress };
+  const { processId, opponentAddress, targetChannelId } = p;
+  return { type: WAIT_FOR_SUCCESS_CONFIRMATION, processId, opponentAddress, targetChannelId };
 }
 
 export function success(): Success {

--- a/packages/wallet/src/redux/protocols/funding/player-b/__tests__/reducer.test.ts
+++ b/packages/wallet/src/redux/protocols/funding/player-b/__tests__/reducer.test.ts
@@ -2,8 +2,9 @@ import * as scenarios from './scenarios';
 import * as states from '../states';
 import { fundingReducer as reducer } from '../reducer';
 import { ProtocolStateWithSharedData } from '../../..';
-import { itSendsThisMessage } from '../../../../__tests__/helpers';
+import { itSendsThisMessage, itSendsThisDisplayEventType } from '../../../../__tests__/helpers';
 import { sendStrategyApproved } from '../../../../../communication';
+import { FUNDING_SUCCESS, HIDE_WALLET } from 'magmo-wallet-client';
 
 function whenIn(state) {
   return `when in ${state}`;
@@ -44,6 +45,8 @@ describe('happyPath', () => {
     const result = reducer(state, store, action);
 
     itTransitionsTo(result, states.SUCCESS);
+    itSendsThisMessage(result, FUNDING_SUCCESS);
+    itSendsThisDisplayEventType(result, HIDE_WALLET);
   });
 });
 

--- a/packages/wallet/src/redux/protocols/funding/player-b/__tests__/scenarios.ts
+++ b/packages/wallet/src/redux/protocols/funding/player-b/__tests__/scenarios.ts
@@ -55,7 +55,7 @@ const waitForFunding = {
 };
 const waitForSuccessConfirmation = {
   state: states.waitForSuccessConfirmation(props),
-  store: EMPTY_SHARED_DATA,
+  store: indirectFundingTests.successState.store,
 };
 const success = states.success();
 const failure = states.failure('User refused');

--- a/packages/wallet/src/redux/protocols/funding/player-b/container.tsx
+++ b/packages/wallet/src/redux/protocols/funding/player-b/container.tsx
@@ -22,7 +22,7 @@ interface Props {
 
 class FundingContainer extends PureComponent<Props> {
   render() {
-    const { state, strategyApproved, cancelled } = this.props;
+    const { state, strategyApproved, cancelled, fundingSuccessAcknowledged } = this.props;
     const { processId } = state;
 
     switch (state.type) {
@@ -41,7 +41,7 @@ class FundingContainer extends PureComponent<Props> {
         return (
           <AcknowledgeX
             title="Channel funded!"
-            action={() => actions.fundingSuccessAcknowledged(processId)}
+            action={() => fundingSuccessAcknowledged(processId)}
             description="You have successfully funded your channel"
             actionTitle="Ok!"
           />

--- a/packages/wallet/src/redux/protocols/funding/player-b/reducer.ts
+++ b/packages/wallet/src/redux/protocols/funding/player-b/reducer.ts
@@ -9,7 +9,7 @@ import { SharedData, queueMessage } from '../../../state';
 import { ProtocolStateWithSharedData } from '../..';
 import { unreachable } from '../../../../utils/reducer-utils';
 import { PlayerIndex } from '../../../types';
-import { showWallet } from '../../reducer-helpers';
+import { showWallet, hideWallet, sendFundingComplete } from '../../reducer-helpers';
 import { fundingFailure } from 'magmo-wallet-client';
 import { sendStrategyApproved } from '../../../../communication';
 import {
@@ -156,7 +156,8 @@ function fundingSuccessAcknowledged(
   if (state.type !== states.WAIT_FOR_SUCCESS_CONFIRMATION) {
     return { protocolState: state, sharedData };
   }
-  return { protocolState: states.success(), sharedData };
+  const updatedSharedData = sendFundingComplete(sharedData, state.targetChannelId);
+  return { protocolState: states.success(), sharedData: hideWallet(updatedSharedData) };
 }
 
 function cancelled(state: states.FundingState, sharedData: SharedData, action: actions.Cancelled) {

--- a/packages/wallet/src/redux/protocols/funding/player-b/states.ts
+++ b/packages/wallet/src/redux/protocols/funding/player-b/states.ts
@@ -38,10 +38,12 @@ export interface WaitForStrategyApproval extends BaseState {
 export interface WaitForFunding extends BaseState {
   type: typeof WAIT_FOR_FUNDING;
   fundingState: NonTerminalIndirectFundingState;
+  targetChannelId: string;
 }
 
 export interface WaitForSuccessConfirmation extends BaseState {
   type: typeof WAIT_FOR_SUCCESS_CONFIRMATION;
+  targetChannelId: string;
 }
 
 export interface Failure {
@@ -92,15 +94,15 @@ export function waitForStrategyApproval(p: P<WaitForStrategyApproval>): WaitForS
 }
 
 export function waitForFunding(p: P<WaitForFunding>): WaitForFunding {
-  const { processId, opponentAddress, fundingState } = p;
-  return { type: WAIT_FOR_FUNDING, processId, opponentAddress, fundingState };
+  const { processId, opponentAddress, fundingState, targetChannelId } = p;
+  return { type: WAIT_FOR_FUNDING, processId, opponentAddress, fundingState, targetChannelId };
 }
 
 export function waitForSuccessConfirmation(
   p: P<WaitForSuccessConfirmation>,
 ): WaitForSuccessConfirmation {
-  const { processId, opponentAddress } = p;
-  return { type: WAIT_FOR_SUCCESS_CONFIRMATION, processId, opponentAddress };
+  const { processId, opponentAddress, targetChannelId } = p;
+  return { type: WAIT_FOR_SUCCESS_CONFIRMATION, processId, opponentAddress, targetChannelId };
 }
 
 export function success(): Success {

--- a/packages/wallet/src/redux/protocols/indirect-funding/player-a/__tests__/index.ts
+++ b/packages/wallet/src/redux/protocols/indirect-funding/player-a/__tests__/index.ts
@@ -2,6 +2,7 @@ import { happyPath, ledgerFundingFails } from './scenarios';
 
 export const initialState = happyPath.waitForPreFundL1.state;
 
+export const successState = happyPath.success.state;
 export const preSuccessState = happyPath.waitForPostFund1.state;
 export const successTrigger = happyPath.waitForPostFund1.action;
 

--- a/packages/wallet/src/redux/protocols/indirect-funding/player-a/__tests__/scenarios.ts
+++ b/packages/wallet/src/redux/protocols/indirect-funding/player-a/__tests__/scenarios.ts
@@ -25,6 +25,7 @@ import {
   ledgerId,
   channelId,
 } from '../../../../../domain/commitments/__tests__';
+import { success } from '../../../indirect-defunding/state';
 
 // -----------
 // Commitments
@@ -86,6 +87,14 @@ const waitForPostFund1 = {
   ]),
 };
 
+const successState = {
+  state: success(),
+  store: setChannels(EMPTY_SHARED_DATA, [
+    channelFromCommitments(app2, app3, asAddress, asPrivateKey),
+    channelFromCommitments(ledger4, ledger5, asAddress, asPrivateKey),
+  ]),
+};
+
 const waitForDirectFundingFailure = {
   state: aWaitForDirectFunding({ ...props, directFundingState: preFailureState.protocolState }), //
   store: setChannels(preFailureState.sharedData, [
@@ -116,6 +125,7 @@ export const happyPath = {
     reply: app2,
   },
   waitForPostFund1: { state: waitForPostFund1, action: postFund1Received },
+  success: { state: successState },
 };
 
 export const ledgerFundingFails = {

--- a/packages/wallet/src/redux/protocols/indirect-funding/player-b/__tests__/index.ts
+++ b/packages/wallet/src/redux/protocols/indirect-funding/player-b/__tests__/index.ts
@@ -1,7 +1,7 @@
 import { happyPath, ledgerFundingFails } from './scenarios';
 
 export const initialState = happyPath.waitForPreFundSetup0.state;
-
+export const successState = happyPath.success.state;
 export const preSuccessState = happyPath.waitForPostFund0.state;
 export const successTrigger = happyPath.waitForPostFund0.action;
 

--- a/packages/wallet/src/redux/protocols/indirect-funding/player-b/__tests__/scenarios.ts
+++ b/packages/wallet/src/redux/protocols/indirect-funding/player-b/__tests__/scenarios.ts
@@ -24,6 +24,7 @@ import {
   ledgerId,
   channelId,
 } from '../../../../../domain/commitments/__tests__';
+import { success } from '../../../indirect-defunding/state';
 
 // -----------
 // Commitments
@@ -98,6 +99,14 @@ const waitForDirectFundingFailure = {
   ]),
 };
 
+const successState = {
+  state: success(),
+  store: setChannels(EMPTY_SHARED_DATA, [
+    channelFromCommitments(app2, app3, asAddress, bsPrivateKey),
+    channelFromCommitments(ledger4, ledger5, asAddress, bsPrivateKey),
+  ]),
+};
+
 // -------
 // Actions
 // -------
@@ -119,6 +128,7 @@ export const happyPath = {
     reply: ledger5,
   },
   waitForPostFund0: { state: waitForPostFund0, action: postFund0Received, reply: app3 },
+  success: { state: successState },
 };
 
 export const ledgerFundingFails = {

--- a/packages/wallet/src/redux/protocols/indirect-funding/player-b/reducer.ts
+++ b/packages/wallet/src/redux/protocols/indirect-funding/player-b/reducer.ts
@@ -37,6 +37,7 @@ import { isSuccess, isFailure } from '../../direct-funding/state';
 import { acceptConsensus } from '../../../../domain/two-player-consensus-game';
 import { sendCommitmentReceived } from '../../../../communication';
 import { addHex } from '../../../../utils/hex-utils';
+import { isTransactionAction } from '../../../actions';
 
 type ReturnVal = ProtocolStateWithSharedData<IndirectFundingState>;
 type IDFAction = actions.indirectFunding.Action;
@@ -76,7 +77,7 @@ function handleWaitForPreFundSetup(
 ): ReturnVal {
   const unchangedState = { protocolState, sharedData };
   if (action.type !== actions.COMMITMENT_RECEIVED) {
-    throw new Error('Incorrect action');
+    throw new Error(`Incorrect action ${action.type}`);
   }
   const addressAndPrivateKey = getAddressAndPrivateKey(sharedData, protocolState.channelId);
   if (!addressAndPrivateKey) {
@@ -189,8 +190,14 @@ function handleWaitForLedgerUpdate(
   action: IDFAction | DirectFundingAction,
 ): ReturnVal {
   const unchangedState = { protocolState, sharedData };
+  if (isTransactionAction(action)) {
+    console.warn(
+      `Ignoring transaction action ${action.type} since direct funding has been completed already.`,
+    );
+    return unchangedState;
+  }
   if (action.type !== actions.COMMITMENT_RECEIVED) {
-    throw new Error('Incorrect action');
+    throw new Error(`Incorrect action ${action.type}`);
   }
   const checkResult = checkAndStore(sharedData, action.signedCommitment);
   if (!checkResult.isSuccess) {
@@ -244,7 +251,7 @@ export function handleWaitForPostFundSetup(
   // We should probably refactor and clean this up
   const unchangedState = { protocolState, sharedData };
   if (action.type !== actions.COMMITMENT_RECEIVED) {
-    throw new Error('Incorrect action');
+    throw new Error(`Incorrect action ${action.type}`);
   }
   const checkResult = checkAndStore(sharedData, action.signedCommitment);
   if (!checkResult.isSuccess) {

--- a/packages/wallet/src/redux/protocols/indirect-funding/player-b/reducer.ts
+++ b/packages/wallet/src/redux/protocols/indirect-funding/player-b/reducer.ts
@@ -173,7 +173,7 @@ function handleWaitForDirectFunding(
   // Update direct funding state on our protocol state
   const newDirectFundingState = protocolStateWithSharedData.protocolState;
   const newProtocolState = { ...protocolState, directFundingState: newDirectFundingState };
-
+  sharedData = protocolStateWithSharedData.sharedData;
   if (isSuccess(newDirectFundingState)) {
     return { protocolState: bWaitForLedgerUpdate0(newProtocolState), sharedData };
   } else if (isFailure(newDirectFundingState)) {


### PR DESCRIPTION
This gets the happy path of app to app funding working to the point that the wallet returns to the application and players can play a funded game of RPS.

(The PR can be based on `master` once #470 is merged in)