### PR TITLE
Update Ledger De-funding to work with Consensus App

### DIFF
--- a/packages/wallet/src/redux/protocols/indirect-defunding/__tests__/reducer.test.ts
+++ b/packages/wallet/src/redux/protocols/indirect-defunding/__tests__/reducer.test.ts
@@ -37,6 +37,16 @@ describe('player A happy path', () => {
   });
 });
 
+describe('player A invalid commitment', () => {
+  const scenario = scenarios.playerAInvalidCommitment;
+
+  describe('when in WaitForLedgerUpdate', () => {
+    const { state, action } = scenario.waitForLedgerUpdate;
+    const updatedState = indirectDefundingReducer(state.state, state.store, action);
+    itTransitionsTo(updatedState, states.FAILURE);
+  });
+});
+
 describe('player B happy path', () => {
   const scenario = scenarios.playerBHappyPath;
   const {
@@ -65,6 +75,16 @@ describe('player B happy path', () => {
     const updatedState = indirectDefundingReducer(state.state, state.store, action);
     itTransitionsTo(updatedState, states.SUCCESS);
     itSendsMessage(updatedState, reply);
+  });
+});
+
+describe('player B invalid commitment', () => {
+  const scenario = scenarios.playerBInvalidCommitment;
+
+  describe('when in WaitForLedgerUpdate', () => {
+    const { state, action } = scenario.waitForLedgerUpdate;
+    const updatedState = indirectDefundingReducer(state.state, state.store, action);
+    itTransitionsTo(updatedState, states.FAILURE);
   });
 });
 

--- a/packages/wallet/src/redux/protocols/indirect-defunding/__tests__/reducer.test.ts
+++ b/packages/wallet/src/redux/protocols/indirect-defunding/__tests__/reducer.test.ts
@@ -1,9 +1,59 @@
-// TODO: Update for new consensus game
+import * as scenarios from './scenarios';
+import { IndirectDefundingState } from '../state';
+import { ProtocolStateWithSharedData } from '../..';
+import { getLastMessage } from '../../../state';
+import { SignedCommitment } from '../../../../domain';
+import * as states from '../state';
+import { initialize } from '../reducer';
 
-it.skip('dummy', () => {
-  expect(true).toBe(true);
+describe('player A happy path', () => {
+  const scenario = scenarios.playerAHappyPath;
+  const {
+    processId,
+    channelId,
+    ledgerId,
+    store,
+    proposedAllocation,
+    proposedDestination,
+  } = scenario.initialParams;
+
+  describe('when initializing', () => {
+    const result = initialize(
+      processId,
+      channelId,
+      ledgerId,
+      proposedAllocation,
+      proposedDestination,
+      store,
+    );
+    itTransitionsTo(result, states.WAIT_FOR_LEDGER_UPDATE);
+    itSendsMessage(result, scenario.initialParams.reply);
+  });
 });
 
+type ReturnVal = ProtocolStateWithSharedData<IndirectDefundingState>;
+function itTransitionsTo(state: ReturnVal, type: IndirectDefundingState['type']) {
+  it(`transitions protocol state to ${type}`, () => {
+    expect(state.protocolState.type).toEqual(type);
+  });
+}
+
+function itSendsMessage(state: ReturnVal, message: SignedCommitment) {
+  it('sends a message', () => {
+    const lastMessage = getLastMessage(state.sharedData);
+    if (lastMessage && 'messagePayload' in lastMessage) {
+      const dataPayload = lastMessage.messagePayload.data;
+      // This is yuk. The data in a message is currently of 'any' type..
+      if (!('signedCommitment' in dataPayload)) {
+        fail('No signedCommitment in the last message.');
+      }
+      const { commitment, signature } = dataPayload.signedCommitment;
+      expect({ commitment, signature }).toEqual(message);
+    } else {
+      fail('No messages in the outbox.');
+    }
+  });
+}
 // import * as states from '../state';
 // import { initialize, indirectDefundingReducer } from '../reducer';
 // import * as scenarios from './scenarios';

--- a/packages/wallet/src/redux/protocols/indirect-defunding/__tests__/reducer.test.ts
+++ b/packages/wallet/src/redux/protocols/indirect-defunding/__tests__/reducer.test.ts
@@ -4,7 +4,7 @@ import { ProtocolStateWithSharedData } from '../..';
 import { getLastMessage } from '../../../state';
 import { SignedCommitment } from '../../../../domain';
 import * as states from '../state';
-import { initialize } from '../reducer';
+import { initialize, indirectDefundingReducer } from '../reducer';
 
 describe('player A happy path', () => {
   const scenario = scenarios.playerAHappyPath;
@@ -28,6 +28,43 @@ describe('player A happy path', () => {
     );
     itTransitionsTo(result, states.WAIT_FOR_LEDGER_UPDATE);
     itSendsMessage(result, scenario.initialParams.reply);
+  });
+
+  describe('when in WaitForLedgerUpdate', () => {
+    const { state, action } = scenario.waitForLedgerUpdate;
+    const updatedState = indirectDefundingReducer(state.state, state.store, action);
+    itTransitionsTo(updatedState, states.SUCCESS);
+  });
+});
+
+describe('player B happy path', () => {
+  const scenario = scenarios.playerBHappyPath;
+  const {
+    processId,
+    channelId,
+    ledgerId,
+    store,
+    proposedAllocation,
+    proposedDestination,
+  } = scenario.initialParams;
+
+  describe('when initializing', () => {
+    const result = initialize(
+      processId,
+      channelId,
+      ledgerId,
+      proposedAllocation,
+      proposedDestination,
+      store,
+    );
+    itTransitionsTo(result, states.WAIT_FOR_LEDGER_UPDATE);
+  });
+
+  describe('when in WaitForLedgerUpdate', () => {
+    const { state, action, reply } = scenario.waitForLedgerUpdate;
+    const updatedState = indirectDefundingReducer(state.state, state.store, action);
+    itTransitionsTo(updatedState, states.SUCCESS);
+    itSendsMessage(updatedState, reply);
   });
 });
 

--- a/packages/wallet/src/redux/protocols/indirect-defunding/__tests__/reducer.test.ts
+++ b/packages/wallet/src/redux/protocols/indirect-defunding/__tests__/reducer.test.ts
@@ -68,6 +68,29 @@ describe('player B happy path', () => {
   });
 });
 
