### PR TITLE
Export code from wallet package

### DIFF
--- a/packages/wallet/.gitignore
+++ b/packages/wallet/.gitignore
@@ -9,6 +9,9 @@
 # production
 /build
 
+# "library"
+/lib
+
 # misc
 .DS_Store
 .env.local

--- a/packages/wallet/index.ts
+++ b/packages/wallet/index.ts
@@ -1,3 +1,4 @@
-// Set options as a parameter, environment variable, or rc file.
+import * as communication from './src/communication';
+import { RelayableAction } from './src/communication';
 
-export {};
+export { communication, RelayableAction };

--- a/packages/wallet/index.ts
+++ b/packages/wallet/index.ts
@@ -1,4 +1,5 @@
 import * as communication from './src/communication';
 import { RelayableAction } from './src/communication';
+import { unreachable } from './src/utils/reducer-utils';
 
-export { communication, RelayableAction };
+export { communication, RelayableAction, unreachable };

--- a/packages/wallet/package.json
+++ b/packages/wallet/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "wallet",
+  "name": "magmo-wallet",
   "version": "0.1.0",
   "license": "MIT",
   "private": true,

--- a/packages/wallet/package.json
+++ b/packages/wallet/package.json
@@ -9,7 +9,9 @@
   },
   "scripts": {
     "start": "npm run clearContracts && node scripts/start.js",
-    "build": "npm run clearContracts && node scripts/build.js",
+    "build": "run-s clearContracts build:typescript build:webpack",
+    "build:typescript": "npx tsc",
+    "build:webpack": "node scripts/build.js",
     "test": "run-s prettier:check 'test:app --all'",
     "test:ci": "DEV_GANACHE_PORT=8503  run-s clearContracts prettier:check build 'test:contracts --all --ci' 'test:app --all --ci --runInBand'",
     "test:app": "npx run-jest -c ./config/jest/jest.config.js",

--- a/packages/wallet/package.json
+++ b/packages/wallet/package.json
@@ -3,8 +3,7 @@
   "version": "0.1.0",
   "license": "MIT",
   "private": true,
-  "main": "index.js",
-  "module": "src/index.js",
+  "main": "lib/index.js",
   "resolutions": {
     "firebase/**/grpc": "^1.16.1"
   },

--- a/packages/wallet/src/communication/__tests__/commitments.ts
+++ b/packages/wallet/src/communication/__tests__/commitments.ts
@@ -18,6 +18,28 @@ export const channelId = channelID(channel);
 
 export const twoThree = [bigNumberify(2).toHexString(), bigNumberify(3).toHexString()];
 
+export const preFundCommitment0: Commitment = {
+  channel,
+  commitmentCount: 0,
+  commitmentType: CommitmentType.PreFundSetup,
+  appAttributes: '0x0',
+  turnNum: 2,
+  allocation: twoThree,
+  destination: participants,
+};
+export const signedCommitment0 = signCommitment2(preFundCommitment0, asPrivateKey);
+
+export const preFundCommitment1: Commitment = {
+  channel,
+  commitmentCount: 1,
+  commitmentType: CommitmentType.PreFundSetup,
+  appAttributes: '0x0',
+  turnNum: 3,
+  allocation: twoThree,
+  destination: participants,
+};
+export const signedCommitment1 = signCommitment2(preFundCommitment1, bsPrivateKey);
+
 export const postFundCommitment0: Commitment = {
   channel,
   commitmentCount: 0,

--- a/packages/wallet/src/communication/__tests__/test-scenarios.ts
+++ b/packages/wallet/src/communication/__tests__/test-scenarios.ts
@@ -2,6 +2,8 @@ import { messageRelayRequested } from 'magmo-wallet-client';
 import { strategyProposed, strategyApproved } from '..';
 import { commitmentReceived } from '../../redux/actions';
 import {
+  signedCommitment0,
+  signedCommitment1,
   signedCommitment2,
   signedCommitment3,
   signedCommitment51,
@@ -20,8 +22,19 @@ const {
 export const asAddress = '0x5409ED021D9299bf6814279A6A1411A7e866A631';
 export const bsAddress = '0x6Ecbe1DB9EF729CBe972C83Fb886247691Fb6beb';
 
+const applicationProcessId = 'Application';
 const fundingProcessId = 'Funding';
 const concludeProcessId = 'Conclude';
+
+const sendAppPrefundSetup = messageRelayRequested(bsAddress, {
+  processId: applicationProcessId,
+  data: commitmentReceived(fundingProcessId, signedCommitment0),
+});
+
+const respondToAppPreFundSetup = messageRelayRequested(asAddress, {
+  processId: applicationProcessId,
+  data: commitmentReceived(fundingProcessId, signedCommitment1),
+});
 
 const indirectStrategyChosen = messageRelayRequested(bsAddress, {
   processId: fundingProcessId,
@@ -84,6 +97,8 @@ const respondToConclude = messageRelayRequested(asAddress, {
 });
 
 export default {
+  sendAppPrefundSetup,
+  respondToAppPreFundSetup,
   indirectStrategyChosen,
   indirectStrategyApproved,
   sendLedgerPrefundSetup,

--- a/packages/wallet/src/redux/protocols/actions.ts
+++ b/packages/wallet/src/redux/protocols/actions.ts
@@ -52,6 +52,7 @@ export type NewProcessAction =
   | ConcludeRequested
   | CreateChallengeRequested
   | RespondToChallengeRequested;
+
 export function isNewProcessAction(action: WalletAction): action is NewProcessAction {
   return (
     action.type === INITIALIZE_CHANNEL ||

--- a/packages/wallet/src/utils/reducer-utils.ts
+++ b/packages/wallet/src/utils/reducer-utils.ts
@@ -1,7 +1,7 @@
 import { accumulateSideEffects } from '../redux/outbox';
-import { SideEffects } from 'src/redux/outbox/state';
-import { WalletAction } from 'src/redux/actions';
-import { StateWithSideEffects } from 'src/redux/utils';
+import { SideEffects } from '../redux/outbox/state';
+import { WalletAction } from '../redux/actions';
+import { StateWithSideEffects } from '../redux/utils';
 
 export function unreachable(x: never) {
   return x;

--- a/packages/wallet/tsconfig.json
+++ b/packages/wallet/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "baseUrl": ".",
-    "outDir": "build/dist",
+    "outDir": "lib",
     "module": "commonjs",
     "target": "es2015",
     "lib": ["es6", "dom"],
@@ -16,11 +16,12 @@
     "noUnusedLocals": true,
     "allowSyntheticDefaultImports": true,
     "resolveJsonModule": true,
-    "esModuleInterop": true,
+    "esModuleInterop": true
   },
   "exclude": [
     "node_modules",
     "build",
+    "lib",
     "scripts",
     "acceptance-tests",
     "webpack",


### PR DESCRIPTION
This PR allows other packages to import code from the wallet package.

By rights, this exported code should live in the `magmo-wallet-common` package, but it's currently a bit spread out in the wallet package.

To more quickly use the code in the `nitro-server` package, exporting it from `index.ts` is a reasonable trade-off. When we refactor the common code into `magmo-wallet-common`, it would only require changing `import * from 'magmo-wallet'` to `import * from 'magmo-wallet-common'` in whatever package is currently using that "common" code.