### PR TITLE
Remove ganache addresses from prebuilt contracts

### DIFF
--- a/packages/wallet-common/prebuilt-contracts/Commitment.json
+++ b/packages/wallet-common/prebuilt-contracts/Commitment.json
@@ -787,12 +787,6 @@
       "links": {},
       "address": "0xCCE26Ac35f5dBB88638bDb0D1252aC8eACde2e82",
       "transactionHash": "0xf5fb0e955f73820717312240eae68252e1af2819c9c39c83957b50ba74f73828"
-    },
-    "123456789": {
-      "events": {},
-      "links": {},
-      "address": "0x6DfFF22588BE9b3ef8cf0aD6Dc9B84796F9fB45f",
-      "transactionHash": "0x67a7695dc36c00d1f0c65f41a03d14fa05a67d0f6b7ca205344e6edc57b517a6"
     }
   }
 }

--- a/packages/wallet-common/prebuilt-contracts/NitroAdjudicator.json
+++ b/packages/wallet-common/prebuilt-contracts/NitroAdjudicator.json
@@ -1142,15 +1142,6 @@
       },
       "address": "0xf29dCaC1E979e6480F981b0b1E0236Da0433a511",
       "transactionHash": "0xea8fdab11ca204c4cba9f2674d4495bf76a0270a600d0f3ca7b4b150a2722ecc"
-    },
-    "123456789": {
-      "events": {},
-      "links": {
-        "Commitment": "0x6DfFF22588BE9b3ef8cf0aD6Dc9B84796F9fB45f",
-        "Rules": "0xcFC18CEc799fBD1793B5C43E773C98D4d61Cc2dB"
-      },
-      "address": "0xF22469F31527adc53284441bae1665A7b9214DBA",
-      "transactionHash": "0x56f50e467a272d9bdefa164b1890cc3078d5ef626cfd8ecbcbf116179902a88b"
     }
   }
 }

--- a/packages/wallet-common/prebuilt-contracts/Rules.json
+++ b/packages/wallet-common/prebuilt-contracts/Rules.json
@@ -1213,14 +1213,6 @@
       },
       "address": "0x772fF73462FFF2eD1342e9bAC1eC74CD50C2B86a",
       "transactionHash": "0x52c079ac0a0ad65ce49b0d4e130dee3ce7d26b3deabbe89010b41386de22d754"
-    },
-    "123456789": {
-      "events": {},
-      "links": {
-        "Commitment": "0x6DfFF22588BE9b3ef8cf0aD6Dc9B84796F9fB45f"
-      },
-      "address": "0xcFC18CEc799fBD1793B5C43E773C98D4d61Cc2dB",
-      "transactionHash": "0x13c6b2f0126ab32a03cd8cad85da7e62433b03b569ca4d24909a3e043375b856"
     }
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -20156,7 +20156,7 @@ web3-utils@1.0.0-beta.37:
     underscore "1.8.3"
     utf8 "2.1.1"
 
-web3-utils@1.0.0-beta.55, web3-utils@^1.0.0-beta.30, web3-utils@^1.0.0-beta.36:
+web3-utils@1.0.0-beta.55, web3-utils@^1.0.0-beta.36:
   version "1.0.0-beta.55"
   resolved "https://registry.yarnpkg.com/web3-utils/-/web3-utils-1.0.0-beta.55.tgz#beb40926b7c04208b752d36a9bc959d27a04b308"
   integrity sha512-ASWqUi8gtWK02Tp8ZtcoAbHenMpQXNvHrakgzvqTNNZn26wgpv+Q4mdPi0KOR6ZgHFL8R/9b5BBoUTglS1WPpg==
@@ -20198,7 +20198,7 @@ web3@1.0.0-beta.37:
     web3-shh "1.0.0-beta.37"
     web3-utils "1.0.0-beta.37"
 
-web3@^1.0.0-beta.34, web3@^1.0.0-beta.36:
+web3@^1.0.0-beta.36:
   version "1.0.0-beta.55"
   resolved "https://registry.yarnpkg.com/web3/-/web3-1.0.0-beta.55.tgz#8845075129299da172c2eb41a748c8a87c2a2b5a"
   integrity sha512-yJpwy4IUA3T/F9hWzYQVn0GbJCrAaZ0KTIO3iuqkhaYH0Y09KV7k4GzFi4hN7hT4cFTj4yIKaeVCwQ5kzvi2Vg==


### PR DESCRIPTION
Ganache addresses snuck into the prebuilt contracts of the `wallet-common` package.