### PR TITLE
Fix Direct Funding Race Condition

### DIFF
--- a/packages/wallet/src/redux/__tests__/helpers.ts
+++ b/packages/wallet/src/redux/__tests__/helpers.ts
@@ -1,6 +1,6 @@
-import { ChannelState } from '../channel-store';
+import { ChannelState, ChannelStore } from '../channel-store';
 import { StateWithSideEffects } from '../utils';
-import { Commitment } from '../../domain';
+import { Commitment, SignedCommitment, getChannelId } from '../../domain';
 import { QueuedTransaction, OutboxState } from '../outbox/state';
 import { SharedData } from '../state';
 import { ProtocolStateWithSharedData } from '../protocols';
@@ -117,5 +117,16 @@ export const itIncreasesTurnNumBy = (
     } else {
       expect(newState.state.turnNum).toEqual(oldState.turnNum + increase);
     }
+  });
+};
+
+export const itStoresThisCommitment = (
+  state: { channelStore: ChannelStore },
+  signedCommitment: SignedCommitment,
+) => {
+  it('stores the commitment in the channel state', () => {
+    const channelId = getChannelId(signedCommitment.commitment);
+    const channelState = state.channelStore[channelId];
+    expect(channelState.lastCommitment).toMatchObject(signedCommitment);
   });
 };

--- a/packages/wallet/src/redux/protocols/direct-funding/__tests__/reducer.test.ts
+++ b/packages/wallet/src/redux/protocols/direct-funding/__tests__/reducer.test.ts
@@ -6,7 +6,7 @@ import * as scenarios from './scenarios';
 import * as transactionSubmissionStates from '../../transaction-submission/states';
 import { ProtocolStateWithSharedData } from '../..';
 import { bigNumberify } from 'ethers/utils';
-import { expectThisCommitmentSent } from '../../../__tests__/helpers';
+import { expectThisCommitmentSent, itStoresThisCommitment } from '../../../__tests__/helpers';
 
 const { channelId } = globalTestScenarios;
 
@@ -178,6 +178,7 @@ describe(startingIn(states.WAIT_FOR_FUNDING_AND_POST_FUND_SETUP), () => {
 
     describe('Player B: channel is not funded', () => {
       const state = scenarios.bEachDepositsInSequenceHappyStates.waitForFundingAndPostFundSetup;
+      const incomingCommitment = scenarios.actions.postFundSetup0.signedCommitment;
       const updatedState = directFundingStateReducer(
         state.protocolState,
         state.sharedData,
@@ -189,6 +190,8 @@ describe(startingIn(states.WAIT_FOR_FUNDING_AND_POST_FUND_SETUP), () => {
         expect(protocolState.channelFunded).toBeFalsy();
         expect(protocolState.postFundSetupReceived).toBeTruthy();
       }
+
+      itStoresThisCommitment(updatedState.sharedData, incomingCommitment);
     });
 
     describe('Player A: channel is funded', () => {


### PR DESCRIPTION
If player B received `postFundSetup0` before the channel is funded the commitment was not stored anywhere.

This means that after the channel gets funded when Player B tries to send out `postFundSetup1` it fails since we're trying to transition from `preFundSetup0` to `postFundSetup1`.

To fix this we now update the channel state with the `postFundSetup0` commitment even if the channel is not funded yet.