### PR TITLE
Concluding Work

### DIFF
--- a/packages/magmo-wallet-client/package.json
+++ b/packages/magmo-wallet-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "magmo-wallet-client",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "description": "Utility library for communicating with the magmo wallet",
   "author": "",
   "homepage": "https://github.com/magmo/apps#readme",

--- a/packages/magmo-wallet-client/src/index.ts
+++ b/packages/magmo-wallet-client/src/index.ts
@@ -7,4 +7,3 @@ export * from './wallet-events';
 
 export * from './wallet-functions';
 export { WalletEventListener } from './wallet-event-listener';
-export * from './wallet-types';

--- a/packages/magmo-wallet-client/src/wallet-events.ts
+++ b/packages/magmo-wallet-client/src/wallet-events.ts
@@ -1,5 +1,4 @@
 import { Commitment } from 'fmg-core';
-import { WalletMessagePayload } from './wallet-types';
 
 // TODO: We should limit WalletEvent/WalletEventTypes to the bare minimum of events we expect the app to handle. Some of these can be pruned.
 // Events that we handle for the user (HideWallet,ShowWallet, ValidateSuccess, etc..) should be removed from WalletEvent/WalletEventTypes
@@ -282,7 +281,7 @@ export const MESSAGE_RELAY_REQUESTED = 'WALLET.MESSAGING.MESSAGE_RELAY_REQUESTED
 /**
  * @ignore
  */
