### PR TITLE
Indirect funding work

### DIFF
--- a/packages/wallet/src/redux/protocols/indirect-funding/player-a/__tests__/reducer.test.ts
+++ b/packages/wallet/src/redux/protocols/indirect-funding/player-a/__tests__/reducer.test.ts
@@ -40,6 +40,11 @@ describe('happy-path scenario', () => {
     const { state, action } = scenario.waitForPostFund1;
     const updatedState = playerAReducer(state.state, state.store, action);
 
+    itUpdatesFundingState(
+      updatedState,
+      scenario.initialParams.channelId,
+      scenario.initialParams.ledgerId, // TODO
+    );
     itTransitionsTo(updatedState, 'Success');
   });
 });
@@ -78,6 +83,21 @@ function itSendsMessage(state: ReturnVal, message: SignedCommitment) {
       expect({ commitment, signature }).toEqual(message);
     } else {
       fail('No messages in the outbox.');
+    }
+  });
+}
+
+function itUpdatesFundingState(state: ReturnVal, channelId: string, fundingChannelId?: string) {
+  it(`Updates the funding state to reflect ${channelId} funded by ${fundingChannelId}`, () => {
+    if (!state.sharedData.fundingState[channelId]) {
+      fail(`No entry for ${channelId} in fundingState`);
+    } else {
+      if (!fundingChannelId) {
+        expect(state.sharedData.fundingState[channelId].directlyFunded).toBeTruthy();
+      } else {
+        expect(state.sharedData.fundingState[channelId].directlyFunded).toBeFalsy();
+        expect(state.sharedData.fundingState[channelId].fundingChannel).toEqual(fundingChannelId);
+      }
     }
   });
 }

--- a/packages/wallet/src/redux/protocols/indirect-funding/player-a/__tests__/reducer.test.ts
+++ b/packages/wallet/src/redux/protocols/indirect-funding/player-a/__tests__/reducer.test.ts
@@ -43,7 +43,7 @@ describe('happy-path scenario', () => {
     itUpdatesFundingState(
       updatedState,
       scenario.initialParams.channelId,
-      scenario.initialParams.ledgerId, // TODO
+      scenario.initialParams.ledgerId,
     );
     itTransitionsTo(updatedState, 'Success');
   });

--- a/packages/wallet/src/redux/protocols/indirect-funding/player-a/__tests__/scenarios.ts
+++ b/packages/wallet/src/redux/protocols/indirect-funding/player-a/__tests__/scenarios.ts
@@ -116,6 +116,7 @@ export const happyPath = {
     channelId,
     reply: ledger0,
     processId: 'processId',
+    ledgerId,
   },
   waitForPreFundL1: { state: waitForPreFundL1, action: preFundL1Received },
   waitForDirectFunding: { state: waitForDirectFunding, action: successTriggerA, reply: ledger4 },

--- a/packages/wallet/src/redux/protocols/indirect-funding/player-a/reducer.ts
+++ b/packages/wallet/src/redux/protocols/indirect-funding/player-a/reducer.ts
@@ -33,6 +33,7 @@ import { UpdateType } from 'fmg-nitro-adjudicator/lib/consensus-app';
 import { proposeNewConsensus } from '../../../../domain/two-player-consensus-game';
 import { unreachable } from '../../../../utils/reducer-utils';
 import { isTransactionAction } from '../../../actions';
+import { ChannelFundingState } from '../../../state';
 
 type ReturnVal = ProtocolStateWithSharedData<IndirectFundingState>;
 type IDFAction = actions.indirectFunding.Action;
@@ -114,6 +115,13 @@ function handleWaitForPostFundSetup(
   }
   sharedData = checkResult.store;
 
+  // update fundingState
+  const fundingState: ChannelFundingState = {
+    directlyFunded: false,
+    fundingChannel: protocolState.ledgerId,
+  };
+
+  sharedData.fundingState[protocolState.channelId] = fundingState;
   const newProtocolState = success();
   const newReturnVal = { protocolState: newProtocolState, sharedData };
   return newReturnVal;

