### PR TITLE
Heroku monorepo configuration

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,16 @@
   "license": "MIT",
   "scripts": {
     "test:ci": "test:ci",
-    "build": "build"
-  }
+    "build": "build",
+    "heroku-postbuild": "npx lerna bootstrap"
+  },
+  "cacheDirectories": [
+    "node_modules",
+    "packages/wallet/node_modules",
+    "packages/server/node_modules",
+    "packages/magmo-wallet-client/node_modules",
+    "packages/rps/node_modules",
+    "packages/tictactoe/node_modules",
+    "packages/wallet-common/node_modules"
+  ]
 }

--- a/packages/server/Procfile
+++ b/packages/server/Procfile
@@ -1,0 +1,2 @@
+web: cd packages/server && yarn start
+adjudicator-watcher: cd packages/server && yarn start:adjudicator-watcher

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -16,7 +16,7 @@
     "test:ci": "run-s contracts:clear prettier:check 'test:chain --all --ci' test:server",
     "watch-server": "nodemon --watch 'src/**/*' -e ts,tsx --exec ts-node ./src/app/server.ts",
     "build": "tsc && npx tsc knexfile.ts",
-    "start": "run-s start:server start-adjudicator-watcher",
+    "start": "run-s start:server",
     "start:server": "node ./lib/app/server.js",
     "start:adjudicator-watcher": "node lib/wallet/adjudicator-watcher/index.js",
     "prestart": "npm run db:rollback && npm run db:migrate && npm run db:seed",

--- a/packages/server/yarn.lock
+++ b/packages/server/yarn.lock
@@ -4625,11 +4625,6 @@ lru-cache@^4.0.1:
     solc "^0.5.4"
     yargs "^12.0.5"
 
-magmo-wallet-common@^0.0.0:
-  version "0.0.0"
-  resolved "https://registry.yarnpkg.com/magmo-wallet-common/-/magmo-wallet-common-0.0.0.tgz#7521780d95d03a1524e674f95f4649449a6000bf"
-  integrity sha512-F496nSmBN6o7reNqfPsdey7TBVLYKp9Uu5XdE8/jO/HRrLJmE7yeigqiv4Jk3mRRpBKUe+fnIz9gZmCchhjwOA==
-
 make-dir@^1.0.0, make-dir@^1.2.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/make-dir/-/make-dir-1.3.0.tgz#79c1033b80515bd6d24ec9933e860ca75ee27f0c"


### PR DESCRIPTION
This configuration is not ideal:
- Builds on Heroku take a while.
- Root `package.json` contains Heroku-specific configuration, which is only applicable to the `server` package.

Another approach we can try is using yarn workspaces to see if that speeds up Heroku builds. With yarn workspaces, we would not need the `cacheDirectories` list. We can also try using Docker with Heroku to speed up builds.