-export const messageRelayRequested = (to: string, messagePayload: WalletMessagePayload) => ({
+export const messageRelayRequested = (to: string, messagePayload: any) => ({
   type: MESSAGE_RELAY_REQUESTED as typeof MESSAGE_RELAY_REQUESTED,
   to,
   messagePayload,

--- a/packages/magmo-wallet-client/src/wallet-functions.ts
+++ b/packages/magmo-wallet-client/src/wallet-functions.ts
@@ -22,7 +22,6 @@ import {
   initializeChannelRequest,
 } from './wallet-instructions';
 import { Commitment } from 'fmg-core';
-import { WalletMessagePayload } from './wallet-types';
 
 /**
  * Creates an iframe element for the wallet to be embedded in the page. The wallet iframe will hide itself and only show when interaction with the wallet is necessary.
@@ -190,7 +189,7 @@ export async function signCommitment(iFrameId: string, commitment: Commitment): 
  * @param iFrameId The id of the embedded wallet iframe.
  * @param walletMessage The message to send to the wallet that was received from the opponent's wallet.
  */
-export function relayMessage(iFrameId: string, messagePayload: WalletMessagePayload) {
+export function relayMessage(iFrameId: string, messagePayload: any) {
   const iFrame = document.getElementById(iFrameId) as HTMLIFrameElement;
   const message = receiveMessage(messagePayload);
   iFrame.contentWindow.postMessage(message, '*');

--- a/packages/magmo-wallet-client/src/wallet-instructions.ts
+++ b/packages/magmo-wallet-client/src/wallet-instructions.ts
@@ -1,5 +1,4 @@
 import { Commitment } from 'fmg-core';
-import { WalletMessagePayload } from './wallet-types';
 
 export enum PlayerIndex {
   'A' = 0,
@@ -93,7 +92,8 @@ export const respondToChallenge = (commitment: Commitment) => ({
 export type RespondToChallenge = ReturnType<typeof respondToChallenge>;
 
 export const CONCLUDE_CHANNEL_REQUEST = 'WALLET.CHANNEL.REQUEST.CONCLUDE';
-export const concludeChannelRequest = () => ({
+export const concludeChannelRequest = (channelId: string) => ({
+  channelId,
   type: CONCLUDE_CHANNEL_REQUEST as typeof CONCLUDE_CHANNEL_REQUEST,
 });
 export type ConcludeChannelRequest = ReturnType<typeof concludeChannelRequest>;
@@ -106,7 +106,7 @@ export type ConcludeChannelRequest = ReturnType<typeof concludeChannelRequest>;
 // wallet meant for wallet-to-wallet communication (e.g. communicating the address of the
 // adjudicator).
 export const RECEIVE_MESSAGE = 'WALLET.MESSAGING.RECEIVE_MESSAGE';
-export const receiveMessage = (messagePayload: WalletMessagePayload) => ({
+export const receiveMessage = (messagePayload: any) => ({
   type: RECEIVE_MESSAGE,
   messagePayload,
 });

--- a/packages/magmo-wallet-client/src/wallet-types.ts
+++ b/packages/magmo-wallet-client/src/wallet-types.ts
@@ -1,4 +1,0 @@
-export interface WalletMessagePayload {
-  processId: string;
-  data: any;
-}

--- a/packages/rps/package.json
+++ b/packages/rps/package.json
@@ -107,7 +107,7 @@
     "html-webpack-plugin": "4.0.0-beta.5",
     "jest": "^23.5.0",
     "magmo-devtools": "git+https://github.com/magmo/devtools.git#v0.1.12",
-    "magmo-wallet-client": "0.0.2",
+    "magmo-wallet-client": "0.0.3",
     "node-sass": "^4.9.3",
     "optimize-css-assets-webpack-plugin": "5.0.1",
     "pnp-webpack-plugin": "1.2.1",

--- a/packages/wallet/package.json
+++ b/packages/wallet/package.json
@@ -57,7 +57,7 @@
     "fs-extra": "3.0.1",
     "key-mirror": "^1.0.1",
     "lodash": "^4.17.10",
-    "magmo-wallet-client": "0.0.2",
+    "magmo-wallet-client": "0.0.3",
     "nanoid": "^1.0.3",
     "npm-run-all": "4.1.5",
     "object-assign": "4.1.1",

--- a/packages/wallet/src/communication/actions.ts
+++ b/packages/wallet/src/communication/actions.ts
@@ -1,6 +1,7 @@
-import { Commitment, SignedCommitment } from '../domain';
+import { SignedCommitment } from '../domain';
 import { WalletAction } from '../redux/actions';
 import { FundingStrategy } from './index';
+import { CONCLUDE_INSTIGATED, ConcludeInstigated } from '../redux/protocols/actions';
 
 export interface BaseProcessAction {
   processId: string;
@@ -31,29 +32,6 @@ export const strategyApproved = (processId: string): StrategyApproved => ({
   processId,
 });
 
-// CONCLUDING
-export const CONCLUDE_CHANNEL = 'WALLET.NEW_PROCESS.CONCLUDE_INSTIGATED';
-export interface ConcludeChannel extends BaseProcessAction {
-  type: typeof CONCLUDE_CHANNEL;
-  commitment: Commitment;
-  signature: string;
-  channelId: string;
-  protocol: 'ConcludingResponder';
-}
-export const concludeChannel = (
-  processId: string,
-  commitment: Commitment,
-  signature: string,
-  channelId: string,
-): ConcludeChannel => ({
-  type: CONCLUDE_CHANNEL,
-  processId,
-  commitment,
-  signature,
-  channelId,
-  protocol: 'ConcludingResponder',
-});
-
 // COMMON
 export const COMMITMENT_RECEIVED = 'WALLET.COMMON.COMMITMENT_RECEIVED';
 export const commitmentReceived = (processId: string, signedCommitment: SignedCommitment) => ({
@@ -66,14 +44,14 @@ export type CommitmentReceived = ReturnType<typeof commitmentReceived>;
 export type RelayableAction =
   | StrategyProposed
   | StrategyApproved
-  | ConcludeChannel
+  | ConcludeInstigated
   | CommitmentReceived;
 
 export function isRelayableAction(action: WalletAction): action is RelayableAction {
   return (
     action.type === STRATEGY_PROPOSED ||
     action.type === STRATEGY_APPROVED ||
-    action.type === CONCLUDE_CHANNEL ||
+    action.type === CONCLUDE_INSTIGATED ||
     action.type === COMMITMENT_RECEIVED
   );
 }

--- a/packages/wallet/src/communication/index.ts
+++ b/packages/wallet/src/communication/index.ts
@@ -1,19 +1,13 @@
-import { Commitment } from '../domain';
+import { Commitment, SignedCommitment } from '../domain';
 import { messageRelayRequested } from 'magmo-wallet-client';
-import {
-  RelayableAction,
-  strategyProposed,
-  strategyApproved,
-  concludeChannel,
-  commitmentReceived,
-} from './actions';
+import { RelayableAction, strategyProposed, strategyApproved, commitmentReceived } from './actions';
+import { concludeInstigated } from '../redux/protocols/actions';
 export * from './actions';
 
 export type FundingStrategy = 'IndirectFundingStrategy';
 
 function sendMessage(to: string, message: RelayableAction) {
-  const { processId } = message;
-  return messageRelayRequested(to, { processId, data: message });
+  return messageRelayRequested(to, message);
 }
 
 export function sendStrategyProposed(to: string, processId: string, strategy: FundingStrategy) {
@@ -24,8 +18,8 @@ export function sendStrategyApproved(to: string, processId: string) {
   return sendMessage(to, strategyApproved(processId));
 }
 
-export function sendConcludeChannel(to: string, processId, commitment, signature, channelId) {
-  return sendMessage(to, concludeChannel(processId, commitment, signature, channelId));
+export function sendConcludeInstigated(to: string, processId, signedCommitment: SignedCommitment) {
+  return sendMessage(to, concludeInstigated(processId, signedCommitment));
 }
 
 export const sendCommitmentReceived = (
@@ -34,9 +28,6 @@ export const sendCommitmentReceived = (
   commitment: Commitment,
   signature: string,
 ) => {
-  const payload = {
-    processId,
-    data: commitmentReceived(processId, { commitment, signature }),
-  };
+  const payload = commitmentReceived(processId, { commitment, signature });
   return messageRelayRequested(to, payload);
 };

--- a/packages/wallet/src/communication/index.ts
+++ b/packages/wallet/src/communication/index.ts
@@ -19,7 +19,7 @@ export function sendStrategyApproved(to: string, processId: string) {
 }
 
 export function sendConcludeInstigated(to: string, processId, signedCommitment: SignedCommitment) {
-  return sendMessage(to, concludeInstigated(processId, signedCommitment));
+  return sendMessage(to, concludeInstigated(signedCommitment));
 }
 
 export const sendCommitmentReceived = (

--- a/packages/wallet/src/domain/commitments/__tests__/index.ts
+++ b/packages/wallet/src/domain/commitments/__tests__/index.ts
@@ -23,7 +23,7 @@ function typeAndCount(
   let commitmentCount;
   let commitmentType;
   if (isFinal) {
-    commitmentCount = 0;
+    commitmentCount = turnNum % 2;
     commitmentType = CommitmentType.Conclude;
   } else if (turnNum < 2) {
     commitmentCount = turnNum;

--- a/packages/wallet/src/redux/__tests__/helpers.ts
+++ b/packages/wallet/src/redux/__tests__/helpers.ts
@@ -68,8 +68,8 @@ const expectSideEffect = (
 
 export const expectThisCommitmentSent = (state: SideEffectState, c: Partial<Commitment>) => {
   expectSideEffect('messageOutbox', state, item => {
-    expect(item.messagePayload.data.type).toEqual(COMMITMENT_RECEIVED);
-    expect(item.messagePayload.data.signedCommitment.commitment).toMatchObject(c);
+    expect(item.messagePayload.type).toEqual(COMMITMENT_RECEIVED);
+    expect(item.messagePayload.signedCommitment.commitment).toMatchObject(c);
   });
 };
 

--- a/packages/wallet/src/redux/__tests__/helpers.ts
+++ b/packages/wallet/src/redux/__tests__/helpers.ts
@@ -66,11 +66,18 @@ const expectSideEffect = (
   expectation(item);
 };
 
-export const expectThisCommitmentSent = (state: SideEffectState, c: Partial<Commitment>) => {
+export const expectThisMessageAndCommitmentSent = (
+  state: SideEffectState,
+  c: Partial<Commitment>,
+  messageType: string,
+) => {
   expectSideEffect('messageOutbox', state, item => {
-    expect(item.messagePayload.type).toEqual(COMMITMENT_RECEIVED);
+    expect(item.messagePayload.type).toEqual(messageType);
     expect(item.messagePayload.signedCommitment.commitment).toMatchObject(c);
   });
+};
+export const expectThisCommitmentSent = (state: SideEffectState, c: Partial<Commitment>) => {
+  expectThisMessageAndCommitmentSent(state, c, COMMITMENT_RECEIVED);
 };
 
 export const itSendsATransaction = (state: SideEffectState) => {

--- a/packages/wallet/src/redux/protocols/actions.ts
+++ b/packages/wallet/src/redux/protocols/actions.ts
@@ -23,7 +23,7 @@ export const CONCLUDE_REQUESTED = 'WALLET.NEW_PROCESS.CONCLUDE_REQUESTED';
 export const concludeRequested = (channelId: string) => ({
   type: CONCLUDE_REQUESTED as typeof CONCLUDE_REQUESTED,
   channelId,
-  protocol: WalletProtocol.ConcludingInstigator,
+  protocol: WalletProtocol.Concluding,
 });
 export type ConcludeRequested = ReturnType<typeof concludeRequested>;
 
@@ -31,7 +31,7 @@ export const CONCLUDE_INSTIGATED = 'WALLET.NEW_PROCESS.CONCLUDE_INSTIGATED';
 export const concludeInstigated = (signedCommitment: SignedCommitment) => ({
   type: CONCLUDE_INSTIGATED as typeof CONCLUDE_INSTIGATED,
   signedCommitment,
-  protocol: WalletProtocol.ConcludingResponder,
+  protocol: WalletProtocol.Concluding,
 });
 export type ConcludeInstigated = ReturnType<typeof concludeInstigated>;
 

--- a/packages/wallet/src/redux/protocols/actions.ts
+++ b/packages/wallet/src/redux/protocols/actions.ts
@@ -1,6 +1,6 @@
 import { ProtocolAction, WalletAction } from '../actions';
 import { PlayerIndex, WalletProtocol } from '../types';
-import { Commitment } from '../../domain';
+import { Commitment, SignedCommitment } from '../../domain';
 export { BaseProcessAction } from '../../communication';
 
 export const INITIALIZE_CHANNEL = 'WALLET.NEW_PROCESS.INITIALIZE_CHANNEL';
@@ -28,9 +28,9 @@ export const concludeRequested = (channelId: string) => ({
 export type ConcludeRequested = ReturnType<typeof concludeRequested>;
 
 export const CONCLUDE_INSTIGATED = 'WALLET.NEW_PROCESS.CONCLUDE_INSTIGATED';
-export const concludeInstigated = (channelId: string) => ({
+export const concludeInstigated = (signedCommitment: SignedCommitment) => ({
   type: CONCLUDE_INSTIGATED as typeof CONCLUDE_INSTIGATED,
-  channelId,
+  signedCommitment,
   protocol: WalletProtocol.ConcludingResponder,
 });
 export type ConcludeInstigated = ReturnType<typeof concludeInstigated>;

--- a/packages/wallet/src/redux/protocols/concluding/container.tsx
+++ b/packages/wallet/src/redux/protocols/concluding/container.tsx
@@ -1,0 +1,38 @@
+import * as states from './state';
+import { PureComponent } from 'react';
+import React from 'react';
+import * as concludingInstigatorStates from './instigator/states';
+import * as concludingResponderStates from './responder/states';
+import { connect } from 'react-redux';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { Concluding as ConcludingInstigator } from './instigator/container';
+import { Concluding as ConcludingResponder } from './responder/container';
+import { faSpinner } from '@fortawesome/free-solid-svg-icons';
+
+interface Props {
+  state: states.ConcludingState;
+}
+
+class ConcludingContainer extends PureComponent<Props> {
+  render() {
+    const { state } = this.props;
+    if (
+      concludingInstigatorStates.isConcludingInstigatorState(state) &&
+      !states.isTerminal(state)
+    ) {
+      return <ConcludingInstigator state={state} />;
+    }
+
+    if (concludingResponderStates.isConcludingResponderState(state) && !states.isTerminal(state)) {
+      return <ConcludingResponder state={state} />;
+    }
+    // TODO: We need a placeholder screen here when transitioning back to the app from a success state
+    return (
+      <div>
+        <FontAwesomeIcon icon={faSpinner} pulse={true} size="lg" />
+      </div>
+    );
+  }
+}
+
+export const Concluding = connect(() => ({}))(ConcludingContainer);

--- a/packages/wallet/src/redux/protocols/concluding/index.ts
+++ b/packages/wallet/src/redux/protocols/concluding/index.ts
@@ -1,0 +1,6 @@
+export { Concluding } from './container';
+export {
+  initializeResponderState,
+  initializeInstigatorState,
+  concludingReducer as reducer,
+} from './reducer';

--- a/packages/wallet/src/redux/protocols/concluding/instigator/__tests__/reducer.test.ts
+++ b/packages/wallet/src/redux/protocols/concluding/instigator/__tests__/reducer.test.ts
@@ -1,10 +1,11 @@
 import * as scenarios from './scenarios';
-import { concludingReducer, initialize, ReturnVal } from '../reducer';
-import { ConcludingStateType, FailureReason } from '../states';
+import { instigatorConcludingReducer, initialize, ReturnVal } from '../reducer';
+import { InstigatorConcludingStateType } from '../states';
 import { SharedData } from '../../../../state';
 import { Commitment } from '../../../../../domain';
 import { CONCLUDE_INSTIGATED } from '../../../actions';
 import { expectThisMessageAndCommitmentSent } from '../../../../__tests__/helpers';
+import { FailureReason } from '../../state';
 
 describe('[ Happy path ]', () => {
   const scenario = scenarios.happyPath;
@@ -18,7 +19,7 @@ describe('[ Happy path ]', () => {
   describe('when in ApproveConcluding', () => {
     const state = scenario.states.approveConcluding;
     const action = scenario.actions.concludeSent;
-    const result = concludingReducer(state, storage, action);
+    const result = instigatorConcludingReducer(state, storage, action);
 
     itSendsConcludeInstigated(result.storage, scenario.commitments.concludeCommitment);
     itTransitionsTo(result, 'InstigatorWaitForOpponentConclude');
@@ -27,7 +28,7 @@ describe('[ Happy path ]', () => {
   describe('when in WaitForOpponentConclude', () => {
     const state = scenario.states.waitForOpponentConclude;
     const action = scenario.actions.concludeReceived;
-    const result = concludingReducer(state, storage, action);
+    const result = instigatorConcludingReducer(state, storage, action);
 
     itTransitionsTo(result, 'InstigatorAcknowledgeConcludeReceived');
   });
@@ -35,7 +36,7 @@ describe('[ Happy path ]', () => {
   describe('when in AcknowledgeConcludeReceived', () => {
     const state = scenario.states.acknowledgeConcludeReceived;
     const action = scenario.actions.defundChosen;
-    const result = concludingReducer(state, storage, action);
+    const result = instigatorConcludingReducer(state, storage, action);
 
     itTransitionsTo(result, 'InstigatorWaitForDefund');
   });
@@ -43,7 +44,7 @@ describe('[ Happy path ]', () => {
   describe('when in WaitForDefund', () => {
     const state = scenario.states.waitForDefund;
     const action = scenario.actions.successTrigger;
-    const result = concludingReducer(state, storage, action);
+    const result = instigatorConcludingReducer(state, storage, action);
 
     itTransitionsTo(result, 'InstigatorAcknowledgeSuccess');
   });
@@ -51,9 +52,9 @@ describe('[ Happy path ]', () => {
   describe('when in AcknowledgeSuccess', () => {
     const state = scenario.states.acknowledgeSuccess;
     const action = scenario.actions.acknowledged;
-    const result = concludingReducer(state, storage, action);
+    const result = instigatorConcludingReducer(state, storage, action);
 
-    itTransitionsTo(result, 'InstigatorSuccess');
+    itTransitionsTo(result, 'Success');
   });
 });
 
@@ -70,7 +71,7 @@ describe('[ Channel doesnt exist ]', () => {
   describe('when in AcknowledgeFailure', () => {
     const state = scenario.states.acknowledgeFailure;
     const action = scenario.actions.acknowledged;
-    const result = concludingReducer(state, storage, action);
+    const result = instigatorConcludingReducer(state, storage, action);
 
     itTransitionsToFailure(result, 'ChannelDoesntExist');
   });
@@ -89,7 +90,7 @@ describe('[ Concluding Not Possible ]', () => {
   describe('when in AcknowledgeFailure', () => {
     const state = scenario.states.acknowledgeFailure;
     const action = scenario.actions.acknowledged;
-    const result = concludingReducer(state, storage, action);
+    const result = instigatorConcludingReducer(state, storage, action);
 
     itTransitionsToFailure(result, 'NotYourTurn');
   });
@@ -102,7 +103,7 @@ describe('[ Concluding Cancelled ]', () => {
   describe('when in ApproveConcluding', () => {
     const state = scenario.states.approveConcluding;
     const action = scenario.actions.cancelled;
-    const result = concludingReducer(state, storage, action);
+    const result = instigatorConcludingReducer(state, storage, action);
 
     itTransitionsToFailure(result, 'ConcludeCancelled');
   });
@@ -115,7 +116,7 @@ describe('[ Defunding Failed ]', () => {
   describe('when in WaitForDefund', () => {
     const state = scenario.states.waitForDefund2;
     const action = scenario.actions.failureTrigger;
-    const result = concludingReducer(state, storage, action);
+    const result = instigatorConcludingReducer(state, storage, action);
 
     itTransitionsToAcknowledgeFailure(result, 'DefundFailed');
   });
@@ -123,7 +124,7 @@ describe('[ Defunding Failed ]', () => {
   describe('when in AcknowledgeFailure', () => {
     const state = scenario.states.acknowledgeFailure;
     const action = scenario.actions.acknowledged;
-    const result = concludingReducer(state, storage, action);
+    const result = instigatorConcludingReducer(state, storage, action);
 
     itTransitionsToFailure(result, 'DefundFailed');
   });
@@ -135,7 +136,7 @@ function itSendsConcludeInstigated(storage: SharedData, commitment: Commitment) 
   });
 }
 
-function itTransitionsTo(result: ReturnVal, type: ConcludingStateType) {
+function itTransitionsTo(result: ReturnVal, type: InstigatorConcludingStateType) {
   it(`transitions to ${type}`, () => {
     expect(result.state.type).toEqual(type);
   });
@@ -143,8 +144,8 @@ function itTransitionsTo(result: ReturnVal, type: ConcludingStateType) {
 
 function itTransitionsToFailure(result: ReturnVal, reason: FailureReason) {
   it(`transitions to Failure with reason ${reason}`, () => {
-    expect(result.state.type).toEqual('InstigatorFailure');
-    if (result.state.type === 'InstigatorFailure') {
+    expect(result.state.type).toEqual('Failure');
+    if (result.state.type === 'Failure') {
       expect(result.state.reason).toEqual(reason);
     }
   });

--- a/packages/wallet/src/redux/protocols/concluding/instigator/__tests__/reducer.test.ts
+++ b/packages/wallet/src/redux/protocols/concluding/instigator/__tests__/reducer.test.ts
@@ -1,7 +1,10 @@
 import * as scenarios from './scenarios';
 import { concludingReducer, initialize, ReturnVal } from '../reducer';
 import { ConcludingStateType, FailureReason } from '../states';
-import { expectThisCommitmentSent } from '../../../../__tests__/helpers';
+import { SharedData } from '../../../../state';
+import { Commitment } from '../../../../../domain';
+import { CONCLUDE_INSTIGATED } from '../../../actions';
+import { expectThisMessageAndCommitmentSent } from '../../../../__tests__/helpers';
 
 describe('[ Happy path ]', () => {
   const scenario = scenarios.happyPath;
@@ -17,7 +20,7 @@ describe('[ Happy path ]', () => {
     const action = scenario.actions.concludeSent;
     const result = concludingReducer(state, storage, action);
 
-    expectThisCommitmentSent(result.storage, scenario.commitments.concludeCommitment);
+    itSendsConcludeInstigated(result.storage, scenario.commitments.concludeCommitment);
     itTransitionsTo(result, 'InstigatorWaitForOpponentConclude');
   });
 
@@ -125,6 +128,12 @@ describe('[ Defunding Failed ]', () => {
     itTransitionsToFailure(result, 'DefundFailed');
   });
 });
+
+function itSendsConcludeInstigated(storage: SharedData, commitment: Commitment) {
+  it('sends a conclude instigated message with the correct commitment', () => {
+    expectThisMessageAndCommitmentSent(storage, commitment, CONCLUDE_INSTIGATED);
+  });
+}
 
 function itTransitionsTo(result: ReturnVal, type: ConcludingStateType) {
   it(`transitions to ${type}`, () => {

--- a/packages/wallet/src/redux/protocols/concluding/instigator/__tests__/reducer.test.ts
+++ b/packages/wallet/src/redux/protocols/concluding/instigator/__tests__/reducer.test.ts
@@ -143,7 +143,7 @@ function itTransitionsTo(result: ReturnVal, type: ConcludingStateType) {
 
 function itTransitionsToFailure(result: ReturnVal, reason: FailureReason) {
   it(`transitions to Failure with reason ${reason}`, () => {
-    expect(result.state.type).toEqual('Failure');
+    expect(result.state.type).toEqual('InstigatorFailure');
     if (result.state.type === 'InstigatorFailure') {
       expect(result.state.reason).toEqual(reason);
     }
@@ -152,7 +152,7 @@ function itTransitionsToFailure(result: ReturnVal, reason: FailureReason) {
 
 function itTransitionsToAcknowledgeFailure(result: ReturnVal, reason: FailureReason) {
   it(`transitions to AcknowledgeFailure with reason ${reason}`, () => {
-    expect(result.state.type).toEqual('AcknowledgeFailure');
+    expect(result.state.type).toEqual('InstigatorAcknowledgeFailure');
     if (result.state.type === 'InstigatorAcknowledgeFailure') {
       expect(result.state.reason).toEqual(reason);
     }

--- a/packages/wallet/src/redux/protocols/concluding/instigator/__tests__/reducer.test.ts
+++ b/packages/wallet/src/redux/protocols/concluding/instigator/__tests__/reducer.test.ts
@@ -91,25 +91,6 @@ describe('[ Concluding Not Possible ]', () => {
   });
 });
 
-describe('[ Concluding Not Possible ]', () => {
-  const scenario = scenarios.concludingNotPossible;
-  const { channelId, processId } = scenario;
-
-  describe('when initializing', () => {
-    const { store } = scenario.initialize;
-    const result = initialize(channelId, processId, store);
-
-    itTransitionsToAcknowledgeFailure(result, 'NotYourTurn');
-  });
-
-  describe('when in AcknowledgeFailure', () => {
-    const { state, action, store } = scenario.acknowledgeFailure;
-    const result = instigatorConcludingReducer(state, store, action);
-
-    itTransitionsToFailure(result, 'NotYourTurn');
-  });
-});
-
 describe('[ Concluding Cancelled ]', () => {
   const scenario = scenarios.concludingCancelled;
 
@@ -122,7 +103,7 @@ describe('[ Concluding Cancelled ]', () => {
 });
 
 describe('[ Defund failed ]', () => {
-  const scenario = scenarios.defudFailed;
+  const scenario = scenarios.defundFailed;
 
   describe('when in WaitForDefund', () => {
     const { state, action, store } = scenario.waitForDefund;

--- a/packages/wallet/src/redux/protocols/concluding/instigator/__tests__/reducer.test.ts
+++ b/packages/wallet/src/redux/protocols/concluding/instigator/__tests__/reducer.test.ts
@@ -5,130 +5,54 @@ import { SharedData } from '../../../../state';
 import { Commitment } from '../../../../../domain';
 import { CONCLUDE_INSTIGATED } from '../../../actions';
 import { expectThisMessageAndCommitmentSent } from '../../../../__tests__/helpers';
-import { FailureReason } from '../../state';
 
 describe('[ Happy path ]', () => {
   const scenario = scenarios.happyPath;
-  const { channelId, processId, storage } = scenario;
+  const { channelId, processId } = scenario;
 
   describe('when initializing', () => {
-    const result = initialize(channelId, processId, storage);
-
+    const { store } = scenario.initialize;
+    const result = initialize(channelId, processId, store);
     itTransitionsTo(result, 'InstigatorApproveConcluding');
   });
   describe('when in ApproveConcluding', () => {
-    const state = scenario.states.approveConcluding;
-    const action = scenario.actions.concludeSent;
-    const result = instigatorConcludingReducer(state, storage, action);
+    const { state, action, store, reply } = scenario.approveConcluding;
+    const result = instigatorConcludingReducer(state, store, action);
 
-    itSendsConcludeInstigated(result.storage, scenario.commitments.concludeCommitment);
+    itSendsConcludeInstigated(result.storage, reply);
     itTransitionsTo(result, 'InstigatorWaitForOpponentConclude');
   });
 
   describe('when in WaitForOpponentConclude', () => {
-    const state = scenario.states.waitForOpponentConclude;
-    const action = scenario.actions.concludeReceived;
-    const result = instigatorConcludingReducer(state, storage, action);
+    const { state, action, store } = scenario.waitforOpponentConclude;
+    const result = instigatorConcludingReducer(state, store, action);
 
     itTransitionsTo(result, 'InstigatorAcknowledgeConcludeReceived');
   });
 
   describe('when in AcknowledgeConcludeReceived', () => {
-    const state = scenario.states.acknowledgeConcludeReceived;
-    const action = scenario.actions.defundChosen;
-    const result = instigatorConcludingReducer(state, storage, action);
+    const { state, action, store } = scenario.acknowledgeConcludeReceived;
+    const result = instigatorConcludingReducer(state, store, action);
 
     itTransitionsTo(result, 'InstigatorWaitForDefund');
   });
 
   describe('when in WaitForDefund', () => {
-    const state = scenario.states.waitForDefund;
-    const action = scenario.actions.successTrigger;
-    const result = instigatorConcludingReducer(state, storage, action);
+    const { state, action, store } = scenario.waitForDefund;
+    const result = instigatorConcludingReducer(state, store, action);
 
     itTransitionsTo(result, 'InstigatorAcknowledgeSuccess');
   });
 
   describe('when in AcknowledgeSuccess', () => {
-    const state = scenario.states.acknowledgeSuccess;
-    const action = scenario.actions.acknowledged;
-    const result = instigatorConcludingReducer(state, storage, action);
+    const { state, action, store } = scenario.acknowledgeSuccess;
+    const result = instigatorConcludingReducer(state, store, action);
 
     itTransitionsTo(result, 'Success');
   });
 });
 
-describe('[ Channel doesnt exist ]', () => {
-  const scenario = scenarios.channelDoesntExist;
-  const { processId, storage } = scenario;
-
-  describe('when initializing', () => {
-    const result = initialize('NotInitializedChannelId', processId, storage);
-
-    itTransitionsToAcknowledgeFailure(result, 'ChannelDoesntExist');
-  });
-
-  describe('when in AcknowledgeFailure', () => {
-    const state = scenario.states.acknowledgeFailure;
-    const action = scenario.actions.acknowledged;
-    const result = instigatorConcludingReducer(state, storage, action);
-
-    itTransitionsToFailure(result, 'ChannelDoesntExist');
-  });
-});
-
-describe('[ Concluding Not Possible ]', () => {
-  const scenario = scenarios.concludingNotPossible;
-  const { channelId, processId, storage } = scenario;
-
-  describe('when initializing', () => {
-    const result = initialize(channelId, processId, storage);
-
-    itTransitionsToAcknowledgeFailure(result, 'NotYourTurn');
-  });
-
-  describe('when in AcknowledgeFailure', () => {
-    const state = scenario.states.acknowledgeFailure;
-    const action = scenario.actions.acknowledged;
-    const result = instigatorConcludingReducer(state, storage, action);
-
-    itTransitionsToFailure(result, 'NotYourTurn');
-  });
-});
-
-describe('[ Concluding Cancelled ]', () => {
-  const scenario = scenarios.concludingCancelled;
-  const { storage } = scenario;
-
-  describe('when in ApproveConcluding', () => {
-    const state = scenario.states.approveConcluding;
-    const action = scenario.actions.cancelled;
-    const result = instigatorConcludingReducer(state, storage, action);
-
-    itTransitionsToFailure(result, 'ConcludeCancelled');
-  });
-});
-
-describe('[ Defunding Failed ]', () => {
-  const scenario = scenarios.defundingFailed;
-  const { storage } = scenario;
-
-  describe('when in WaitForDefund', () => {
-    const state = scenario.states.waitForDefund2;
-    const action = scenario.actions.failureTrigger;
-    const result = instigatorConcludingReducer(state, storage, action);
-
-    itTransitionsToAcknowledgeFailure(result, 'DefundFailed');
-  });
-
-  describe('when in AcknowledgeFailure', () => {
-    const state = scenario.states.acknowledgeFailure;
-    const action = scenario.actions.acknowledged;
-    const result = instigatorConcludingReducer(state, storage, action);
-
-    itTransitionsToFailure(result, 'DefundFailed');
-  });
-});
+// TODO: Unhappy path
 
 function itSendsConcludeInstigated(storage: SharedData, commitment: Commitment) {
   it('sends a conclude instigated message with the correct commitment', () => {
@@ -142,20 +66,20 @@ function itTransitionsTo(result: ReturnVal, type: InstigatorConcludingStateType)
   });
 }
 
-function itTransitionsToFailure(result: ReturnVal, reason: FailureReason) {
-  it(`transitions to Failure with reason ${reason}`, () => {
-    expect(result.state.type).toEqual('Failure');
-    if (result.state.type === 'Failure') {
-      expect(result.state.reason).toEqual(reason);
-    }
-  });
-}
+// function itTransitionsToFailure(result: ReturnVal, reason: FailureReason) {
+//   it(`transitions to Failure with reason ${reason}`, () => {
+//     expect(result.state.type).toEqual('Failure');
+//     if (result.state.type === 'Failure') {
+//       expect(result.state.reason).toEqual(reason);
+//     }
+//   });
+// }
 
-function itTransitionsToAcknowledgeFailure(result: ReturnVal, reason: FailureReason) {
-  it(`transitions to AcknowledgeFailure with reason ${reason}`, () => {
-    expect(result.state.type).toEqual('InstigatorAcknowledgeFailure');
-    if (result.state.type === 'InstigatorAcknowledgeFailure') {
-      expect(result.state.reason).toEqual(reason);
-    }
-  });
-}
+// function itTransitionsToAcknowledgeFailure(result: ReturnVal, reason: FailureReason) {
+//   it(`transitions to AcknowledgeFailure with reason ${reason}`, () => {
+//     expect(result.state.type).toEqual('InstigatorAcknowledgeFailure');
+//     if (result.state.type === 'InstigatorAcknowledgeFailure') {
+//       expect(result.state.reason).toEqual(reason);
+//     }
+//   });
+// }

--- a/packages/wallet/src/redux/protocols/concluding/instigator/__tests__/reducer.test.ts
+++ b/packages/wallet/src/redux/protocols/concluding/instigator/__tests__/reducer.test.ts
@@ -1,6 +1,7 @@
 import * as scenarios from './scenarios';
 import { instigatorConcludingReducer, initialize, ReturnVal } from '../reducer';
 import { InstigatorConcludingStateType } from '../states';
+import { FailureReason } from '../../state';
 import { SharedData } from '../../../../state';
 import { Commitment } from '../../../../../domain';
 import { CONCLUDE_INSTIGATED } from '../../../actions';
@@ -52,7 +53,95 @@ describe('[ Happy path ]', () => {
   });
 });
 
-// TODO: Unhappy path
+describe('[ Channel doesnt exist ]', () => {
+  const scenario = scenarios.channelDoesntExist;
+  const { channelId, processId } = scenario;
+
+  describe('when initializing', () => {
+    const { store } = scenario.initialize;
+    const result = initialize(channelId, processId, store);
+
+    itTransitionsToAcknowledgeFailure(result, 'ChannelDoesntExist');
+  });
+
+  describe('when in AcknowledgeFailure', () => {
+    const { state, action, store } = scenario.acknowledgeFailure;
+    const result = instigatorConcludingReducer(state, store, action);
+
+    itTransitionsToFailure(result, 'ChannelDoesntExist');
+  });
+});
+
+describe('[ Concluding Not Possible ]', () => {
+  const scenario = scenarios.concludingNotPossible;
+  const { channelId, processId } = scenario;
+
+  describe('when initializing', () => {
+    const { store } = scenario.initialize;
+    const result = initialize(channelId, processId, store);
+
+    itTransitionsToAcknowledgeFailure(result, 'NotYourTurn');
+  });
+
+  describe('when in AcknowledgeFailure', () => {
+    const { state, action, store } = scenario.acknowledgeFailure;
+    const result = instigatorConcludingReducer(state, store, action);
+
+    itTransitionsToFailure(result, 'NotYourTurn');
+  });
+});
+
+describe('[ Concluding Not Possible ]', () => {
+  const scenario = scenarios.concludingNotPossible;
+  const { channelId, processId } = scenario;
+
+  describe('when initializing', () => {
+    const { store } = scenario.initialize;
+    const result = initialize(channelId, processId, store);
+
+    itTransitionsToAcknowledgeFailure(result, 'NotYourTurn');
+  });
+
+  describe('when in AcknowledgeFailure', () => {
+    const { state, action, store } = scenario.acknowledgeFailure;
+    const result = instigatorConcludingReducer(state, store, action);
+
+    itTransitionsToFailure(result, 'NotYourTurn');
+  });
+});
+
+describe('[ Concluding Cancelled ]', () => {
+  const scenario = scenarios.concludingCancelled;
+
+  describe('when in ApproveConcluding', () => {
+    const { state, action, store } = scenario.approveConcluding;
+    const result = instigatorConcludingReducer(state, store, action);
+
+    itTransitionsToFailure(result, 'ConcludeCancelled');
+  });
+});
+
+describe('[ Defund failed ]', () => {
+  const scenario = scenarios.defudFailed;
+
+  describe('when in WaitForDefund', () => {
+    const { state, action, store } = scenario.waitForDefund;
+    const result = instigatorConcludingReducer(state, store, action);
+
+    itTransitionsToAcknowledgeFailure(result, 'DefundFailed');
+  });
+
+  describe('when in AcknowledgeFailure', () => {
+    const { state, action, store } = scenario.acknowledgeFailure;
+    const result = instigatorConcludingReducer(state, store, action);
+
+    itTransitionsToFailure(result, 'DefundFailed');
+  });
+});
+
+/////////////
+// Helpers //
+/////////////
 
 function itSendsConcludeInstigated(storage: SharedData, commitment: Commitment) {
   it('sends a conclude instigated message with the correct commitment', () => {
@@ -66,20 +155,20 @@ function itTransitionsTo(result: ReturnVal, type: InstigatorConcludingStateType)
   });
 }
 
-// function itTransitionsToFailure(result: ReturnVal, reason: FailureReason) {
-//   it(`transitions to Failure with reason ${reason}`, () => {
-//     expect(result.state.type).toEqual('Failure');
-//     if (result.state.type === 'Failure') {
-//       expect(result.state.reason).toEqual(reason);
-//     }
-//   });
-// }
+function itTransitionsToFailure(result: ReturnVal, reason: FailureReason) {
+  it(`transitions to Failure with reason ${reason}`, () => {
+    expect(result.state.type).toEqual('Failure');
+    if (result.state.type === 'Failure') {
+      expect(result.state.reason).toEqual(reason);
+    }
+  });
+}
 
-// function itTransitionsToAcknowledgeFailure(result: ReturnVal, reason: FailureReason) {
-//   it(`transitions to AcknowledgeFailure with reason ${reason}`, () => {
-//     expect(result.state.type).toEqual('InstigatorAcknowledgeFailure');
-//     if (result.state.type === 'InstigatorAcknowledgeFailure') {
-//       expect(result.state.reason).toEqual(reason);
-//     }
-//   });
-// }
+function itTransitionsToAcknowledgeFailure(result: ReturnVal, reason: FailureReason) {
+  it(`transitions to AcknowledgeFailure with reason ${reason}`, () => {
+    expect(result.state.type).toEqual('InstigatorAcknowledgeFailure');
+    if (result.state.type === 'InstigatorAcknowledgeFailure') {
+      expect(result.state.reason).toEqual(reason);
+    }
+  });
+}

--- a/packages/wallet/src/redux/protocols/concluding/instigator/__tests__/scenarios.ts
+++ b/packages/wallet/src/redux/protocols/concluding/instigator/__tests__/scenarios.ts
@@ -64,7 +64,7 @@ const acknowledgeConcludeReceived = states.instigatorAcknowledgeConcludeReceived
 const concludeSent = actions.concludeApproved(processId);
 const acknowledged = actions.acknowledged(processId);
 const commitmentReceivedAction = commitmentReceived(processId, app53);
-
+const defundChosen = actions.defundChosen(processId);
 // TODO: Failure scenarios
 
 // -------
@@ -87,7 +87,7 @@ export const happyPath = {
   acknowledgeConcludeReceived: {
     state: acknowledgeConcludeReceived,
     store: secondConcludeReceived,
-    action: acknowledged,
+    action: defundChosen,
   },
   waitForDefund: { state: waitForDefund, store: secondConcludeReceived, action: successTrigger },
   acknowledgeSuccess: {

--- a/packages/wallet/src/redux/protocols/concluding/instigator/__tests__/scenarios.ts
+++ b/packages/wallet/src/redux/protocols/concluding/instigator/__tests__/scenarios.ts
@@ -1,45 +1,48 @@
 import * as states from '../../state';
-import {
-  preSuccessState,
-  preFailureState,
-  successTrigger,
-  failureTrigger,
-} from '../../../defunding/__tests__';
+
+import { preSuccessState, successTrigger } from '../../../defunding/__tests__';
 import * as actions from '../actions';
 import * as channelScenarios from '../../../../__tests__/test-scenarios';
-import { CommitmentType, Commitment } from 'fmg-core';
-
+import { EMPTY_SHARED_DATA, setChannels, setFundingState } from '../../../../state';
+import { channelFromCommitments } from '../../../../channel-store/channel-state/__tests__';
+import { appCommitment, asPrivateKey } from '../../../../../domain/commitments/__tests__';
+import { bigNumberify } from 'ethers/utils';
+import { commitmentReceived } from '../../../../actions';
 // -----------------
 // Channel Scenarios
 // -----------------
-const { channelId, asAddress: address, asPrivateKey: privateKey } = channelScenarios;
-import { ChannelState } from '../../../../channel-store';
-import { setChannel, EMPTY_SHARED_DATA } from '../../../../state';
-import { channelFromCommitments } from '../../../../channel-store/channel-state/__tests__';
+const { channelId, bsAddress, asAddress } = channelScenarios;
 
-const { signedCommitment19, signedCommitment20, signedCommitment21 } = channelScenarios;
-const theirTurn = channelFromCommitments(
-  signedCommitment19,
-  signedCommitment20,
-  address,
-  privateKey,
-);
-const ourTurn = channelFromCommitments(signedCommitment20, signedCommitment21, address, privateKey);
+const twoThree = [
+  { address: asAddress, wei: bigNumberify(2).toHexString() },
+  { address: bsAddress, wei: bigNumberify(3).toHexString() },
+];
 
-const concludeCommitment: Commitment = {
-  ...signedCommitment21.commitment,
-  channel: channelScenarios.channel,
-  commitmentCount: 0,
-  commitmentType: CommitmentType.Conclude,
-  appAttributes: '0x0',
-  turnNum: 22,
-};
+const app50 = appCommitment({ turnNum: 50, balances: twoThree, isFinal: false });
+const app51 = appCommitment({ turnNum: 51, balances: twoThree, isFinal: false });
+const app52 = appCommitment({ turnNum: 52, balances: twoThree, isFinal: true });
+const app53 = appCommitment({ turnNum: 53, balances: twoThree, isFinal: true });
 
+const initialStore = setChannels(EMPTY_SHARED_DATA, [
+  channelFromCommitments(app50, app51, asAddress, asPrivateKey),
+]);
+const firstConcludeReceivedChannelState = setChannels(EMPTY_SHARED_DATA, [
+  channelFromCommitments(app51, app52, asAddress, asPrivateKey),
+]);
+const secondConcludeReceivedChannelState = setChannels(EMPTY_SHARED_DATA, [
+  channelFromCommitments(app52, app53, asAddress, asPrivateKey),
+]);
+
+const firstConcludeReceived = setFundingState(firstConcludeReceivedChannelState, channelId, {
+  directlyFunded: true,
+});
+const secondConcludeReceived = setFundingState(secondConcludeReceivedChannelState, channelId, {
+  directlyFunded: true,
+});
 // --------
 // Defaults
 // --------
 const processId = 'processId';
-const storage = (channelState: ChannelState) => setChannel(EMPTY_SHARED_DATA, channelState);
 
 const defaults = { processId, channelId };
 
@@ -47,108 +50,49 @@ const defaults = { processId, channelId };
 // States
 // ------
 const approveConcluding = states.instigatorApproveConcluding(defaults);
-const waitForOpponentConclude = states.instigatorWaitForOpponentConclude(defaults);
-const acknowledgeConcludeReceived = states.instigatorAcknowledgeConcludeReceived(defaults);
 const waitForDefund = states.instigatorWaitForDefund({
   ...defaults,
   defundingState: preSuccessState,
 });
-const waitForDefund2 = states.instigatorWaitForDefund({
-  ...defaults,
-  defundingState: preFailureState,
-});
-const acknowledgeSuccess = states.instigatorAcknowledgeSuccess(defaults);
-const success = states.success();
 
+const acknowledgeSuccess = states.instigatorAcknowledgeSuccess(defaults);
+const waitforOpponentConclude = states.instigatorWaitForOpponentConclude(defaults);
+const acknowledgeConcludeReceived = states.instigatorAcknowledgeConcludeReceived(defaults);
 // -------
 // Actions
 // -------
-const concludeSent = actions.concludeSent(processId);
-const concludeReceived = actions.concludeReceived(processId);
-const defundChosen = actions.defundChosen(processId);
-const concludingImpossibleAcknowledged = actions.acknowledged(processId);
-const cancelled = actions.cancelled(processId);
+const concludeSent = actions.concludeApproved(processId);
 const acknowledged = actions.acknowledged(processId);
+const commitmentReceivedAction = commitmentReceived(processId, app53);
+
+// TODO: Failure scenarios
 
 // -------
 // Scenarios
 // -------
 export const happyPath = {
   ...defaults,
-  storage: storage(ourTurn),
-  states: {
-    approveConcluding,
-    waitForOpponentConclude,
-    acknowledgeConcludeReceived,
-    waitForDefund,
-    acknowledgeSuccess,
-    success,
+  initialize: { channelId, store: initialStore },
+  approveConcluding: {
+    state: approveConcluding,
+    store: initialStore,
+    action: concludeSent,
+    reply: app52.commitment,
   },
-  actions: {
-    concludeSent,
-    concludeReceived,
-    defundChosen,
-    successTrigger,
-    acknowledged,
+  waitforOpponentConclude: {
+    state: waitforOpponentConclude,
+    store: firstConcludeReceived,
+    action: commitmentReceivedAction,
   },
-  commitments: {
-    concludeCommitment,
+  acknowledgeConcludeReceived: {
+    state: acknowledgeConcludeReceived,
+    store: secondConcludeReceived,
+    action: acknowledged,
   },
-};
-
-export const channelDoesntExist = {
-  ...defaults,
-  storage: storage(ourTurn),
-  states: {
-    acknowledgeFailure: states.instigatorAcknowledgeFailure({
-      ...defaults,
-      reason: 'ChannelDoesntExist',
-    }),
-    failure: states.failure({ reason: 'ChannelDoesntExist' }),
-  },
-  actions: {
-    acknowledged,
-  },
-};
-
-export const concludingNotPossible = {
-  ...defaults,
-  storage: storage(theirTurn),
-  states: {
-    acknowledgeFailure: states.instigatorAcknowledgeFailure({ ...defaults, reason: 'NotYourTurn' }),
-    failure: states.failure({ reason: 'NotYourTurn' }),
-  },
-  actions: {
-    concludingImpossibleAcknowledged,
-    acknowledged,
-  },
-};
-
-export const concludingCancelled = {
-  ...defaults,
-  storage: storage(ourTurn),
-  states: {
-    approveConcluding,
-    failure: states.failure({ reason: 'ConcludeCancelled' }),
-  },
-  actions: {
-    cancelled,
-  },
-};
-
-export const defundingFailed = {
-  ...defaults,
-  storage: storage(ourTurn),
-  states: {
-    waitForDefund2,
-    acknowledgeFailure: states.instigatorAcknowledgeFailure({
-      ...defaults,
-      reason: 'DefundFailed',
-    }),
-    failure: states.failure({ reason: 'DefundFailed' }),
-  },
-  actions: {
-    acknowledged,
-    failureTrigger,
+  waitForDefund: { state: waitForDefund, store: secondConcludeReceived, action: successTrigger },
+  acknowledgeSuccess: {
+    state: acknowledgeSuccess,
+    store: secondConcludeReceived,
+    action: acknowledged,
   },
 };

--- a/packages/wallet/src/redux/protocols/concluding/instigator/__tests__/scenarios.ts
+++ b/packages/wallet/src/redux/protocols/concluding/instigator/__tests__/scenarios.ts
@@ -144,7 +144,7 @@ export const concludingCancelled = {
   },
 };
 
-export const defudFailed = {
+export const defundFailed = {
   ...defaults,
   waitForDefund: {
     state: waitForDefundPreFailure,

--- a/packages/wallet/src/redux/protocols/concluding/instigator/__tests__/scenarios.ts
+++ b/packages/wallet/src/redux/protocols/concluding/instigator/__tests__/scenarios.ts
@@ -1,4 +1,4 @@
-import * as states from '../states';
+import * as states from '../../state';
 import {
   preSuccessState,
   preFailureState,
@@ -46,12 +46,18 @@ const defaults = { processId, channelId };
 // ------
 // States
 // ------
-const approveConcluding = states.approveConcluding(defaults);
-const waitForOpponentConclude = states.waitForOpponentConclude(defaults);
-const acknowledgeConcludeReceived = states.acknowledgeConcludeReceived(defaults);
-const waitForDefund = states.waitForDefund({ ...defaults, defundingState: preSuccessState });
-const waitForDefund2 = states.waitForDefund({ ...defaults, defundingState: preFailureState });
-const acknowledgeSuccess = states.acknowledgeSuccess(defaults);
+const approveConcluding = states.instigatorApproveConcluding(defaults);
+const waitForOpponentConclude = states.instigatorWaitForOpponentConclude(defaults);
+const acknowledgeConcludeReceived = states.instigatorAcknowledgeConcludeReceived(defaults);
+const waitForDefund = states.instigatorWaitForDefund({
+  ...defaults,
+  defundingState: preSuccessState,
+});
+const waitForDefund2 = states.instigatorWaitForDefund({
+  ...defaults,
+  defundingState: preFailureState,
+});
+const acknowledgeSuccess = states.instigatorAcknowledgeSuccess(defaults);
 const success = states.success();
 
 // -------
@@ -94,7 +100,10 @@ export const channelDoesntExist = {
   ...defaults,
   storage: storage(ourTurn),
   states: {
-    acknowledgeFailure: states.acknowledgeFailure({ ...defaults, reason: 'ChannelDoesntExist' }),
+    acknowledgeFailure: states.instigatorAcknowledgeFailure({
+      ...defaults,
+      reason: 'ChannelDoesntExist',
+    }),
     failure: states.failure({ reason: 'ChannelDoesntExist' }),
   },
   actions: {
@@ -106,7 +115,7 @@ export const concludingNotPossible = {
   ...defaults,
   storage: storage(theirTurn),
   states: {
-    acknowledgeFailure: states.acknowledgeFailure({ ...defaults, reason: 'NotYourTurn' }),
+    acknowledgeFailure: states.instigatorAcknowledgeFailure({ ...defaults, reason: 'NotYourTurn' }),
     failure: states.failure({ reason: 'NotYourTurn' }),
   },
   actions: {
@@ -132,7 +141,7 @@ export const defundingFailed = {
   storage: storage(ourTurn),
   states: {
     waitForDefund2,
-    acknowledgeFailure: states.acknowledgeFailure({
+    acknowledgeFailure: states.instigatorAcknowledgeFailure({
       ...defaults,
       reason: 'DefundFailed',
     }),

--- a/packages/wallet/src/redux/protocols/concluding/instigator/__tests__/stories.tsx
+++ b/packages/wallet/src/redux/protocols/concluding/instigator/__tests__/stories.tsx
@@ -6,7 +6,6 @@ import { Concluding } from '..';
 import { fakeStore } from '../../../../../__stories__/index';
 import StatusBarLayout from '../../../../../components/status-bar-layout';
 import * as scenarios from './scenarios';
-import { isTerminal } from '../../../responding/state';
 
 const render = container => () => {
   // todo: rework this modal stuff
@@ -27,11 +26,14 @@ const render = container => () => {
 // Convention is to add all scenarios here, and allow the
 // addStories function to govern what ends up being shown.
 addStories(scenarios.happyPath, 'Concluding / Instigator / Happy Path');
+addStories(scenarios.channelDoesntExist, 'Concluding / Instigator / Channel doesnt exist');
+addStories(scenarios.concludingNotPossible, 'Concluding / Instigator / Concluding impossible');
+addStories(scenarios.defundFailed, 'Concluding / Instigator / Defund failed');
 
 function addStories(scenario, chapter) {
-  Object.keys(scenario.states).forEach(key => {
-    if (!isTerminal(scenario.states[key])) {
-      storiesOf(chapter, module).add(key, render(<Concluding state={scenario.states[key]} />));
+  Object.keys(scenario).forEach(key => {
+    if (scenario[key].state) {
+      storiesOf(chapter, module).add(key, render(<Concluding state={scenario[key].state} />));
     }
   });
 }

--- a/packages/wallet/src/redux/protocols/concluding/instigator/__tests__/stories.tsx
+++ b/packages/wallet/src/redux/protocols/concluding/instigator/__tests__/stories.tsx
@@ -27,9 +27,6 @@ const render = container => () => {
 // Convention is to add all scenarios here, and allow the
 // addStories function to govern what ends up being shown.
 addStories(scenarios.happyPath, 'Concluding / Instigator / Happy Path');
-addStories(scenarios.channelDoesntExist, 'Concluding / Instigator / Channel doesnt exist');
-addStories(scenarios.concludingNotPossible, 'Concluding / Instigator / Concluding impossible');
-addStories(scenarios.defundingFailed, 'Concluding / Instigator / Defund failed');
 
 function addStories(scenario, chapter) {
   Object.keys(scenario.states).forEach(key => {

--- a/packages/wallet/src/redux/protocols/concluding/instigator/actions.ts
+++ b/packages/wallet/src/redux/protocols/concluding/instigator/actions.ts
@@ -1,23 +1,19 @@
-import { WalletAction } from '../../../actions';
+import { WalletAction, CommitmentReceived, COMMITMENT_RECEIVED } from '../../../actions';
 
 export type ConcludingAction =
   | Cancelled
-  | ConcludeSent
-  | ConcludeReceived
+  | ConcludeApproved
+  | CommitmentReceived
   | DefundChosen
-  | Acknowledged;
+  | Acknowledged
+  | CommitmentReceived;
 export interface Cancelled {
   type: 'WALLET.CONCLUDING.INSTIGATOR.CONCLUDING_CANCELLED';
   processId: string;
 }
-
-export interface ConcludeSent {
-  type: 'WALLET.CONCLUDING.INSTIGATOR.CONCLUDE_SENT';
-  processId: string;
-}
-
-export interface ConcludeReceived {
-  type: 'WALLET.CONCLUDING.INSTIGATOR.CONCLUDE_RECEIVED';
+// TODO: This should probably be called ApproveConclude.
+export interface ConcludeApproved {
+  type: 'WALLET.CONCLUDING.INSTIGATOR.CONCLUDE_APPROVED';
   processId: string;
 }
 
@@ -40,13 +36,8 @@ export const cancelled = (processId: string): Cancelled => ({
   processId,
 });
 
-export const concludeSent = (processId: string): ConcludeSent => ({
-  type: 'WALLET.CONCLUDING.INSTIGATOR.CONCLUDE_SENT',
-  processId,
-});
-
-export const concludeReceived = (processId: string): ConcludeReceived => ({
-  type: 'WALLET.CONCLUDING.INSTIGATOR.CONCLUDE_RECEIVED',
+export const concludeApproved = (processId: string): ConcludeApproved => ({
+  type: 'WALLET.CONCLUDING.INSTIGATOR.CONCLUDE_APPROVED',
   processId,
 });
 
@@ -65,10 +56,12 @@ export const acknowledged = (processId: string): Acknowledged => ({
 // --------
 
 export const isConcludingAction = (action: WalletAction): action is ConcludingAction => {
+  if (action.type === COMMITMENT_RECEIVED) {
+    return true;
+  }
   return (
     action.type === 'WALLET.CONCLUDING.INSTIGATOR.CONCLUDING_CANCELLED' ||
-    action.type === 'WALLET.CONCLUDING.INSTIGATOR.CONCLUDE_SENT' ||
-    action.type === 'WALLET.CONCLUDING.INSTIGATOR.CONCLUDE_RECEIVED' ||
+    action.type === 'WALLET.CONCLUDING.INSTIGATOR.CONCLUDE_APPROVED' ||
     action.type === 'WALLET.CONCLUDING.INSTIGATOR.DEFUND_CHOSEN' ||
     action.type === 'WALLET.CONCLUDING.INSTIGATOR.ACKNOWLEDGED'
   );

--- a/packages/wallet/src/redux/protocols/concluding/instigator/container.tsx
+++ b/packages/wallet/src/redux/protocols/concluding/instigator/container.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { PureComponent } from 'react';
 import { connect } from 'react-redux';
-import { NonTerminalState as NonTerminalConcludingState } from './states';
+import { InstigatorNonTerminalState as NonTerminalConcludingState } from './states';
 import { unreachable } from '../../../../utils/reducer-utils';
 import ApproveConcluding from './components/approve-concluding';
 import ApproveDefunding from './components/approve-defunding';

--- a/packages/wallet/src/redux/protocols/concluding/instigator/container.tsx
+++ b/packages/wallet/src/redux/protocols/concluding/instigator/container.tsx
@@ -56,7 +56,7 @@ class ConcludingContainer extends PureComponent<Props> {
 }
 
 const mapDispatchToProps = {
-  approve: actions.concludeSent,
+  approve: actions.concludeApproved,
   deny: actions.cancelled,
   defund: actions.defundChosen,
   acknowledge: actions.acknowledged,

--- a/packages/wallet/src/redux/protocols/concluding/instigator/index.ts
+++ b/packages/wallet/src/redux/protocols/concluding/instigator/index.ts
@@ -1,2 +1,2 @@
 export { Concluding } from './container';
-export { initialize, concludingReducer as reducer } from './reducer';
+export { initialize, instigatorConcludingReducer as reducer } from './reducer';

--- a/packages/wallet/src/redux/protocols/concluding/instigator/readme.md
+++ b/packages/wallet/src/redux/protocols/concluding/instigator/readme.md
@@ -48,7 +48,7 @@ We will use the following scenarios for testing:
 1. **Happy path**: `InstigatorApproveConcluding` -> `InstigatorWaitForOpponentConclude` -> `InstigatorAcknowledgeChannelConcluded` -> `InstigatorWaitForDefund` -> `InstigatorAcknowledgeSuccess` -> `Success`
 2. **Channel doesnt exist** `InstigatorAcknowledgeFailure` -> `Failure`
 3. **Concluding not possible**: `InstigatorAcknowledgeFailure` -> `Failure`
-4. **Concluding cancelled** `InstigatorApproveConcluding` -> `Failure`
+4. **Concluding cancelled** `InstigatorApproveConcluding` -> `Failure` (note lack of acknowledgement screen)
 5. **Defund failed** `InstigatorWaitForDefund` -> `InstigatorAcknowledgeFailure` -> `Failure`
 
 # Terminology

--- a/packages/wallet/src/redux/protocols/concluding/instigator/readme.md
+++ b/packages/wallet/src/redux/protocols/concluding/instigator/readme.md
@@ -22,7 +22,7 @@ The protocol is implemented with the following state machine
 graph TD
   S((Start)) --> E{Channel Exists?}
   E --> |No| AF(InstigatorAcknowledgeFailure)
-  AF -->|ACKNOWLEDGED| F((InstigatorFailure))
+  AF -->|ACKNOWLEDGED| F((Failure))
   E --> |Yes| MT{My turn?}
   MT  --> |Yes| CC(InstigatorApproveConcluding)
   MT  --> |No| AF(InstigatorAcknowledgeFailure)
@@ -31,7 +31,7 @@ graph TD
   WOC --> |CONCLUDE.RECEIVED| ACR(InstigatorAcknowledgeConcludeReceived)
   ACR --> |DEFUND.CHOSEN| D(WInstigatorWaitForDefund)
   D   --> |defunding protocol succeeded| AS(InstigatorAcknowledgeSuccess)
-  AS -->  |ACKNOWLEDGED| SS((InstigatorSuccess))
+  AS -->  |ACKNOWLEDGED| SS((Success))
   D   --> |defunding protocol failed| AF(InstigatorAcknowledgeFailure)
   style S  fill:#efdd20
   style E  fill:#efdd20
@@ -45,11 +45,11 @@ graph TD
 
 We will use the following scenarios for testing:
 
-1. **Happy path**: `InstigatorApproveConcluding` -> `InstigatorWaitForOpponentConclude` -> `InstigatorAcknowledgeChannelConcluded` -> `InstigatorWaitForDefund` -> `InstigatorAcknowledgeSuccess` -> `InstigatorSuccess`
-2. **Channel doesnt exist** `InstigatorAcknowledgeFailure` -> `InstigatorFailure`
-3. **Concluding not possible**: `InstigatorAcknowledgeFailure` -> `InstigatorFailure`
-4. **Concluding cancelled** `InstigatorApproveConcluding` -> `InstigatorFailure`
-5. **Defund failed** `InstigatorWaitForDefund` -> `InstigatorAcknowledgeFailure` -> `InstigatorFailure`
+1. **Happy path**: `InstigatorApproveConcluding` -> `InstigatorWaitForOpponentConclude` -> `InstigatorAcknowledgeChannelConcluded` -> `InstigatorWaitForDefund` -> `InstigatorAcknowledgeSuccess` -> `Success`
+2. **Channel doesnt exist** `InstigatorAcknowledgeFailure` -> `Failure`
+3. **Concluding not possible**: `InstigatorAcknowledgeFailure` -> `Failure`
+4. **Concluding cancelled** `InstigatorApproveConcluding` -> `Failure`
+5. **Defund failed** `InstigatorWaitForDefund` -> `InstigatorAcknowledgeFailure` -> `Failure`
 
 # Terminology
 

--- a/packages/wallet/src/redux/protocols/concluding/instigator/reducer.ts
+++ b/packages/wallet/src/redux/protocols/concluding/instigator/reducer.ts
@@ -24,7 +24,7 @@ import * as selectors from '../../../selectors';
 import { showWallet } from '../../reducer-helpers';
 import { ProtocolAction } from '../../../../redux/actions';
 import { theirAddress } from '../../../channel-store';
-import { sendConcludeChannel } from '../../../../communication';
+import { sendConcludeInstigated } from '../../../../communication';
 
 export interface ReturnVal {
   state: CState;
@@ -178,12 +178,10 @@ const createAndSendConcludeCommitment = (
   const signResult = channelStoreReducer.signAndStore(sharedData.channelStore, commitment);
   if (signResult.isSuccess) {
     const sharedDataWithOwnCommitment = setChannelStore(sharedData, signResult.store);
-    const messageRelay = sendConcludeChannel(
+    const messageRelay = sendConcludeInstigated(
       theirAddress(channelState),
       processId,
-      signResult.signedCommitment.commitment,
-      signResult.signedCommitment.signature,
-      channelId,
+      signResult.signedCommitment,
     );
     return queueMessage(sharedDataWithOwnCommitment, messageRelay);
   } else {

--- a/packages/wallet/src/redux/protocols/concluding/instigator/states.ts
+++ b/packages/wallet/src/redux/protocols/concluding/instigator/states.ts
@@ -1,89 +1,64 @@
 import { Constructor } from '../../../utils';
 import { DefundingState } from '../../defunding';
-export type ConcludingState = NonTerminalState | PreTerminalState | TerminalState;
-export type ConcludingStateType = ConcludingState['type'];
+export type InstigatorConcludingState =
+  | InstigatorNonTerminalState
+  | InstigatorPreTerminalState
+  | TerminalState;
+export type InstigatorConcludingStateType = InstigatorConcludingState['type'];
 import { ProtocolState } from '../..';
+import { FailureReason, TerminalState } from '../state';
 
-export type NonTerminalState =
-  | ApproveConcluding
-  | WaitForOpponentConclude
-  | AcknowledgeConcludeReceived
-  | AcknowledgeFailure
-  | AcknowledgeSuccess
-  | WaitForDefund;
+export type InstigatorNonTerminalState =
+  | InstigatorApproveConcluding
+  | InstigatorWaitForOpponentConclude
+  | InstigatorAcknowledgeConcludeReceived
+  | InstigatorAcknowledgeFailure
+  | InstigatorAcknowledgeSuccess
+  | InstigatorWaitForDefund;
 
-export type PreTerminalState = AcknowledgeSuccess | AcknowledgeFailure;
+export type InstigatorPreTerminalState =
+  | InstigatorAcknowledgeSuccess
+  | InstigatorAcknowledgeFailure;
 
-export type TerminalState = Success | Failure;
-
-export type FailureReason =
-  | 'NotYourTurn'
-  | 'ChannelDoesntExist'
-  | 'ConcludeCancelled'
-  | 'DefundFailed';
-
-export interface AcknowledgeSuccess {
+export interface InstigatorAcknowledgeSuccess {
   type: 'InstigatorAcknowledgeSuccess';
   processId: string;
   channelId: string;
 }
-export interface AcknowledgeFailure {
+export interface InstigatorAcknowledgeFailure {
   type: 'InstigatorAcknowledgeFailure';
   reason: FailureReason;
   processId: string;
   channelId: string;
 }
-export interface ApproveConcluding {
+export interface InstigatorApproveConcluding {
   type: 'InstigatorApproveConcluding';
   processId: string;
   channelId: string;
 }
 
-export interface WaitForOpponentConclude {
+export interface InstigatorWaitForOpponentConclude {
   type: 'InstigatorWaitForOpponentConclude';
   processId: string;
   channelId: string;
 }
 
-export interface AcknowledgeConcludeReceived {
+export interface InstigatorAcknowledgeConcludeReceived {
   type: 'InstigatorAcknowledgeConcludeReceived';
   processId: string;
   channelId: string;
 }
 
-export interface WaitForDefund {
+export interface InstigatorWaitForDefund {
   type: 'InstigatorWaitForDefund';
   processId: string;
   channelId: string;
   defundingState: DefundingState;
 }
 
-export interface Failure {
-  type: 'InstigatorFailure';
-  reason: FailureReason;
-}
-
-export interface Success {
-  type: 'InstigatorSuccess';
-}
-
-// -------
-// Helpers
-// -------
-
-export function isTerminal(state: ConcludingState): state is Failure | Success {
-  return state.type === 'InstigatorFailure' || state.type === 'InstigatorSuccess';
-}
-
-export function isSuccess(state: ConcludingState): state is Success {
-  return state.type === 'InstigatorSuccess';
-}
-
-export function isFailure(state: ConcludingState): state is Failure {
-  return state.type === 'InstigatorFailure';
-}
-
-export function isConcludingInstigatorState(state: ProtocolState): state is ConcludingState {
+export function isConcludingInstigatorState(
+  state: ProtocolState,
+): state is InstigatorConcludingState {
   return (
     state.type === 'InstigatorAcknowledgeSuccess' ||
     state.type === 'InstigatorAcknowledgeFailure' ||
@@ -98,41 +73,36 @@ export function isConcludingInstigatorState(state: ProtocolState): state is Conc
 // Constructors
 // ------------
 
-export const approveConcluding: Constructor<ApproveConcluding> = p => {
+export const instigatorApproveConcluding: Constructor<InstigatorApproveConcluding> = p => {
   const { processId, channelId } = p;
   return { type: 'InstigatorApproveConcluding', processId, channelId };
 };
 
-export const waitForOpponentConclude: Constructor<WaitForOpponentConclude> = p => {
+export const instigatorWaitForOpponentConclude: Constructor<
+  InstigatorWaitForOpponentConclude
+> = p => {
   const { processId, channelId } = p;
   return { type: 'InstigatorWaitForOpponentConclude', processId, channelId };
 };
 
-export const acknowledgeConcludeReceived: Constructor<AcknowledgeConcludeReceived> = p => {
+export const instigatorAcknowledgeConcludeReceived: Constructor<
+  InstigatorAcknowledgeConcludeReceived
+> = p => {
   const { processId, channelId } = p;
   return { type: 'InstigatorAcknowledgeConcludeReceived', processId, channelId };
 };
 
-export const acknowledgeSuccess: Constructor<AcknowledgeSuccess> = p => {
+export const instigatorAcknowledgeSuccess: Constructor<InstigatorAcknowledgeSuccess> = p => {
   const { processId, channelId } = p;
   return { type: 'InstigatorAcknowledgeSuccess', processId, channelId };
 };
 
-export const acknowledgeFailure: Constructor<AcknowledgeFailure> = p => {
+export const instigatorAcknowledgeFailure: Constructor<InstigatorAcknowledgeFailure> = p => {
   const { processId, channelId, reason } = p;
   return { type: 'InstigatorAcknowledgeFailure', processId, channelId, reason };
 };
 
-export const waitForDefund: Constructor<WaitForDefund> = p => {
+export const instigatorWaitForDefund: Constructor<InstigatorWaitForDefund> = p => {
   const { processId, channelId, defundingState } = p;
   return { type: 'InstigatorWaitForDefund', processId, channelId, defundingState };
-};
-
-export function success(): Success {
-  return { type: 'InstigatorSuccess' };
-}
-
-export const failure: Constructor<Failure> = p => {
-  const { reason } = p;
-  return { type: 'InstigatorFailure', reason };
 };

--- a/packages/wallet/src/redux/protocols/concluding/reducer.ts
+++ b/packages/wallet/src/redux/protocols/concluding/reducer.ts
@@ -1,0 +1,22 @@
+import { ResponderNonTerminalState } from './responder/states';
+import { InstigatorNonTerminalState, isConcludingInstigatorState } from './instigator/states';
+import { SharedData } from '../../state';
+import { ProtocolAction } from '../../actions';
+import { ConcludingState } from './state';
+import { instigatorConcludingReducer } from './instigator/reducer';
+import { responderConcludingReducer } from './responder/reducer';
+import { ProtocolStateWithSharedData } from '..';
+
+export function concludingReducer(
+  state: ResponderNonTerminalState | InstigatorNonTerminalState,
+  storage: SharedData,
+  action: ProtocolAction,
+): ProtocolStateWithSharedData<ConcludingState> {
+  if (isConcludingInstigatorState(state)) {
+    const result = instigatorConcludingReducer(state, storage, action);
+    return { protocolState: result.state, sharedData: result.storage };
+  } else {
+    const result = responderConcludingReducer(state, storage, action);
+    return { protocolState: result.state, sharedData: result.storage };
+  }
+}

--- a/packages/wallet/src/redux/protocols/concluding/reducer.ts
+++ b/packages/wallet/src/redux/protocols/concluding/reducer.ts
@@ -3,9 +3,13 @@ import { InstigatorNonTerminalState, isConcludingInstigatorState } from './insti
 import { SharedData } from '../../state';
 import { ProtocolAction } from '../../actions';
 import { ConcludingState } from './state';
-import { instigatorConcludingReducer } from './instigator/reducer';
-import { responderConcludingReducer } from './responder/reducer';
+import {
+  instigatorConcludingReducer,
+  initialize as initializeInstigator,
+} from './instigator/reducer';
+import { responderConcludingReducer, initialize as initializeResponder } from './responder/reducer';
 import { ProtocolStateWithSharedData } from '..';
+import { SignedCommitment } from '../../../domain';
 
 export function concludingReducer(
   state: ResponderNonTerminalState | InstigatorNonTerminalState,
@@ -19,4 +23,22 @@ export function concludingReducer(
     const result = responderConcludingReducer(state, storage, action);
     return { protocolState: result.state, sharedData: result.storage };
   }
+}
+
+export function initializeInstigatorState(
+  channelId: string,
+  processId: string,
+  sharedData: SharedData,
+) {
+  const result = initializeInstigator(channelId, processId, sharedData);
+  return { protocolState: result.state, sharedData: result.storage };
+}
+
+export function initializeResponderState(
+  signedCommitment: SignedCommitment,
+  processId: string,
+  sharedData: SharedData,
+) {
+  const result = initializeResponder(signedCommitment, processId, sharedData);
+  return { protocolState: result.state, sharedData: result.storage };
 }

--- a/packages/wallet/src/redux/protocols/concluding/responder/__tests__/reducer.test.ts
+++ b/packages/wallet/src/redux/protocols/concluding/responder/__tests__/reducer.test.ts
@@ -29,7 +29,7 @@ describe('[ Happy path ]', () => {
   });
 
   describe('when in WaitForDefund', () => {
-    const { state, store, action } = scenario.decideDefund;
+    const { state, store, action } = scenario.waitForDefund;
     const result = responderConcludingReducer(state, store, action);
 
     itTransitionsTo(result, 'ResponderAcknowledgeSuccess');

--- a/packages/wallet/src/redux/protocols/concluding/responder/__tests__/reducer.test.ts
+++ b/packages/wallet/src/redux/protocols/concluding/responder/__tests__/reducer.test.ts
@@ -2,109 +2,48 @@ import * as scenarios from './scenarios';
 import { responderConcludingReducer, initialize, ReturnVal } from '../reducer';
 import { ResponderConcludingStateType } from '../states';
 import { expectThisCommitmentSent } from '../../../../__tests__/helpers';
-import { FailureReason } from '../../state';
 
 describe('[ Happy path ]', () => {
   const scenario = scenarios.happyPath;
-  const { channelId, processId, storage } = scenario;
+  const { processId } = scenario;
 
   describe('when initializing', () => {
-    const result = initialize(channelId, processId, storage);
+    const { commitment, store } = scenario.initialize;
+    const result = initialize(commitment, processId, store);
 
     itTransitionsTo(result, 'ResponderApproveConcluding');
   });
   describe('when in ApproveConcluding', () => {
-    const state = scenario.states.approveConcluding;
-    const action = scenario.actions.concludeSent;
-    const result = responderConcludingReducer(state, storage, action);
+    const { state, store, action, reply } = scenario.approveConcluding;
+    const result = responderConcludingReducer(state, store, action);
 
-    expectThisCommitmentSent(result.storage, scenario.commitments.concludeCommitment);
+    expectThisCommitmentSent(result.storage, reply);
     itTransitionsTo(result, 'ResponderDecideDefund');
   });
 
   describe('when in DecideDefund', () => {
-    const state = scenario.states.decideDefund;
-    const action = scenario.actions.defundChosen;
-    const result = responderConcludingReducer(state, storage, action);
+    const { state, store, action } = scenario.decideDefund;
+    const result = responderConcludingReducer(state, store, action);
 
     itTransitionsTo(result, 'ResponderWaitForDefund');
   });
 
   describe('when in WaitForDefund', () => {
-    const state = scenario.states.waitForDefund;
-    const action = scenario.actions.successTrigger;
-    const result = responderConcludingReducer(state, storage, action);
+    const { state, store, action } = scenario.decideDefund;
+    const result = responderConcludingReducer(state, store, action);
 
     itTransitionsTo(result, 'ResponderAcknowledgeSuccess');
   });
 
   describe('when in AcknowledgeSuccess', () => {
-    const state = scenario.states.acknowledgeSuccess;
-    const action = scenario.actions.acknowledged;
-    const result = responderConcludingReducer(state, storage, action);
+    const { state, store, action } = scenario.acknowledgeSuccess;
+    const result = responderConcludingReducer(state, store, action);
 
     itTransitionsTo(result, 'Success');
   });
 });
 
-describe('[ Channel doesnt exist ]', () => {
-  const scenario = scenarios.channelDoesntExist;
-  const { processId, storage } = scenario;
-
-  describe('when initializing', () => {
-    const result = initialize(scenario.initialProps.commitment, processId, storage);
-
-    itTransitionsToAcknowledgeFailure(result, 'ChannelDoesntExist');
-  });
-
-  describe('when in AcknowledgeFailure', () => {
-    const state = scenario.states.acknowledgeFailure;
-    const action = scenario.actions.acknowledged;
-    const result = responderConcludingReducer(state, storage, action);
-
-    itTransitionsToFailure(result, 'ChannelDoesntExist');
-  });
-});
-
-describe('[ Concluding Not Possible ]', () => {
-  const scenario = scenarios.concludingNotPossible;
-  const { channelId, processId, storage } = scenario;
-
-  describe('when initializing', () => {
-    const result = initialize(channelId, processId, storage);
-
-    itTransitionsToAcknowledgeFailure(result, 'NotYourTurn');
-  });
-
-  describe('when in AcknowledgeFailure', () => {
-    const state = scenario.states.acknowledgeFailure;
-    const action = scenario.actions.acknowledged;
-    const result = responderConcludingReducer(state, storage, action);
-
-    itTransitionsToFailure(result, 'NotYourTurn');
-  });
-});
-
-describe('[ Defunding Failed ]', () => {
-  const scenario = scenarios.defundingFailed;
-  const { storage } = scenario;
-
-  describe('when in WaitForDefund', () => {
-    const state = scenario.states.waitForDefund2;
-    const action = scenario.actions.failureTrigger;
-    const result = responderConcludingReducer(state, storage, action);
-
-    itTransitionsToAcknowledgeFailure(result, 'DefundFailed');
-  });
-
-  describe('when in AcknowledgeFailure', () => {
-    const state = scenario.states.acknowledgeFailure;
-    const action = scenario.actions.acknowledged;
-    const result = responderConcludingReducer(state, storage, action);
-
-    itTransitionsToFailure(result, 'DefundFailed');
-  });
-});
+// TODO: Unhappy paths
 
 function itTransitionsTo(result: ReturnVal, type: ResponderConcludingStateType) {
   it(`transitions to ${type}`, () => {
@@ -112,20 +51,20 @@ function itTransitionsTo(result: ReturnVal, type: ResponderConcludingStateType) 
   });
 }
 
-function itTransitionsToFailure(result: ReturnVal, reason: FailureReason) {
-  it(`transitions to Failure with reason ${reason}`, () => {
-    expect(result.state.type).toEqual('Failure');
-    if (result.state.type === 'Failure') {
-      expect(result.state.reason).toEqual(reason);
-    }
-  });
-}
+// function itTransitionsToFailure(result: ReturnVal, reason: FailureReason) {
+//   it(`transitions to Failure with reason ${reason}`, () => {
+//     expect(result.state.type).toEqual('Failure');
+//     if (result.state.type === 'Failure') {
+//       expect(result.state.reason).toEqual(reason);
+//     }
+//   });
+// }
 
-function itTransitionsToAcknowledgeFailure(result: ReturnVal, reason: FailureReason) {
-  it(`transitions to AcknowledgeFailure with reason ${reason}`, () => {
-    expect(result.state.type).toEqual('ResponderAcknowledgeFailure');
-    if (result.state.type === 'ResponderAcknowledgeFailure') {
-      expect(result.state.reason).toEqual(reason);
-    }
-  });
-}
+// function itTransitionsToAcknowledgeFailure(result: ReturnVal, reason: FailureReason) {
+//   it(`transitions to AcknowledgeFailure with reason ${reason}`, () => {
+//     expect(result.state.type).toEqual('ResponderAcknowledgeFailure');
+//     if (result.state.type === 'ResponderAcknowledgeFailure') {
+//       expect(result.state.reason).toEqual(reason);
+//     }
+//   });
+// }

--- a/packages/wallet/src/redux/protocols/concluding/responder/__tests__/reducer.test.ts
+++ b/packages/wallet/src/redux/protocols/concluding/responder/__tests__/reducer.test.ts
@@ -51,7 +51,7 @@ describe('[ Channel doesnt exist ]', () => {
   const { processId, storage } = scenario;
 
   describe('when initializing', () => {
-    const result = initialize('NotInitializedChannelId', processId, storage);
+    const result = initialize(scenario.initialProps.commitment, processId, storage);
 
     itTransitionsToAcknowledgeFailure(result, 'ChannelDoesntExist');
   });

--- a/packages/wallet/src/redux/protocols/concluding/responder/__tests__/reducer.test.ts
+++ b/packages/wallet/src/redux/protocols/concluding/responder/__tests__/reducer.test.ts
@@ -1,7 +1,8 @@
 import * as scenarios from './scenarios';
-import { concludingReducer, initialize, ReturnVal } from '../reducer';
-import { ConcludingStateType, FailureReason } from '../states';
+import { responderConcludingReducer, initialize, ReturnVal } from '../reducer';
+import { ResponderConcludingStateType } from '../states';
 import { expectThisCommitmentSent } from '../../../../__tests__/helpers';
+import { FailureReason } from '../../state';
 
 describe('[ Happy path ]', () => {
   const scenario = scenarios.happyPath;
@@ -15,7 +16,7 @@ describe('[ Happy path ]', () => {
   describe('when in ApproveConcluding', () => {
     const state = scenario.states.approveConcluding;
     const action = scenario.actions.concludeSent;
-    const result = concludingReducer(state, storage, action);
+    const result = responderConcludingReducer(state, storage, action);
 
     expectThisCommitmentSent(result.storage, scenario.commitments.concludeCommitment);
     itTransitionsTo(result, 'ResponderDecideDefund');
@@ -24,7 +25,7 @@ describe('[ Happy path ]', () => {
   describe('when in DecideDefund', () => {
     const state = scenario.states.decideDefund;
     const action = scenario.actions.defundChosen;
-    const result = concludingReducer(state, storage, action);
+    const result = responderConcludingReducer(state, storage, action);
 
     itTransitionsTo(result, 'ResponderWaitForDefund');
   });
@@ -32,7 +33,7 @@ describe('[ Happy path ]', () => {
   describe('when in WaitForDefund', () => {
     const state = scenario.states.waitForDefund;
     const action = scenario.actions.successTrigger;
-    const result = concludingReducer(state, storage, action);
+    const result = responderConcludingReducer(state, storage, action);
 
     itTransitionsTo(result, 'ResponderAcknowledgeSuccess');
   });
@@ -40,9 +41,9 @@ describe('[ Happy path ]', () => {
   describe('when in AcknowledgeSuccess', () => {
     const state = scenario.states.acknowledgeSuccess;
     const action = scenario.actions.acknowledged;
-    const result = concludingReducer(state, storage, action);
+    const result = responderConcludingReducer(state, storage, action);
 
-    itTransitionsTo(result, 'ResponderSuccess');
+    itTransitionsTo(result, 'Success');
   });
 });
 
@@ -59,7 +60,7 @@ describe('[ Channel doesnt exist ]', () => {
   describe('when in AcknowledgeFailure', () => {
     const state = scenario.states.acknowledgeFailure;
     const action = scenario.actions.acknowledged;
-    const result = concludingReducer(state, storage, action);
+    const result = responderConcludingReducer(state, storage, action);
 
     itTransitionsToFailure(result, 'ChannelDoesntExist');
   });
@@ -78,7 +79,7 @@ describe('[ Concluding Not Possible ]', () => {
   describe('when in AcknowledgeFailure', () => {
     const state = scenario.states.acknowledgeFailure;
     const action = scenario.actions.acknowledged;
-    const result = concludingReducer(state, storage, action);
+    const result = responderConcludingReducer(state, storage, action);
 
     itTransitionsToFailure(result, 'NotYourTurn');
   });
@@ -91,7 +92,7 @@ describe('[ Defunding Failed ]', () => {
   describe('when in WaitForDefund', () => {
     const state = scenario.states.waitForDefund2;
     const action = scenario.actions.failureTrigger;
-    const result = concludingReducer(state, storage, action);
+    const result = responderConcludingReducer(state, storage, action);
 
     itTransitionsToAcknowledgeFailure(result, 'DefundFailed');
   });
@@ -99,13 +100,13 @@ describe('[ Defunding Failed ]', () => {
   describe('when in AcknowledgeFailure', () => {
     const state = scenario.states.acknowledgeFailure;
     const action = scenario.actions.acknowledged;
-    const result = concludingReducer(state, storage, action);
+    const result = responderConcludingReducer(state, storage, action);
 
     itTransitionsToFailure(result, 'DefundFailed');
   });
 });
 
-function itTransitionsTo(result: ReturnVal, type: ConcludingStateType) {
+function itTransitionsTo(result: ReturnVal, type: ResponderConcludingStateType) {
   it(`transitions to ${type}`, () => {
     expect(result.state.type).toEqual(type);
   });
@@ -114,7 +115,7 @@ function itTransitionsTo(result: ReturnVal, type: ConcludingStateType) {
 function itTransitionsToFailure(result: ReturnVal, reason: FailureReason) {
   it(`transitions to Failure with reason ${reason}`, () => {
     expect(result.state.type).toEqual('Failure');
-    if (result.state.type === 'ResponderFailure') {
+    if (result.state.type === 'Failure') {
       expect(result.state.reason).toEqual(reason);
     }
   });
@@ -122,7 +123,7 @@ function itTransitionsToFailure(result: ReturnVal, reason: FailureReason) {
 
 function itTransitionsToAcknowledgeFailure(result: ReturnVal, reason: FailureReason) {
   it(`transitions to AcknowledgeFailure with reason ${reason}`, () => {
-    expect(result.state.type).toEqual('AcknowledgeFailure');
+    expect(result.state.type).toEqual('ResponderAcknowledgeFailure');
     if (result.state.type === 'ResponderAcknowledgeFailure') {
       expect(result.state.reason).toEqual(reason);
     }

--- a/packages/wallet/src/redux/protocols/concluding/responder/__tests__/reducer.test.ts
+++ b/packages/wallet/src/redux/protocols/concluding/responder/__tests__/reducer.test.ts
@@ -2,6 +2,7 @@ import * as scenarios from './scenarios';
 import { responderConcludingReducer, initialize, ReturnVal } from '../reducer';
 import { ResponderConcludingStateType } from '../states';
 import { expectThisCommitmentSent } from '../../../../__tests__/helpers';
+import { FailureReason } from '../../state';
 
 describe('[ Happy path ]', () => {
   const scenario = scenarios.happyPath;
@@ -43,7 +44,61 @@ describe('[ Happy path ]', () => {
   });
 });
 
-// TODO: Unhappy paths
+describe('[ Channel doesnt exist ]', () => {
+  const scenario = scenarios.channelDoesntExist;
+  const { processId } = scenario;
+
+  describe('when initializing', () => {
+    const { commitment, store } = scenario.initialize;
+    const result = initialize(commitment, processId, store);
+
+    itTransitionsToAcknowledgeFailure(result, 'ChannelDoesntExist');
+  });
+
+  describe('when in AcknowledgeFailure', () => {
+    const { state, action, store } = scenario.acknowledgeFailure;
+    const result = responderConcludingReducer(state, store, action);
+
+    itTransitionsToFailure(result, 'ChannelDoesntExist');
+  });
+});
+
+describe('[ Concluding Not Possible ]', () => {
+  const scenario = scenarios.concludingNotPossible;
+  const { processId } = scenario;
+
+  describe('when initializing', () => {
+    const { commitment, store } = scenario.initialize;
+    const result = initialize(commitment, processId, store);
+
+    itTransitionsToAcknowledgeFailure(result, 'NotYourTurn');
+  });
+
+  describe('when in AcknowledgeFailure', () => {
+    const { state, action, store } = scenario.acknowledgeFailure;
+    const result = responderConcludingReducer(state, store, action);
+
+    itTransitionsToFailure(result, 'NotYourTurn');
+  });
+});
+
+describe('[ Defund failed ]', () => {
+  const scenario = scenarios.defundFailed;
+
+  describe('when in WaitForDefund', () => {
+    const { state, action, store } = scenario.waitForDefund;
+    const result = responderConcludingReducer(state, store, action);
+
+    itTransitionsToAcknowledgeFailure(result, 'DefundFailed');
+  });
+
+  describe('when in AcknowledgeFailure', () => {
+    const { state, action, store } = scenario.acknowledgeFailure;
+    const result = responderConcludingReducer(state, store, action);
+
+    itTransitionsToFailure(result, 'DefundFailed');
+  });
+});
 
 function itTransitionsTo(result: ReturnVal, type: ResponderConcludingStateType) {
   it(`transitions to ${type}`, () => {
@@ -51,20 +106,20 @@ function itTransitionsTo(result: ReturnVal, type: ResponderConcludingStateType) 
   });
 }
 
-// function itTransitionsToFailure(result: ReturnVal, reason: FailureReason) {
-//   it(`transitions to Failure with reason ${reason}`, () => {
-//     expect(result.state.type).toEqual('Failure');
-//     if (result.state.type === 'Failure') {
-//       expect(result.state.reason).toEqual(reason);
-//     }
-//   });
-// }
+function itTransitionsToFailure(result: ReturnVal, reason: FailureReason) {
+  it(`transitions to Failure with reason ${reason}`, () => {
+    expect(result.state.type).toEqual('Failure');
+    if (result.state.type === 'Failure') {
+      expect(result.state.reason).toEqual(reason);
+    }
+  });
+}
 
-// function itTransitionsToAcknowledgeFailure(result: ReturnVal, reason: FailureReason) {
-//   it(`transitions to AcknowledgeFailure with reason ${reason}`, () => {
-//     expect(result.state.type).toEqual('ResponderAcknowledgeFailure');
-//     if (result.state.type === 'ResponderAcknowledgeFailure') {
-//       expect(result.state.reason).toEqual(reason);
-//     }
-//   });
-// }
+function itTransitionsToAcknowledgeFailure(result: ReturnVal, reason: FailureReason) {
+  it(`transitions to AcknowledgeFailure with reason ${reason}`, () => {
+    expect(result.state.type).toEqual('ResponderAcknowledgeFailure');
+    if (result.state.type === 'ResponderAcknowledgeFailure') {
+      expect(result.state.reason).toEqual(reason);
+    }
+  });
+}

--- a/packages/wallet/src/redux/protocols/concluding/responder/__tests__/scenarios.ts
+++ b/packages/wallet/src/redux/protocols/concluding/responder/__tests__/scenarios.ts
@@ -1,4 +1,5 @@
-import * as states from '../states';
+import * as states from '../../state';
+
 import {
   preSuccessState,
   preFailureState,
@@ -8,14 +9,14 @@ import {
 import * as actions from '../actions';
 import * as channelScenarios from '../../../../__tests__/test-scenarios';
 import { CommitmentType, Commitment } from 'fmg-core';
+import { ChannelState } from '../../../../channel-store';
+import { setChannel, EMPTY_SHARED_DATA } from '../../../../state';
+import { channelFromCommitments } from '../../../../channel-store/channel-state/__tests__';
 
 // -----------------
 // Channel Scenarios
 // -----------------
 const { channelId, bsAddress: address, bsPrivateKey: privateKey } = channelScenarios;
-import { ChannelState } from '../../../../channel-store';
-import { setChannel, EMPTY_SHARED_DATA } from '../../../../state';
-import { channelFromCommitments } from '../../../../channel-store/channel-state/__tests__';
 
 const { signedCommitment20, signedCommitment21, signedCommitment22 } = channelScenarios;
 const theirTurn = channelFromCommitments(
@@ -46,11 +47,17 @@ const defaults = { processId, channelId };
 // ------
 // States
 // ------
-const approveConcluding = states.approveConcluding(defaults);
-const decideDefund = states.decideDefund(defaults);
-const waitForDefund = states.waitForDefund({ ...defaults, defundingState: preSuccessState });
-const waitForDefund2 = states.waitForDefund({ ...defaults, defundingState: preFailureState });
-const acknowledgeSuccess = states.acknowledgeSuccess(defaults);
+const approveConcluding = states.responderApproveConcluding(defaults);
+const decideDefund = states.responderDecideDefund(defaults);
+const waitForDefund = states.responderWaitForDefund({
+  ...defaults,
+  defundingState: preSuccessState,
+});
+const waitForDefund2 = states.responderWaitForDefund({
+  ...defaults,
+  defundingState: preFailureState,
+});
+const acknowledgeSuccess = states.responderAcknowledgeSuccess(defaults);
 const success = states.success();
 
 // -------
@@ -92,7 +99,10 @@ export const channelDoesntExist = {
   },
   storage: storage(ourTurn),
   states: {
-    acknowledgeFailure: states.acknowledgeFailure({ ...defaults, reason: 'ChannelDoesntExist' }),
+    acknowledgeFailure: states.responderAcknowledgeFailure({
+      ...defaults,
+      reason: 'ChannelDoesntExist',
+    }),
     failure: states.failure({ reason: 'ChannelDoesntExist' }),
   },
   actions: {
@@ -104,7 +114,7 @@ export const concludingNotPossible = {
   ...defaults,
   storage: storage(theirTurn),
   states: {
-    acknowledgeFailure: states.acknowledgeFailure({ ...defaults, reason: 'NotYourTurn' }),
+    acknowledgeFailure: states.responderAcknowledgeFailure({ ...defaults, reason: 'NotYourTurn' }),
     failure: states.failure({ reason: 'NotYourTurn' }),
   },
   actions: {
@@ -118,7 +128,7 @@ export const defundingFailed = {
   storage: storage(ourTurn),
   states: {
     waitForDefund2,
-    acknowledgeFailure: states.acknowledgeFailure({
+    acknowledgeFailure: states.responderAcknowledgeFailure({
       ...defaults,
       reason: 'DefundFailed',
     }),

--- a/packages/wallet/src/redux/protocols/concluding/responder/__tests__/scenarios.ts
+++ b/packages/wallet/src/redux/protocols/concluding/responder/__tests__/scenarios.ts
@@ -61,7 +61,7 @@ const acknowledgeSuccess = states.responderAcknowledgeSuccess(defaults);
 // -------
 // Actions
 // -------
-const concludeSent = actions.concludeSent(processId);
+const concludeSent = actions.concludeApproved(processId);
 const defundChosen = actions.defundChosen(processId);
 const acknowledged = actions.acknowledged(processId);
 

--- a/packages/wallet/src/redux/protocols/concluding/responder/__tests__/scenarios.ts
+++ b/packages/wallet/src/redux/protocols/concluding/responder/__tests__/scenarios.ts
@@ -87,6 +87,9 @@ export const happyPath = {
 
 export const channelDoesntExist = {
   ...defaults,
+  initialProps: {
+    commitment: signedCommitment20,
+  },
   storage: storage(ourTurn),
   states: {
     acknowledgeFailure: states.acknowledgeFailure({ ...defaults, reason: 'ChannelDoesntExist' }),

--- a/packages/wallet/src/redux/protocols/concluding/responder/__tests__/scenarios.ts
+++ b/packages/wallet/src/redux/protocols/concluding/responder/__tests__/scenarios.ts
@@ -11,7 +11,7 @@ import { bsPrivateKey } from '../../../../../communication/__tests__/commitments
 // -----------------
 // Channel Scenarios
 // -----------------
-const { channelId, bsAddress, asAddress, ledgerId } = channelScenarios;
+const { channelId, bsAddress, asAddress } = channelScenarios;
 
 const twoThree = [
   { address: asAddress, wei: bigNumberify(2).toHexString() },
@@ -34,12 +34,10 @@ const secondConcludeReceivedChannelState = setChannels(EMPTY_SHARED_DATA, [
 ]);
 
 const firstConcludeReceived = setFundingState(firstConcludeReceivedChannelState, channelId, {
-  directlyFunded: false,
-  fundingChannel: ledgerId,
+  directlyFunded: true,
 });
 const secondConcludeReceived = setFundingState(secondConcludeReceivedChannelState, channelId, {
-  directlyFunded: false,
-  fundingChannel: ledgerId,
+  directlyFunded: true,
 });
 // --------
 // Defaults

--- a/packages/wallet/src/redux/protocols/concluding/responder/__tests__/stories.tsx
+++ b/packages/wallet/src/redux/protocols/concluding/responder/__tests__/stories.tsx
@@ -27,9 +27,6 @@ const render = container => () => {
 // Convention is to add all scenarios here, and allow the
 // addStories function to govern what ends up being shown.
 addStories(scenarios.happyPath, 'Concluding / Responder / Happy Path');
-addStories(scenarios.channelDoesntExist, 'Concluding / Responder / Channel doesnt exist');
-addStories(scenarios.concludingNotPossible, 'Concluding / Responder / Concluding impossible');
-addStories(scenarios.defundingFailed, 'Concluding / Responder / Defund failed');
 
 function addStories(scenario, chapter) {
   Object.keys(scenario.states).forEach(key => {

--- a/packages/wallet/src/redux/protocols/concluding/responder/__tests__/stories.tsx
+++ b/packages/wallet/src/redux/protocols/concluding/responder/__tests__/stories.tsx
@@ -6,7 +6,6 @@ import { Concluding } from '..';
 import { fakeStore } from '../../../../../__stories__/index';
 import StatusBarLayout from '../../../../../components/status-bar-layout';
 import * as scenarios from './scenarios';
-import { isTerminal } from '../../../responding/state';
 
 const render = container => () => {
   // todo: rework this modal stuff
@@ -27,11 +26,14 @@ const render = container => () => {
 // Convention is to add all scenarios here, and allow the
 // addStories function to govern what ends up being shown.
 addStories(scenarios.happyPath, 'Concluding / Responder / Happy Path');
+addStories(scenarios.channelDoesntExist, 'Concluding / Responder / Channel doesnt exist');
+addStories(scenarios.concludingNotPossible, 'Concluding / Responder / Concluding impossible');
+addStories(scenarios.defundFailed, 'Concluding / Responder / Defund failed');
 
 function addStories(scenario, chapter) {
-  Object.keys(scenario.states).forEach(key => {
-    if (!isTerminal(scenario.states[key])) {
-      storiesOf(chapter, module).add(key, render(<Concluding state={scenario.states[key]} />));
+  Object.keys(scenario).forEach(key => {
+    if (scenario[key].state) {
+      storiesOf(chapter, module).add(key, render(<Concluding state={scenario[key].state} />));
     }
   });
 }

--- a/packages/wallet/src/redux/protocols/concluding/responder/actions.ts
+++ b/packages/wallet/src/redux/protocols/concluding/responder/actions.ts
@@ -1,9 +1,9 @@
 import { WalletAction } from '../../../actions';
 
-export type ConcludingAction = ConcludeSent | DefundChosen | Acknowledged;
+export type ConcludingAction = ConcludeApproved | DefundChosen | Acknowledged;
 
-export interface ConcludeSent {
-  type: 'WALLET.CONCLUDING.RESPONDER.CONCLUDE_SENT';
+export interface ConcludeApproved {
+  type: 'WALLET.CONCLUDING.RESPONDER.CONCLUDE_APPROVED';
   processId: string;
 }
 
@@ -21,8 +21,8 @@ export interface Acknowledged {
 // Creators
 // --------
 
-export const concludeSent = (processId: string): ConcludeSent => ({
-  type: 'WALLET.CONCLUDING.RESPONDER.CONCLUDE_SENT',
+export const concludeApproved = (processId: string): ConcludeApproved => ({
+  type: 'WALLET.CONCLUDING.RESPONDER.CONCLUDE_APPROVED',
   processId,
 });
 
@@ -42,7 +42,7 @@ export const acknowledged = (processId: string): Acknowledged => ({
 
 export const isConcludingAction = (action: WalletAction): action is ConcludingAction => {
   return (
-    action.type === 'WALLET.CONCLUDING.RESPONDER.CONCLUDE_SENT' ||
+    action.type === 'WALLET.CONCLUDING.RESPONDER.CONCLUDE_APPROVED' ||
     action.type === 'WALLET.CONCLUDING.RESPONDER.DEFUND_CHOSEN' ||
     action.type === 'WALLET.CONCLUDING.RESPONDER.ACKNOWLEDGED'
   );

--- a/packages/wallet/src/redux/protocols/concluding/responder/container.tsx
+++ b/packages/wallet/src/redux/protocols/concluding/responder/container.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { PureComponent } from 'react';
 import { connect } from 'react-redux';
-import { NonTerminalState as NonTerminalConcludingState } from './states';
+import { ResponderNonTerminalState as NonTerminalConcludingState } from './states';
 import { unreachable } from '../../../../utils/reducer-utils';
 import ApproveConcluding from './components/approve-concluding';
 import ApproveDefunding from './components/approve-defunding';

--- a/packages/wallet/src/redux/protocols/concluding/responder/container.tsx
+++ b/packages/wallet/src/redux/protocols/concluding/responder/container.tsx
@@ -50,7 +50,7 @@ class ConcludingContainer extends PureComponent<Props> {
 }
 
 const mapDispatchToProps = {
-  approve: actions.concludeSent,
+  approve: actions.concludeApproved,
   defund: actions.defundChosen,
   acknowledge: actions.acknowledged,
 };

--- a/packages/wallet/src/redux/protocols/concluding/responder/index.ts
+++ b/packages/wallet/src/redux/protocols/concluding/responder/index.ts
@@ -1,2 +1,2 @@
 export { Concluding } from './container';
-export { initialize, concludingReducer as reducer } from './reducer';
+export { initialize, responderConcludingReducer as reducer } from './reducer';

--- a/packages/wallet/src/redux/protocols/concluding/responder/reducer.ts
+++ b/packages/wallet/src/redux/protocols/concluding/responder/reducer.ts
@@ -51,8 +51,8 @@ export function responderConcludingReducer(
   }
 
   switch (action.type) {
-    case 'WALLET.CONCLUDING.RESPONDER.CONCLUDE_SENT':
-      return concludeSent(state, storage);
+    case 'WALLET.CONCLUDING.RESPONDER.CONCLUDE_APPROVED':
+      return concludeApproved(state, storage);
     case 'WALLET.CONCLUDING.RESPONDER.DEFUND_CHOSEN':
       return defundChosen(state, storage);
     case 'WALLET.CONCLUDING.RESPONDER.ACKNOWLEDGED':
@@ -117,7 +117,7 @@ function handleDefundingAction(
   return { state, storage };
 }
 
-function concludeSent(state: NonTerminalCState, storage: Storage): ReturnVal {
+function concludeApproved(state: NonTerminalCState, storage: Storage): ReturnVal {
   if (state.type !== 'ResponderApproveConcluding') {
     return { state, storage };
   }

--- a/packages/wallet/src/redux/protocols/concluding/responder/states.ts
+++ b/packages/wallet/src/redux/protocols/concluding/responder/states.ts
@@ -1,78 +1,55 @@
 import { Constructor } from '../../../utils';
 import { DefundingState } from '../../defunding';
-export type ConcludingState = NonTerminalState | PreTerminalState | TerminalState;
-export type ConcludingStateType = ConcludingState['type'];
+export type ResponderConcludingState =
+  | ResponderNonTerminalState
+  | ResponderPreTerminalState
+  | TerminalState;
+export type ResponderConcludingStateType = ResponderConcludingState['type'];
 import { ProtocolState } from '../..';
+import { TerminalState, FailureReason } from '../state';
 
-export type NonTerminalState =
-  | ApproveConcluding
-  | DecideDefund
-  | WaitForDefund
-  | AcknowledgeFailure
-  | AcknowledgeSuccess;
+export type ResponderNonTerminalState =
+  | ResponderApproveConcluding
+  | ResponderDecideDefund
+  | ResponderWaitForDefund
+  | ResponderAcknowledgeFailure
+  | ResponderAcknowledgeSuccess;
 
-export type PreTerminalState = AcknowledgeSuccess | AcknowledgeFailure;
+export type ResponderPreTerminalState = ResponderAcknowledgeSuccess | ResponderAcknowledgeFailure;
 
-export type TerminalState = Success | Failure;
-
-export type FailureReason = 'NotYourTurn' | 'ChannelDoesntExist' | 'DefundFailed';
-
-export interface AcknowledgeSuccess {
+export interface ResponderAcknowledgeSuccess {
   type: 'ResponderAcknowledgeSuccess';
   processId: string;
   channelId: string;
 }
-export interface AcknowledgeFailure {
+export interface ResponderAcknowledgeFailure {
   type: 'ResponderAcknowledgeFailure';
   reason: FailureReason;
   processId: string;
   channelId: string;
 }
-export interface ApproveConcluding {
+export interface ResponderApproveConcluding {
   type: 'ResponderApproveConcluding';
   processId: string;
   channelId: string;
 }
 
-export interface DecideDefund {
+export interface ResponderDecideDefund {
   type: 'ResponderDecideDefund';
   processId: string;
   channelId: string;
 }
 
-export interface WaitForDefund {
+export interface ResponderWaitForDefund {
   type: 'ResponderWaitForDefund';
   processId: string;
   channelId: string;
   defundingState: DefundingState;
 }
 
-export interface Failure {
-  type: 'ResponderFailure';
-  reason: FailureReason;
-}
-
-export interface Success {
-  type: 'ResponderSuccess';
-}
-
-// -------
-// Helpers
-// -------
-
-export function isTerminal(state: ConcludingState): state is Failure | Success {
-  return state.type === 'ResponderFailure' || state.type === 'ResponderSuccess';
-}
-
-export function isSuccess(state: ConcludingState): state is Success {
-  return state.type === 'ResponderSuccess';
-}
-
-export function isFailure(state: ConcludingState): state is Failure {
-  return state.type === 'ResponderFailure';
-}
-
-export function isConcludingResponderState(state: ProtocolState): state is ConcludingState {
+export function isConcludingResponderState(
+  state: ProtocolState,
+): state is ResponderConcludingState {
   return (
     state.type === 'ResponderAcknowledgeSuccess' ||
     state.type === 'ResponderAcknowledgeFailure' ||
@@ -86,36 +63,27 @@ export function isConcludingResponderState(state: ProtocolState): state is Concl
 // Constructors
 // ------------
 
-export const approveConcluding: Constructor<ApproveConcluding> = p => {
+export const responderApproveConcluding: Constructor<ResponderApproveConcluding> = p => {
   const { processId, channelId } = p;
   return { type: 'ResponderApproveConcluding', processId, channelId };
 };
 
-export const decideDefund: Constructor<DecideDefund> = p => {
+export const responderDecideDefund: Constructor<ResponderDecideDefund> = p => {
   const { processId, channelId } = p;
   return { type: 'ResponderDecideDefund', processId, channelId };
 };
 
-export const acknowledgeSuccess: Constructor<AcknowledgeSuccess> = p => {
+export const responderAcknowledgeSuccess: Constructor<ResponderAcknowledgeSuccess> = p => {
   const { processId, channelId } = p;
   return { type: 'ResponderAcknowledgeSuccess', processId, channelId };
 };
 
-export const acknowledgeFailure: Constructor<AcknowledgeFailure> = p => {
+export const responderAcknowledgeFailure: Constructor<ResponderAcknowledgeFailure> = p => {
   const { processId, channelId, reason } = p;
   return { type: 'ResponderAcknowledgeFailure', processId, channelId, reason };
 };
 
-export const waitForDefund: Constructor<WaitForDefund> = p => {
+export const responderWaitForDefund: Constructor<ResponderWaitForDefund> = p => {
   const { processId, channelId, defundingState } = p;
   return { type: 'ResponderWaitForDefund', processId, channelId, defundingState };
-};
-
-export function success(): Success {
-  return { type: 'ResponderSuccess' };
-}
-
-export const failure: Constructor<Failure> = p => {
-  const { reason } = p;
-  return { type: 'ResponderFailure', reason };
 };

--- a/packages/wallet/src/redux/protocols/concluding/state.ts
+++ b/packages/wallet/src/redux/protocols/concluding/state.ts
@@ -1,0 +1,55 @@
+import { InstigatorConcludingState, isConcludingInstigatorState } from './instigator/states';
+import { ResponderConcludingState, isConcludingResponderState } from './responder/states';
+import { Constructor } from '../../utils';
+import { ProtocolState } from '..';
+
+export * from './instigator/states';
+export * from './responder/states';
+
+export type ConcludingState = InstigatorConcludingState | ResponderConcludingState;
+
+export type TerminalState = Success | Failure;
+
+export type FailureReason =
+  | 'NotYourTurn'
+  | 'ChannelDoesntExist'
+  | 'ConcludeCancelled'
+  | 'DefundFailed';
+
+export interface Failure {
+  type: 'Failure';
+  reason: FailureReason;
+}
+
+export interface Success {
+  type: 'Success';
+}
+
+export function success(): Success {
+  return { type: 'Success' };
+}
+
+export const failure: Constructor<Failure> = p => {
+  const { reason } = p;
+  return { type: 'Failure', reason };
+};
+
+// -------
+// Helpers
+// -------
+
+export function isConcludingState(state: ProtocolState): state is ConcludingState {
+  return isConcludingInstigatorState(state) || isConcludingResponderState(state);
+}
+
+export function isTerminal(state: ConcludingState): state is Failure | Success {
+  return state.type === 'Failure' || state.type === 'Success';
+}
+
+export function isSuccess(state: ConcludingState): state is Success {
+  return state.type === 'Success';
+}
+
+export function isFailure(state: ConcludingState): state is Failure {
+  return state.type === 'Failure';
+}

--- a/packages/wallet/src/redux/protocols/container.tsx
+++ b/packages/wallet/src/redux/protocols/container.tsx
@@ -1,12 +1,10 @@
 import { PureComponent } from 'react';
 import { ProtocolState } from '.';
 import * as fundingStates from './funding/states';
-import * as concludingInstigatorStates from './concluding/instigator/states';
-import * as concludingResponderStates from './concluding/responder/states';
+import * as concludingStates from './concluding/state';
 import React from 'react';
 import { Funding } from './funding/container';
-import { Concluding as ConcludingInstigator } from './concluding/instigator/container';
-import { Concluding as ConcludingResponder } from './concluding/responder/container';
+import { Concluding } from './concluding/container';
 import { connect } from 'react-redux';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faSpinner } from '@fortawesome/free-solid-svg-icons';
@@ -23,26 +21,15 @@ class ProtocolContainer extends PureComponent<Props> {
     const { protocolState } = this.props;
     if (fundingStates.isFundingState(protocolState) && !fundingStates.isTerminal(protocolState)) {
       return <Funding state={protocolState} />;
+    } else if (concludingStates.isConcludingState(protocolState)) {
+      return <Concluding state={protocolState} />;
+    } else {
+      return (
+        <div>
+          <FontAwesomeIcon icon={faSpinner} pulse={true} size="lg" />
+        </div>
+      );
     }
-    if (
-      concludingInstigatorStates.isConcludingInstigatorState(protocolState) &&
-      !concludingInstigatorStates.isTerminal(protocolState)
-    ) {
-      return <ConcludingInstigator state={protocolState} />;
-    }
-
-    if (
-      concludingResponderStates.isConcludingResponderState(protocolState) &&
-      !concludingResponderStates.isTerminal(protocolState)
-    ) {
-      return <ConcludingResponder state={protocolState} />;
-    }
-    // TODO: We need a placeholder screen here when transitioning back to the app from a success state
-    return (
-      <div>
-        <FontAwesomeIcon icon={faSpinner} pulse={true} size="lg" />
-      </div>
-    );
   }
 }
 export const Protocol = connect(() => ({}))(ProtocolContainer);

--- a/packages/wallet/src/redux/protocols/defunding/__tests__/scenarios.ts
+++ b/packages/wallet/src/redux/protocols/defunding/__tests__/scenarios.ts
@@ -3,7 +3,7 @@ import * as withdrawalScenarios from '../../withdrawing/__tests__/scenarios';
 import * as testScenarios from '../../../__tests__/test-scenarios';
 import { ChannelState, ChannelStore } from '../../../channel-store';
 import { EMPTY_SHARED_DATA, FundingState } from '../../../state';
-
+import * as indirectDefundingStates from '../../indirect-defunding/state';
 const processId = 'process-id.123';
 
 const {
@@ -70,7 +70,7 @@ const waitForWithdrawalFailure = states.waitForWithdrawal({
 
 const waitForLedgerDefunding = states.waitForLedgerDefunding({
   processId,
-  ledgerDefundingState: 'Success',
+  indirectDefundingState: indirectDefundingStates.success(),
 });
 
 const success = states.success();

--- a/packages/wallet/src/redux/protocols/defunding/actions.ts
+++ b/packages/wallet/src/redux/protocols/defunding/actions.ts
@@ -1,20 +1,10 @@
 import { WalletAction } from '../../actions';
-import {
-  WithdrawalAction,
-  WITHDRAWAL_APPROVED,
-  WITHDRAWAL_REJECTED,
-  WITHDRAWAL_SUCCESS_ACKNOWLEDGED,
-} from '../withdrawing/actions';
-import { TransactionConfirmed, TRANSACTION_CONFIRMED } from '../transaction-submission/actions';
+import { WithdrawalAction, isWithdrawalAction } from '../withdrawing/actions';
+import { IndirectDefundingAction, isIndirectDefundingAction } from '../indirect-defunding/actions';
+
 // TODO: Replace once ledger defunding actions are defined
-type LedgerDefundingAction = TransactionConfirmed;
-export type DefundingAction = WithdrawalAction | LedgerDefundingAction;
+export type DefundingAction = WithdrawalAction | IndirectDefundingAction;
 
 export const isDefundingAction = (action: WalletAction): action is DefundingAction => {
-  return (
-    action.type === WITHDRAWAL_APPROVED ||
-    action.type === WITHDRAWAL_SUCCESS_ACKNOWLEDGED ||
-    action.type === WITHDRAWAL_REJECTED ||
-    action.type === TRANSACTION_CONFIRMED
-  );
+  return isWithdrawalAction(action) || isIndirectDefundingAction(action);
 };

--- a/packages/wallet/src/redux/protocols/defunding/container.tsx
+++ b/packages/wallet/src/redux/protocols/defunding/container.tsx
@@ -16,7 +16,7 @@ class DefundingContainer extends PureComponent<Props> {
     switch (state.type) {
       case states.WAIT_FOR_WITHDRAWAL:
         return <Withdrawal state={state.withdrawalState} />;
-      case states.WAIT_FOR_LEDGER_DEFUNDING:
+      case states.WAIT_FOR_INDIRECT_DEFUNDING:
         return <div>TODO: Ledger defunding container</div>;
       case states.FAILURE:
         return <Failure name="de-funding" reason={state.reason} />;

--- a/packages/wallet/src/redux/protocols/defunding/states.ts
+++ b/packages/wallet/src/redux/protocols/defunding/states.ts
@@ -1,13 +1,14 @@
 import { WithdrawalState } from '../withdrawing/states';
 import { Properties } from '../../utils';
+import { IndirectDefundingState } from '../indirect-defunding/state';
 
 export const WAIT_FOR_WITHDRAWAL = 'WaitForWithdrawal';
-export const WAIT_FOR_LEDGER_DEFUNDING = 'WaitForLedgerDefunding';
+export const WAIT_FOR_INDIRECT_DEFUNDING = 'WaitForIndirectDefunding';
 export const FAILURE = 'Failure';
 export const SUCCESS = 'Success';
 
-export type NonTerminalDefundingState = WaitForWithdrawal | WaitForLedgerDefunding;
-export type DefundingState = WaitForWithdrawal | WaitForLedgerDefunding | Failure | Success;
+export type NonTerminalDefundingState = WaitForWithdrawal | WaitForIndirectDefunding;
+export type DefundingState = WaitForWithdrawal | WaitForIndirectDefunding | Failure | Success;
 
 export type FailureReason =
   | 'Withdrawal Failure'
@@ -20,11 +21,10 @@ export interface WaitForWithdrawal {
   withdrawalState: WithdrawalState;
 }
 
-export interface WaitForLedgerDefunding {
-  type: typeof WAIT_FOR_LEDGER_DEFUNDING;
+export interface WaitForIndirectDefunding {
+  type: typeof WAIT_FOR_INDIRECT_DEFUNDING;
   processId: string;
-  // TODO: This will be typed to Ledger Defunding state when it exists
-  ledgerDefundingState: any;
+  indirectDefundingState: IndirectDefundingState;
 }
 
 export interface Failure {
@@ -62,10 +62,14 @@ export function waitForWithdrawal(properties: Properties<WaitForWithdrawal>): Wa
 }
 
 export function waitForLedgerDefunding(
-  properties: Properties<WaitForLedgerDefunding>,
-): WaitForLedgerDefunding {
-  const { processId, ledgerDefundingState } = properties;
-  return { type: WAIT_FOR_LEDGER_DEFUNDING, processId, ledgerDefundingState };
+  properties: Properties<WaitForIndirectDefunding>,
+): WaitForIndirectDefunding {
+  const { processId, indirectDefundingState: ledgerDefundingState } = properties;
+  return {
+    type: WAIT_FOR_INDIRECT_DEFUNDING,
+    processId,
+    indirectDefundingState: ledgerDefundingState,
+  };
 }
 
 export function success(): Success {

--- a/packages/wallet/src/redux/protocols/index.ts
+++ b/packages/wallet/src/redux/protocols/index.ts
@@ -1,7 +1,6 @@
 import { SharedData } from '../state';
 import { ChallengingState } from './challenging/states';
-import { ConcludingState as ConcludingInstigatorState } from './concluding/instigator/states';
-import { ConcludingState as ConcludingResponderState } from './concluding/responder/states';
+
 import { DirectFundingState } from './direct-funding/state';
 import { FundingState } from './funding/states';
 import { IndirectFundingState } from './indirect-funding/state';
@@ -10,6 +9,7 @@ import { WithdrawalState } from './withdrawing/states';
 import { ApplicationState } from './application/states';
 import { IndirectDefundingState } from './indirect-defunding/state';
 import { DefundingState } from './defunding/states';
+import { ConcludingState } from './concluding/state';
 
 export type ProtocolState =
   | ApplicationState
@@ -20,8 +20,7 @@ export type ProtocolState =
   | FundingState
   | DefundingState
   | ChallengingState
-  | ConcludingInstigatorState
-  | ConcludingResponderState
+  | ConcludingState
   | IndirectDefundingState;
 
 export type ProtocolReducer<T extends ProtocolState> = (

--- a/packages/wallet/src/redux/protocols/indirect-defunding/__tests__/reducer.test.ts
+++ b/packages/wallet/src/redux/protocols/indirect-defunding/__tests__/reducer.test.ts
@@ -122,7 +122,7 @@ function itSendsMessage(state: ReturnVal, message: SignedCommitment) {
   it('sends a message', () => {
     const lastMessage = getLastMessage(state.sharedData);
     if (lastMessage && 'messagePayload' in lastMessage) {
-      const dataPayload = lastMessage.messagePayload.data;
+      const dataPayload = lastMessage.messagePayload;
       // This is yuk. The data in a message is currently of 'any' type..
       if (!('signedCommitment' in dataPayload)) {
         fail('No signedCommitment in the last message.');

--- a/packages/wallet/src/redux/protocols/indirect-defunding/actions.ts
+++ b/packages/wallet/src/redux/protocols/indirect-defunding/actions.ts
@@ -1,3 +1,7 @@
-import { CommitmentReceived } from '../../actions';
+import { CommitmentReceived, COMMITMENT_RECEIVED, WalletAction } from '../../actions';
 
 export type IndirectDefundingAction = CommitmentReceived;
+
+export function isIndirectDefundingAction(action: WalletAction): action is IndirectDefundingAction {
+  return action.type === COMMITMENT_RECEIVED;
+}

--- a/packages/wallet/src/redux/protocols/indirect-funding/player-a/__tests__/reducer.test.ts
+++ b/packages/wallet/src/redux/protocols/indirect-funding/player-a/__tests__/reducer.test.ts
@@ -69,7 +69,7 @@ function itSendsMessage(state: ReturnVal, message: SignedCommitment) {
   it('sends a message', () => {
     const lastMessage = getLastMessage(state.sharedData);
     if (lastMessage && 'messagePayload' in lastMessage) {
-      const dataPayload = lastMessage.messagePayload.data;
+      const dataPayload = lastMessage.messagePayload;
       // This is yuk. The data in a message is currently of 'any' type..
       if (!('signedCommitment' in dataPayload)) {
         fail('No signedCommitment in the last message.');

--- a/packages/wallet/src/redux/protocols/indirect-funding/player-b/__tests__/reducer.test.ts
+++ b/packages/wallet/src/redux/protocols/indirect-funding/player-b/__tests__/reducer.test.ts
@@ -68,7 +68,7 @@ function itSendsMessage(state: ReturnVal, message: SignedCommitment) {
   it('sends a message', () => {
     const lastMessage = getLastMessage(state.sharedData);
     if (lastMessage && 'messagePayload' in lastMessage) {
-      const dataPayload = lastMessage.messagePayload.data;
+      const dataPayload = lastMessage.messagePayload;
       // This is yuk. The data in a message is currently of 'any' type..
       if (!('signedCommitment' in dataPayload)) {
         fail('No signedCommitment in the last message.');

--- a/packages/wallet/src/redux/protocols/reducer-helpers.ts
+++ b/packages/wallet/src/redux/protocols/reducer-helpers.ts
@@ -103,6 +103,18 @@ export const isChannelDirectlyFunded = (channelId: string, sharedData: SharedDat
   return channelFundingState.directlyFunded;
 };
 
+export const getFundingChannelId = (channelId: string, sharedData: SharedData): string => {
+  const channelFundingState = selectors.getChannelFundingState(sharedData, channelId);
+  if (!channelFundingState) {
+    throw new Error(`No funding state for ${channelId}. Cannot determine funding type.`);
+  }
+
+  if (!channelFundingState.fundingChannel) {
+    throw new Error('No funding channel id defined.');
+  }
+  return channelFundingState.fundingChannel;
+};
+
 export const isFirstPlayer = (channelId: string, sharedData: SharedData) => {
   const channelState = selectors.getChannelState(sharedData, channelId);
   return channelState.ourIndex === PlayerIndex.A;

--- a/packages/wallet/src/redux/reducer.ts
+++ b/packages/wallet/src/redux/reducer.ts
@@ -15,7 +15,6 @@ import * as states from './state';
 import { WalletProtocol } from './types';
 import { APPLICATION_PROCESS_ID } from './protocols/application/reducer';
 import { adjudicatorStateReducer } from './adjudicator-state/reducer';
-import { getChannel } from './state';
 
 const initialState = states.waitForLogin();
 
@@ -165,18 +164,11 @@ function initializeNewProtocol(
       return { protocolState, sharedData };
     }
     case actions.protocol.CONCLUDE_INSTIGATED: {
-      const { channelId } = action;
-      const channelState = getChannel(incomingSharedData, channelId);
-      const updatedChannelState = channelState;
-      let updatedSharedData = incomingSharedData;
-      if (channelState && updatedChannelState) {
-        updatedChannelState.turnNum = channelState.turnNum + 1;
-        updatedSharedData = { ...incomingSharedData, ...updatedChannelState };
-      } // TODO this is a bit hacky and possibly the wrong place to update the turn number...
+      const { signedCommitment } = action;
       const { state: protocolState, storage: sharedData } = concludingResponderProtocol.initialize(
-        channelId,
+        signedCommitment,
         processId,
-        updatedSharedData,
+        incomingSharedData,
       );
       return { protocolState, sharedData };
     }

--- a/packages/wallet/src/redux/reducer.ts
+++ b/packages/wallet/src/redux/reducer.ts
@@ -7,8 +7,7 @@ import { ProtocolState } from './protocols';
 import { isNewProcessAction, isProtocolAction, NewProcessAction } from './protocols/actions';
 import * as applicationProtocol from './protocols/application';
 import * as challengeProtocol from './protocols/challenging';
-import * as concludingInstigatorProtocol from './protocols/concluding/instigator';
-import * as concludingResponderProtocol from './protocols/concluding/responder';
+import * as concludingProtocol from './protocols/concluding';
 import * as fundProtocol from './protocols/funding';
 import * as challengeResponseProtocol from './protocols/responding';
 import * as states from './state';
@@ -96,22 +95,16 @@ function routeToProtocolReducer(
         );
         return updatedState(state, appSharedData, processState, appProtocolState);
 
-      case WalletProtocol.ConcludingInstigator:
-        const { state: concIState, storage: concIStorage } = concludingInstigatorProtocol.reducer(
+      case WalletProtocol.Concluding:
+        const {
+          protocolState: concludingProtocolState,
+          sharedData: concludingSharedData,
+        } = concludingProtocol.reducer(
           processState.protocolState,
           states.sharedData(state),
           action,
         );
-        return updatedState(state, concIStorage, processState, concIState);
-
-      case WalletProtocol.ConcludingResponder:
-        const { state: concRState, storage: concRStorage } = concludingResponderProtocol.reducer(
-          processState.protocolState,
-          states.sharedData(state),
-          action,
-        );
-        return updatedState(state, concRStorage, processState, concRState);
-
+        return updatedState(state, concludingSharedData, processState, concludingProtocolState);
       default:
         // TODO: This should return unreachable(state), but right now, only some protocols are
         // "whitelisted" to run as a top-level process, which means we can't
@@ -156,7 +149,7 @@ function initializeNewProtocol(
     }
     case actions.protocol.CONCLUDE_REQUESTED: {
       const { channelId } = action;
-      const { state: protocolState, storage: sharedData } = concludingInstigatorProtocol.initialize(
+      const { protocolState, sharedData } = concludingProtocol.initializeInstigatorState(
         channelId,
         processId,
         incomingSharedData,
@@ -165,7 +158,7 @@ function initializeNewProtocol(
     }
     case actions.protocol.CONCLUDE_INSTIGATED: {
       const { signedCommitment } = action;
-      const { state: protocolState, storage: sharedData } = concludingResponderProtocol.initialize(
+      const { protocolState, sharedData } = concludingProtocol.initializeResponderState(
         signedCommitment,
         processId,
         incomingSharedData,

--- a/packages/wallet/src/redux/sagas/message-listener.ts
+++ b/packages/wallet/src/redux/sagas/message-listener.ts
@@ -72,9 +72,7 @@ export function* messageListener() {
 }
 
 function handleIncomingMessage(action: incoming.ReceiveMessage) {
-  const { messagePayload } = action as incoming.ReceiveMessage;
-
-  const { data } = messagePayload;
+  const data = action.messagePayload;
 
   if ('type' in data && isRelayableAction(data)) {
     return data;

--- a/packages/wallet/src/redux/state.ts
+++ b/packages/wallet/src/redux/state.ts
@@ -186,6 +186,14 @@ export function setChannelStore(state: SharedData, channelStore: ChannelStore): 
   return { ...state, channelStore };
 }
 
+export function setFundingState(
+  state: SharedData,
+  channelId: string,
+  fundingState: ChannelFundingState,
+) {
+  return { ...state, fundingState: { ...state.fundingState, [channelId]: fundingState } };
+}
+
 export function getLastMessage(state: SharedData): WalletEvent | undefined {
   return getLastMessageFromOutbox(state.outboxState);
 }

--- a/packages/wallet/src/redux/types.ts
+++ b/packages/wallet/src/redux/types.ts
@@ -2,8 +2,7 @@ export const enum WalletProtocol {
   Application = 'Application',
   Funding = 'Funding',
   Challenging = 'Challenging',
-  ConcludingInstigator = 'ConcludingInstigator',
-  ConcludingResponder = 'ConcludingResponder',
+  Concluding = 'Concluding',
   Responding = 'Responding',
 
   Withdrawing = 'Withdrawing',


### PR DESCRIPTION
Work on getting concluding work. 

- Updated magmo-wallet-client to remove the `processId` from messages. This allows us to treat the `concludeInstigated` as both a message action and a new process action.
- Switched from  `ConcludingInstigator`/`ConcludingResponder` to a single `Concluding` protocol. This allows communication between the concluding players to use the same `processId` (like or other protocols)
- Updated 'responder' to initialize with a `commitment` which gets stored and validated.
- Updated the tests a bunch.
- Renamed and removed some actions.

TODO:

- [x] Update Instigator to handle `COMMITMENT_RECEIVED`
- [x] Add back unhappy path tests.
- [ ] Set `FundingState` during the funding process. We rely on the funding state to figure out whether a channel is directly funded and what the ledger id is. Currently this is never set.
- [ ] Update defunding reducer to call the `indirectDefundingReducer`