--- a/packages/wallet/src/redux/protocols/indirect-funding/player-b/__tests__/reducer.test.ts
+++ b/packages/wallet/src/redux/protocols/indirect-funding/player-b/__tests__/reducer.test.ts
@@ -37,7 +37,11 @@ describe('happy-path scenario', () => {
   describe('when in WaitForPostFund0', () => {
     const { state, action, reply } = scenario.waitForPostFund0;
     const updatedState = playerBReducer(state.state, state.store, action);
-
+    itUpdatesFundingState(
+      updatedState,
+      scenario.initialParams.channelId,
+      scenario.initialParams.ledgerId,
+    );
     itTransitionsTo(updatedState, 'Success');
     itSendsMessage(updatedState, reply);
   });
@@ -77,6 +81,21 @@ function itSendsMessage(state: ReturnVal, message: SignedCommitment) {
       expect({ commitment, signature }).toEqual(message);
     } else {
       fail('No messages in the outbox.');
+    }
+  });
+}
+
+function itUpdatesFundingState(state: ReturnVal, channelId: string, fundingChannelId?: string) {
+  it(`Updates the funding state to reflect ${channelId} funded by ${fundingChannelId}`, () => {
+    if (!state.sharedData.fundingState[channelId]) {
+      fail(`No entry for ${channelId} in fundingState`);
+    } else {
+      if (!fundingChannelId) {
+        expect(state.sharedData.fundingState[channelId].directlyFunded).toBeTruthy();
+      } else {
+        expect(state.sharedData.fundingState[channelId].directlyFunded).toBeFalsy();
+        expect(state.sharedData.fundingState[channelId].fundingChannel).toEqual(fundingChannelId);
+      }
     }
   });
 }

--- a/packages/wallet/src/redux/protocols/indirect-funding/player-b/__tests__/scenarios.ts
+++ b/packages/wallet/src/redux/protocols/indirect-funding/player-b/__tests__/scenarios.ts
@@ -115,7 +115,7 @@ const ledgerUpdate0Received = globalActions.commitmentReceived(processId, ledger
 const postFund0Received = globalActions.commitmentReceived(processId, app2);
 
 export const happyPath = {
-  initialParams: { store: waitForPreFundSetup0.store, channelId, processId: 'processId' },
+  initialParams: { store: waitForPreFundSetup0.store, channelId, processId: 'processId', ledgerId },
   waitForPreFundSetup0: {
     state: waitForPreFundSetup0,
     action: preFundSetup0Received,

--- a/packages/wallet/src/redux/protocols/indirect-funding/player-b/reducer.ts
+++ b/packages/wallet/src/redux/protocols/indirect-funding/player-b/reducer.ts
@@ -38,6 +38,7 @@ import { acceptConsensus } from '../../../../domain/two-player-consensus-game';
 import { sendCommitmentReceived } from '../../../../communication';
 import { addHex } from '../../../../utils/hex-utils';
 import { isTransactionAction } from '../../../actions';
+import { ChannelFundingState } from '../../../state';
 
 type ReturnVal = ProtocolStateWithSharedData<IndirectFundingState>;
 type IDFAction = actions.indirectFunding.Action;
@@ -286,6 +287,14 @@ export function handleWaitForPostFundSetup(
   );
   sharedData = queueMessage(sharedData, messageRelay);
   channel = getChannel(sharedData, appId); // refresh channel
+
+  // update fundingState
+  const fundingState: ChannelFundingState = {
+    directlyFunded: false,
+    fundingChannel: protocolState.ledgerId,
+  };
+
+  sharedData.fundingState[protocolState.channelId] = fundingState;
 
   const newProtocolState = success();
   const newReturnVal = { protocolState: newProtocolState, sharedData };


### PR DESCRIPTION
This PR appropriately updates the fundingState as the very last step of the `indirect-funding` protocol, and introduces tests for this behaviour. 