+describe('not defundable', () => {
+  const scenario = scenarios.notDefundable;
+  const {
+    processId,
+    channelId,
+    ledgerId,
+    store,
+    proposedAllocation,
+    proposedDestination,
+  } = scenario.initialParams;
+  describe('when initializing', () => {
+    const result = initialize(
+      processId,
+      channelId,
+      ledgerId,
+      proposedAllocation,
+      proposedDestination,
+      store,
+    );
+    itTransitionsTo(result, states.FAILURE);
+  });
+});
+
 type ReturnVal = ProtocolStateWithSharedData<IndirectDefundingState>;
 function itTransitionsTo(state: ReturnVal, type: IndirectDefundingState['type']) {
   it(`transitions protocol state to ${type}`, () => {

--- a/packages/wallet/src/redux/protocols/indirect-defunding/__tests__/scenarios.ts
+++ b/packages/wallet/src/redux/protocols/indirect-defunding/__tests__/scenarios.ts
@@ -57,7 +57,7 @@ const notDefundableInitialStore = setChannels(EMPTY_SHARED_DATA, [
   channelFromCommitments(ledger4, ledger5, asAddress, asPrivateKey),
 ]);
 
-const playerAWaitForLedgerUpdate = {
+const playerAWaitForUpdate = {
   state: waitForLedgerUpdate(props),
   store: setChannels(EMPTY_SHARED_DATA, [
     channelFromCommitments(app10, app11, asAddress, asPrivateKey),
@@ -78,7 +78,7 @@ const playerBWaitForUpdate = {
 // -----------
 const ledgerUpdate0Received = globalActions.commitmentReceived(processId, ledger6);
 const ledgerUpdate1Received = globalActions.commitmentReceived(processId, ledger7);
-
+const invalidLedgerUpdateReceived = globalActions.commitmentReceived(processId, ledger5);
 // -----------
 // Scenarios
 // -----------
@@ -88,13 +88,14 @@ export const playerAHappyPath = {
     ...props,
     reply: ledger6,
   },
-  waitForLedgerUpdate: { state: playerAWaitForLedgerUpdate, action: ledgerUpdate1Received },
+  waitForLedgerUpdate: { state: playerAWaitForUpdate, action: ledgerUpdate1Received },
 };
-export const notDefundable = {
-  initialParams: {
-    store: notDefundableInitialStore,
-    ...props,
-  },
+
+export const playerAInvalidCommitment = {
+  waitForLedgerUpdate: { state: playerAWaitForUpdate, action: invalidLedgerUpdateReceived },
+};
+export const playerBInvalidCommitment = {
+  waitForLedgerUpdate: { state: playerBWaitForUpdate, action: invalidLedgerUpdateReceived },
 };
 
 export const playerBHappyPath = {
@@ -106,5 +107,12 @@ export const playerBHappyPath = {
     state: playerBWaitForUpdate,
     action: ledgerUpdate0Received,
     reply: ledger7,
+  },
+};
+
+export const notDefundable = {
+  initialParams: {
+    store: notDefundableInitialStore,
+    ...props,
   },
 };

--- a/packages/wallet/src/redux/protocols/indirect-defunding/__tests__/scenarios.ts
+++ b/packages/wallet/src/redux/protocols/indirect-defunding/__tests__/scenarios.ts
@@ -12,6 +12,7 @@ import { waitForLedgerUpdate } from '../state';
 import { setChannels, EMPTY_SHARED_DATA } from '../../../state';
 import { channelFromCommitments } from '../../../channel-store/channel-state/__tests__';
 import { bsPrivateKey } from '../../../../communication/__tests__/commitments';
+import * as globalActions from '../../../actions';
 // -----------
 // Commitments
 // -----------
@@ -38,13 +39,18 @@ const app11 = appCommitment({ turnNum: 11, balances: twoThree, isFinal: true });
 const ledger4 = ledgerCommitment({ turnNum: 4, balances: twoThree, proposedBalances: fiveToApp });
 const ledger5 = ledgerCommitment({ turnNum: 5, balances: fiveToApp });
 const ledger6 = ledgerCommitment({ turnNum: 6, balances: fiveToApp, proposedBalances: twoThree });
-// const ledger7 = ledgerCommitment({ turnNum: 7, balances: twoThree });
+const ledger7 = ledgerCommitment({ turnNum: 7, balances: twoThree });
 
-const playerAWaitForUpdate = {
+const initialStore = setChannels(EMPTY_SHARED_DATA, [
+  channelFromCommitments(app10, app11, asAddress, asPrivateKey),
+  channelFromCommitments(ledger4, ledger5, asAddress, asPrivateKey),
+]);
+
+const playerAWaitForLedgerUpdate = {
   state: waitForLedgerUpdate(props),
   store: setChannels(EMPTY_SHARED_DATA, [
     channelFromCommitments(app10, app11, asAddress, asPrivateKey),
-    channelFromCommitments(ledger4, ledger5, asAddress, asPrivateKey),
+    channelFromCommitments(ledger5, ledger6, asAddress, asPrivateKey),
   ]),
 };
 
@@ -55,20 +61,25 @@ const playerBWaitForUpdate = {
     channelFromCommitments(ledger4, ledger5, bsAddress, bsPrivateKey),
   ]),
 };
-
+const ledgerUpdate0Received = globalActions.commitmentReceived(processId, ledger6);
+const ledgerUpdate1Received = globalActions.commitmentReceived(processId, ledger7);
 export const playerAHappyPath = {
   initialParams: {
-    store: playerAWaitForUpdate.store,
+    store: initialStore,
     ...props,
     reply: ledger6,
   },
+  waitForLedgerUpdate: { state: playerAWaitForLedgerUpdate, action: ledgerUpdate1Received },
 };
 
 export const playerBHappyPath = {
   initialParams: {
-    store: playerBWaitForUpdate.store,
-    channelId,
-    ledgerId,
-    processId: 'processId',
+    store: initialStore,
+    ...props,
+  },
+  waitForLedgerUpdate: {
+    state: playerBWaitForUpdate,
+    action: ledgerUpdate0Received,
+    reply: ledger7,
   },
 };

--- a/packages/wallet/src/redux/protocols/indirect-defunding/__tests__/scenarios.ts
+++ b/packages/wallet/src/redux/protocols/indirect-defunding/__tests__/scenarios.ts
@@ -13,9 +13,7 @@ import { setChannels, EMPTY_SHARED_DATA } from '../../../state';
 import { channelFromCommitments } from '../../../channel-store/channel-state/__tests__';
 import { bsPrivateKey } from '../../../../communication/__tests__/commitments';
 import * as globalActions from '../../../actions';
-// -----------
-// Commitments
-// -----------
+
 const processId = 'processId';
 
 const twoThree = [
@@ -33,6 +31,11 @@ const props = {
   proposedDestination: twoThree.map(a => a.address),
 };
 
+// -----------
+// Commitments
+// -----------
+
+const app9 = appCommitment({ turnNum: 9, balances: twoThree, isFinal: false });
 const app10 = appCommitment({ turnNum: 10, balances: twoThree, isFinal: true });
 const app11 = appCommitment({ turnNum: 11, balances: twoThree, isFinal: true });
 
@@ -41,8 +44,16 @@ const ledger5 = ledgerCommitment({ turnNum: 5, balances: fiveToApp });
 const ledger6 = ledgerCommitment({ turnNum: 6, balances: fiveToApp, proposedBalances: twoThree });
 const ledger7 = ledgerCommitment({ turnNum: 7, balances: twoThree });
 
+// -----------
+// States
+// -----------
 const initialStore = setChannels(EMPTY_SHARED_DATA, [
   channelFromCommitments(app10, app11, asAddress, asPrivateKey),
+  channelFromCommitments(ledger4, ledger5, asAddress, asPrivateKey),
+]);
+
+const notDefundableInitialStore = setChannels(EMPTY_SHARED_DATA, [
+  channelFromCommitments(app9, app10, asAddress, asPrivateKey),
   channelFromCommitments(ledger4, ledger5, asAddress, asPrivateKey),
 ]);
 
@@ -61,8 +72,16 @@ const playerBWaitForUpdate = {
     channelFromCommitments(ledger4, ledger5, bsAddress, bsPrivateKey),
   ]),
 };
+
+// -----------
+// Actions
+// -----------
 const ledgerUpdate0Received = globalActions.commitmentReceived(processId, ledger6);
 const ledgerUpdate1Received = globalActions.commitmentReceived(processId, ledger7);
+
+// -----------
+// Scenarios
+// -----------
 export const playerAHappyPath = {
   initialParams: {
     store: initialStore,
@@ -70,6 +89,12 @@ export const playerAHappyPath = {
     reply: ledger6,
   },
   waitForLedgerUpdate: { state: playerAWaitForLedgerUpdate, action: ledgerUpdate1Received },
+};
+export const notDefundable = {
+  initialParams: {
+    store: notDefundableInitialStore,
+    ...props,
+  },
 };
 
 export const playerBHappyPath = {

--- a/packages/wallet/src/redux/protocols/indirect-defunding/readme.md
+++ b/packages/wallet/src/redux/protocols/indirect-defunding/readme.md
@@ -16,10 +16,9 @@ It covers:
 graph TD
   St((start))-->DF{Defundable?}
   DF --> |No| F((Failure))
-  DF -->|Yes|SC0[SendLedgerUpdate0]
+  DF -->|Yes|SC0[SendLedgerUpdate]
   SC0-->WFU(WaitForLedgerUpdate)
-  WFU --> |"CommitmentReceived(Accept)"|SC1[SendLedgerUpdate2]
-  SC1-->S((success))
+  WFU --> |"CommitmentReceived(Accept)"|Su[Success]
   WFU --> |"CommitmentReceived(Reject)"| F
 ```
 
@@ -32,26 +31,19 @@ graph TD
   DF --> |Yes| WFU(WaitForLedgerUpdate)
   WFU-->|"CommitmentReceived(Accept)"|SC1[SendLedgerUpdate1]
   WFU --> |"CommitmentReceived(Reject)"| F
-  SC1-->WFFU(WaitForFinalLedgerUpdate)
-  WFFU-->|"CommitmentReceived(Accept)"|S((success))
-  WFFU-->|"CommitmentReceived(Reject)"|F
+  SC1-->S((success))
 
 ```
 
 Notes:
 
-- SendLedgerUpdate0/1 are not states but indicate when the ledger update is sent.
+- SendLedgerUpdate is not a state but indicate when the ledger update is sent.
 - A single reducer implements both the player A and B state machine.
-
-Assumptions:
-
-- It is Player A's turn to make the next ledger update.
 
 ## Scenarios
 
-1. **Happy Path - Player A** Start->WaitForLedgerUpdate->Success
-2. **Happy Path - Player B** Start->WaitForLedgerUpdate->WaitForFinalLedgerUpdate->Success
+1. **Happy Path - Player A** Start->SendLedgerUpdate->WaitForLedgerUpdate->Success
+2. **Happy Path - Player B** Start->WaitForLedgerUpdate->SendLedgerUpdate->Success
 3. **Not De-fundable** Start->Failure
-4. **Commitment Rejected - Player A** Start->WaitForLedgerUpdate->Failure
-5. **First Commitment Rejected - Player B** Start->WaitForLedgerUpdate->Failure
-6. **Final Commitment Rejected - Player B** Start->WaitForLedgerUpdate->WaitForFinalLedgerUpdate->Failure
+4. **Commitment Rejected - Player A** Start->SendLedgerUpdate->WaitForLedgerUpdate->Failure
+5. **Commitment Rejected - Player B** Start->WaitForLedgerUpdate->Failure

--- a/packages/wallet/src/redux/protocols/indirect-defunding/reducer.ts
+++ b/packages/wallet/src/redux/protocols/indirect-defunding/reducer.ts
@@ -1,17 +1,19 @@
 import { ProtocolStateWithSharedData } from '..';
-import { SharedData, setChannelStore } from '../../state';
+import { SharedData, signAndStore, queueMessage } from '../../state';
 import * as states from './state';
 import { IndirectDefundingAction } from './actions';
 import { COMMITMENT_RECEIVED } from '../../actions';
-import { Commitment } from 'fmg-core/lib/commitment';
 import * as helpers from '../reducer-helpers';
-import { getChannelState } from '../../selectors';
 import { unreachable } from '../../../utils/reducer-utils';
-import { checkAndStore } from '../../channel-store/reducer';
+import * as selectors from '../../selectors';
+import { proposeNewConsensus } from '../../../domain/two-player-consensus-game';
+import { sendCommitmentReceived } from '../../../communication';
+import { theirAddress } from '../../channel-store';
 
 export const initialize = (
   processId: string,
   channelId: string,
+  ledgerId: string,
   proposedAllocation: string[],
   proposedDestination: string[],
   sharedData: SharedData,
@@ -22,20 +24,34 @@ export const initialize = (
       sharedData,
     };
   }
-  const newSharedData = { ...sharedData };
-  // TODO: update to latest consensus game
-  // if (helpers.isFirstPlayer(channelId, sharedData)) {
-  //   newSharedData = craftAndSendLegerUpdate(
-  //     newSharedData,
-  //     processId,
-  //     channelId,
-  //     proposedAllocation,
-  //     proposedDestination,
-  //   );
-  // }
+  let newSharedData = { ...sharedData };
+  if (helpers.isFirstPlayer(ledgerId, sharedData)) {
+    const ledgerChannel = selectors.getChannelState(sharedData, ledgerId);
+
+    const theirCommitment = ledgerChannel.lastCommitment.commitment;
+    const ourCommitment = proposeNewConsensus(
+      theirCommitment,
+      proposedAllocation,
+      proposedDestination,
+    );
+    const signResult = signAndStore(sharedData, ourCommitment);
+    if (!signResult.isSuccess) {
+      return { protocolState: states.failure('Received Invalid Commitment'), sharedData };
+    }
+    newSharedData = signResult.store;
+
+    const messageRelay = sendCommitmentReceived(
+      theirAddress(ledgerChannel),
+      processId,
+      signResult.signedCommitment.commitment,
+      signResult.signedCommitment.signature,
+    );
+    newSharedData = queueMessage(newSharedData, messageRelay);
+  }
   return {
     protocolState: states.waitForLedgerUpdate({
       processId,
+      ledgerId,
       channelId,
       proposedAllocation,
       proposedDestination,
@@ -52,32 +68,12 @@ export const indirectDefundingReducer = (
   switch (protocolState.type) {
     case states.WAIT_FOR_LEDGER_UPDATE:
       return waitForLedgerUpdateReducer(protocolState, sharedData, action);
-    case states.WAIT_FOR_FINAL_LEDGER_UPDATE:
-      return waitForFinalLedgerUpdateReducer(protocolState, sharedData, action);
     case states.SUCCESS:
     case states.FAILURE:
       return { protocolState, sharedData };
     default:
       return unreachable(protocolState);
   }
-};
-const waitForFinalLedgerUpdateReducer = (
-  protocolState: states.WaitForFinalLedgerUpdate,
-  sharedData: SharedData,
-  action: IndirectDefundingAction,
-): ProtocolStateWithSharedData<states.IndirectDefundingState> => {
-  if (action.type !== COMMITMENT_RECEIVED) {
-    return { protocolState, sharedData };
-  }
-  const { commitment, signature } = action.signedCommitment;
-  const newSharedData = receiveLedgerCommitment(sharedData, commitment, signature);
-  if (!validTransition(newSharedData, protocolState.channelId, commitment)) {
-    return {
-      protocolState: states.failure('Received Invalid Commitment'),
-      sharedData: newSharedData,
-    };
-  }
-  return { protocolState: states.success(), sharedData: newSharedData };
 };
 
 const waitForLedgerUpdateReducer = (
@@ -86,150 +82,35 @@ const waitForLedgerUpdateReducer = (
   action: IndirectDefundingAction,
 ): ProtocolStateWithSharedData<states.IndirectDefundingState> => {
   if (action.type !== COMMITMENT_RECEIVED) {
-    return { protocolState, sharedData };
+    throw new Error(`Invalid action ${action.type}`);
   }
-  const { commitment, signature } = action.signedCommitment;
-  const newSharedData = receiveLedgerCommitment(sharedData, commitment, signature);
-  if (!validTransition(newSharedData, protocolState.channelId, commitment)) {
-    return {
-      protocolState: states.failure('Received Invalid Commitment'),
-      sharedData: newSharedData,
-    };
-  }
+  return { protocolState, sharedData };
+  // const { commitment, signature } = action.signedCommitment;
+  // const newSharedData = receiveLedgerCommitment(sharedData, commitment, signature);
+  // if (!validTransition(newSharedData, protocolState.ledgerChannelId, commitment)) {
+  //   return {
+  //     protocolState: states.failure('Received Invalid Commitment'),
+  //     sharedData: newSharedData,
+  //   };
+  // }
   // const { processId, channelId, proposedAllocation, proposedDestination } = protocolState;
-  if (helpers.isFirstPlayer(protocolState.channelId, newSharedData)) {
-    // TODO: Needs to be updated to the new consensus game
-    // newSharedData = craftFinalLedgerUpdate(
-    //   newSharedData,
-    //   processId,
-    //   channelId,
-    //   proposedAllocation,
-    //   proposedDestination,
-    // );
-    return {
-      protocolState: states.success(),
-      sharedData: newSharedData,
-    };
-  } else {
-    // TODO: This needs to be updated to the new consensus game
-    // newSharedData = craftAndSendLegerUpdate(
-    //   newSharedData,
-    //   processId,
-    //   channelId,
-    //   proposedAllocation,
-    //   proposedDestination,
-    // );
-    return {
-      protocolState: states.waitForFinalLedgerUpdate(protocolState),
-      sharedData: newSharedData,
-    };
-  }
+  // if (helpers.isFirstPlayer(protocolState.ledgerChannelId, newSharedData)) {
+  //   return {
+  //     protocolState: states.success(),
+  //     sharedData: newSharedData,
+  //   };
+  // } else {
+  //   // TODO: This needs to be updated to the new consensus game
+  //   // newSharedData = craftAndSendLegerUpdate(
+  //   //   newSharedData,
+  //   //   processId,
+  //   //   channelId,
+  //   //   proposedAllocation,
+  //   //   proposedDestination,
+  //   // );
+  //   return {
+  //     protocolState: states.waitForFinalLedgerUpdate(protocolState),
+  //     sharedData: newSharedData,
+  //   };
+  // }
 };
-
-const receiveLedgerCommitment = (
-  sharedData: SharedData,
-  commitment: Commitment,
-  signature: string,
-): SharedData => {
-  const result = checkAndStore(sharedData.channelStore, { commitment, signature });
-  if (result.isSuccess) {
-    return setChannelStore(sharedData, result.store);
-  }
-  return sharedData;
-};
-
-// TODO: Once the channel state is simplified we can probably rely on a better check than this
-const validTransition = (
-  sharedData: SharedData,
-  channelId: string,
-  commitment: Commitment,
-): boolean => {
-  return getChannelState(sharedData, channelId).lastCommitment.commitment === commitment;
-};
-// TODO: Update to latest consensus game
-// const craftAndSendLegerUpdate = (
-//   sharedData: SharedData,
-//   processId: string,
-//   channelId: string,
-//   proposedAllocation: string[],
-//   proposedDestination: string[],
-// ): SharedData => {
-//   const channelState = getChannelState(sharedData, channelId);
-//   const appAttributes = bytesFromAppAttributes({
-//     consensusCounter: channelState.ourIndex,
-//     proposedAllocation,
-//     proposedDestination,
-//   });
-//   const lastCommitment = channelState.lastCommitment.commitment;
-
-//   const newCommitment: Commitment = {
-//     ...lastCommitment,
-//     commitmentCount: channelState.ourIndex,
-//     turnNum: lastCommitment.turnNum + 1,
-//     appAttributes,
-//   };
-
-//   return receiveAndSendUpdateCommitment(
-//     sharedData,
-//     processId,
-//     channelId,
-//     newCommitment,
-//     channelState.ourIndex,
-//   );
-// };
-
-// const craftFinalLedgerUpdate = (
-//   sharedData: SharedData,
-//   processId: string,
-//   channelId: string,
-//   proposedAllocation: string[],
-//   proposedDestination: string[],
-// ): SharedData => {
-//   const channelState = getChannelState(sharedData, channelId);
-//   const appAttributes = bytesFromAppAttributes({
-//     consensusCounter: 0,
-//     proposedAllocation,
-//     proposedDestination,
-//   });
-//   const lastCommitment = channelState.lastCommitment.commitment;
-
-//   const newCommitment: Commitment = {
-//     ...lastCommitment,
-//     commitmentCount: 0,
-//     turnNum: lastCommitment.turnNum + 1,
-//     appAttributes,
-//     allocation: proposedAllocation,
-//     destination: proposedDestination,
-//   };
-
-//   return receiveAndSendUpdateCommitment(
-//     sharedData,
-//     processId,
-//     channelId,
-//     newCommitment,
-//     PlayerIndex.A,
-//   );
-// };
-// const receiveAndSendUpdateCommitment = (
-//   sharedData: SharedData,
-//   processId: string,
-//   channelId: string,
-//   commitment: Commitment,
-//   ourIndex: PlayerIndex,
-// ) => {
-//   const channelState = getChannelState(sharedData, channelId);
-//   const result = signAndStore(sharedData.channelStore, commitment);
-//   if (result.isSuccess) {
-//     const newSharedData = setChannelStore(sharedData, result.store);
-//     const message = helpers.createCommitmentMessageRelay(
-//       processId,
-//       channelState.participants[ourIndex],
-//       commitment,
-//       result.signedCommitment.signature,
-//     );
-
-//     return queueMessage(newSharedData, message);
-//   }
-
-//   return sharedData;
-// };

--- a/packages/wallet/src/redux/protocols/indirect-defunding/state.ts
+++ b/packages/wallet/src/redux/protocols/indirect-defunding/state.ts
@@ -7,21 +7,11 @@ export const SUCCESS = 'Success';
 
 export type FailureReason = 'Received Invalid Commitment' | 'Channel Not Closed';
 
-export type IndirectDefundingState =
-  | WaitForLedgerUpdate
-  | WaitForFinalLedgerUpdate
-  | Success
-  | Failure;
+export type IndirectDefundingState = WaitForLedgerUpdate | Success | Failure;
 export interface WaitForLedgerUpdate {
   type: typeof WAIT_FOR_LEDGER_UPDATE;
   processId: string;
-  channelId: string;
-  proposedAllocation: string[];
-  proposedDestination: string[];
-}
-export interface WaitForFinalLedgerUpdate {
-  type: typeof WAIT_FOR_FINAL_LEDGER_UPDATE;
-  processId: string;
+  ledgerId: string;
   channelId: string;
   proposedAllocation: string[];
   proposedDestination: string[];
@@ -50,23 +40,11 @@ export function isTerminal(state: IndirectDefundingState): state is Failure | Su
 export function waitForLedgerUpdate(
   properties: Properties<WaitForLedgerUpdate>,
 ): WaitForLedgerUpdate {
-  const { processId, channelId, proposedAllocation, proposedDestination } = properties;
+  const { processId, ledgerId, channelId, proposedAllocation, proposedDestination } = properties;
   return {
     type: WAIT_FOR_LEDGER_UPDATE,
     processId,
-    channelId,
-    proposedAllocation,
-    proposedDestination,
-  };
-}
-
-export function waitForFinalLedgerUpdate(
-  properties: Properties<WaitForFinalLedgerUpdate>,
-): WaitForFinalLedgerUpdate {
-  const { processId, channelId, proposedAllocation, proposedDestination } = properties;
-  return {
-    type: WAIT_FOR_FINAL_LEDGER_UPDATE,
-    processId,
+    ledgerId,
     channelId,
     proposedAllocation,
     proposedDestination,


### PR DESCRIPTION
Updates the ledger de-funding protocol to work with the recent changes made to the consensus app.

(The PR can be based on master once #471  is merged in)