### PR TITLE
Handle challenge timeouts

### DIFF
--- a/packages/wallet/package.json
+++ b/packages/wallet/package.json
@@ -111,7 +111,6 @@
     "ganache-cli": "^6.3.0",
     "html-webpack-plugin": "4.0.0-beta.5",
     "jest": "^23.5.0",
-    "lodash": "4.17.11",
     "magmo-devtools": "git+https://github.com/magmo/devtools.git#v0.1.15",
     "node-sass": "^4.9.3",
     "optimize-css-assets-webpack-plugin": "5.0.1",

--- a/packages/wallet/src/redux/actions.ts
+++ b/packages/wallet/src/redux/actions.ts
@@ -174,6 +174,7 @@ export type ProtocolAction =
   | FundingAction
   | TransactionAction
   | challenging.ChallengingAction
+  | RespondingAction
   | directFunding.FundingAction
   | indirectFunding.Action
   | WithdrawalAction

--- a/packages/wallet/src/redux/protocols/challenging/__tests__/reducer.test.ts
+++ b/packages/wallet/src/redux/protocols/challenging/__tests__/reducer.test.ts
@@ -18,7 +18,7 @@ import {
   SHOW_WALLET,
 } from 'magmo-wallet-client';
 
-describe('opponent-responds scenario', () => {
+describe('OPPONENT RESPONDS', () => {
   const scenario = scenarios.opponentResponds;
   const { channelId, processId, storage } = scenario;
 
@@ -29,54 +29,48 @@ describe('opponent-responds scenario', () => {
     itTransitionsTo(result, 'Challenging.ApproveChallenge');
   });
   describe('when in ApproveChallenge', () => {
-    const state = scenario.approveChallenge;
-    const action = scenario.challengeApproved;
+    const { state, action } = scenario.approveChallenge;
     const result = challengingReducer(state, storage, action);
 
     itTransitionsTo(result, 'Challenging.WaitForTransaction');
     // it initializes the transaction state machine
   });
   describe('when in WaitForTransaction', () => {
-    const state = scenario.waitForTransaction;
-    const action = scenario.challengeExpirySet;
-    const result = challengingReducer(state, storage, action);
+    const { state, action2 } = scenario.waitForTransaction;
+    const result = challengingReducer(state, storage, action2);
 
     itTransitionsTo(result, 'Challenging.WaitForTransaction');
     it('updates the expiry time', () => {
-      expect((result.state as WaitForTransaction).expiryTime).toEqual(action.expiryTime);
+      expect((result.state as WaitForTransaction).expiryTime).toEqual(action2.expiryTime);
     });
   });
   describe('when in WaitForTransaction', () => {
-    const state = scenario.waitForTransaction;
-    const action = scenario.transactionSuccessTrigger;
+    const { state, action } = scenario.waitForTransaction;
     const result = challengingReducer(state, storage, action);
 
     itTransitionsTo(result, 'Challenging.WaitForResponseOrTimeout');
   });
 
   describe('when in WaitForResponseOrTimeout', () => {
-    const state = scenario.waitForResponseOrTimeout;
-    const action = scenario.challengeExpirySet;
-    const result = challengingReducer(state, storage, action);
+    const { state, action1 } = scenario.waitForResponseOrTimeout;
+    const result = challengingReducer(state, storage, action1);
 
     itTransitionsTo(result, 'Challenging.WaitForResponseOrTimeout');
     it('updates the expiry time', () => {
-      expect((result.state as WaitForResponseOrTimeout).expiryTime).toEqual(action.expiryTime);
+      expect((result.state as WaitForResponseOrTimeout).expiryTime).toEqual(action1.expiryTime);
     });
   });
   describe('when in WaitForResponseOrTimeout', () => {
-    const state = scenario.waitForResponseOrTimeout;
-    const action = scenario.responseReceived;
-    const result = challengingReducer(state, storage, action);
+    const { state, action2, commitment } = scenario.waitForResponseOrTimeout;
+    const result = challengingReducer(state, storage, action2);
 
     itSendsThisMessage(result.storage, CHALLENGE_COMMITMENT_RECEIVED);
-    itStoresThisCommitment(result.storage, scenario.challengeCommitment);
+    itStoresThisCommitment(result.storage, commitment);
     itTransitionsTo(result, 'Challenging.AcknowledgeResponse');
   });
 
   describe('when in AcknowledgeResponse', () => {
-    const state = scenario.acknowledgeResponse;
-    const action = scenario.responseAcknowledged;
+    const { state, action } = scenario.acknowledgeResponse;
     const result = challengingReducer(state, storage, action);
 
     itTransitionsTo(result, 'Challenging.SuccessOpen');
@@ -85,27 +79,27 @@ describe('opponent-responds scenario', () => {
   });
 });
 
-describe('challenge-times-out scenario', () => {
-  const scenario = scenarios.challengeTimesOut;
-  const { storage } = scenario;
+// describe('challenge-times-out ', () => {
+//   const scenario = scenarios.challengeTimesOut;
+//   const { storage } = scenario;
 
-  describe('when in WaitForResponseOrTimeout', () => {
-    const state = scenario.waitForResponseOrTimeout;
-    const action = scenario.challengeTimedOut;
-    const result = challengingReducer(state, storage, action);
-    itTransitionsTo(result, 'Challenging.AcknowledgeTimeout');
-  });
+//   describe('when in WaitForResponseOrTimeout', () => {
+//     const state = scenario.waitForResponseOrTimeout;
+//     const action = scenario.challengeTimedOut;
+//     const result = challengingReducer(state, storage, action);
+//     itTransitionsTo(result, 'Challenging.AcknowledgeTimeout');
+//   });
 
-  describe('when in AcknowledgeTimeout', () => {
-    const state = scenario.acknowledgeTimeout;
-    const action = scenario.timeoutAcknowledged;
-    const result = challengingReducer(state, storage, action);
+//   describe('when in AcknowledgeTimeout', () => {
+//     const state = scenario.acknowledgeTimeout;
+//     const action = scenario.timeoutAcknowledged;
+//     const result = challengingReducer(state, storage, action);
 
-    itTransitionsTo(result, 'Challenging.SuccessClosed');
-  });
-});
+//     itTransitionsTo(result, 'Challenging.SuccessClosed');
+//   });
+// });
 
-describe("channel-doesn't-exist scenario", () => {
+describe('CHANNEL DOESNT EXIST  ', () => {
   const scenario = scenarios.channelDoesntExist;
   const { channelId, processId, storage } = scenario;
 
@@ -117,8 +111,7 @@ describe("channel-doesn't-exist scenario", () => {
   });
 
   describe('when in AcknowledgeFailure', () => {
-    const state = scenario.acknowledgeFailure;
-    const action = scenario.failureAcknowledged;
+    const { state, action } = scenario.acknowledgeFailure;
     const result = challengingReducer(state, storage, action);
 
     itTransitionsTo(result, 'Challenging.Failure');
@@ -126,7 +119,7 @@ describe("channel-doesn't-exist scenario", () => {
   });
 });
 
-describe('channel-not-fully-open scenario', () => {
+describe('CHANNEL NOT FULLY OPEN  ', () => {
   const scenario = scenarios.channelNotFullyOpen;
   const { channelId, processId, storage } = scenario;
 
@@ -138,8 +131,7 @@ describe('channel-not-fully-open scenario', () => {
   });
 
   describe('when in AcknowledgeFailure', () => {
-    const state = scenario.acknowledgeFailure;
-    const action = scenario.failureAcknowledged;
+    const { state, action } = scenario.acknowledgeFailure;
     const result = challengingReducer(state, storage, action);
 
     itTransitionsTo(result, 'Challenging.Failure');
@@ -147,7 +139,7 @@ describe('channel-not-fully-open scenario', () => {
   });
 });
 
-describe('already-have-latest-commitment scenario', () => {
+describe('ALREADY HAVE LATEST COMMITMENT', () => {
   const scenario = scenarios.alreadyHaveLatest;
   const { channelId, processId, storage } = scenario;
 
@@ -159,8 +151,7 @@ describe('already-have-latest-commitment scenario', () => {
   });
 
   describe('when in AcknowledgeFailure', () => {
-    const state = scenario.acknowledgeFailure;
-    const action = scenario.failureAcknowledged;
+    const { state, action } = scenario.acknowledgeFailure;
     const result = challengingReducer(state, storage, action);
 
     itTransitionsTo(result, 'Challenging.Failure');
@@ -168,21 +159,19 @@ describe('already-have-latest-commitment scenario', () => {
   });
 });
 
-describe('user-declines-challenge scenario', () => {
+describe('USER DECLINES CHALLENGE  ', () => {
   const scenario = scenarios.userDeclinesChallenge;
   const { storage } = scenario;
 
   describe('when in ApproveChallenge', () => {
-    const state = scenario.approveChallenge;
-    const action = scenario.challengeDenied;
+    const { state, action } = scenario.approveChallenge;
     const result = challengingReducer(state, storage, action);
 
     itTransitionsTo(result, 'Challenging.AcknowledgeFailure');
     itHasFailureReason(result, 'DeclinedByUser');
   });
   describe('when in AcknowledgeFailure', () => {
-    const state = scenario.acknowledgeFailure;
-    const action = scenario.failureAcknowledged;
+    const { state, action } = scenario.acknowledgeFailure;
     const result = challengingReducer(state, storage, action);
 
     itTransitionsTo(result, 'Challenging.Failure');
@@ -190,14 +179,13 @@ describe('user-declines-challenge scenario', () => {
   });
 });
 
-describe('receive-commitment-while-approving scenario', () => {
+describe('RECEIVE COMMITMENT WHILE APPROVING  ', () => {
   const scenario = scenarios.receiveCommitmentWhileApproving;
   const { storage } = scenario;
 
   describe('when in ApproveChallenge', () => {
-    const state = scenario.approveChallenge;
+    const { state, action } = scenario.approveChallenge;
     // note: we're triggering this off the user's acceptance, not the arrival of the update
-    const action = scenario.challengeApproved;
     const result = challengingReducer(state, storage, action);
 
     itTransitionsTo(result, 'Challenging.AcknowledgeFailure');
@@ -205,8 +193,8 @@ describe('receive-commitment-while-approving scenario', () => {
   });
 
   describe('when in AcknowledgeFailure', () => {
-    const state = scenario.acknowledgeFailure;
-    const action = scenario.failureAcknowledged;
+    const { state, action } = scenario.acknowledgeFailure;
+
     const result = challengingReducer(state, storage, action);
 
     itTransitionsTo(result, 'Challenging.Failure');
@@ -214,13 +202,12 @@ describe('receive-commitment-while-approving scenario', () => {
   });
 });
 
-describe('transaction-fails scenario', () => {
+describe('TRANSACTION FAILS  ', () => {
   const scenario = scenarios.transactionFails;
   const { storage } = scenario;
 
   describe('when in WaitForTransaction', () => {
-    const state = scenario.waitForTransaction;
-    const action = scenario.transactionFailureTrigger;
+    const { state, action } = scenario.waitForTransaction;
     const result = challengingReducer(state, storage, action);
 
     itTransitionsTo(result, 'Challenging.AcknowledgeFailure');
@@ -228,8 +215,7 @@ describe('transaction-fails scenario', () => {
   });
 
   describe('when in AcknowledgeFailure', () => {
-    const state = scenario.acknowledgeFailure;
-    const action = scenario.failureAcknowledged;
+    const { state, action } = scenario.acknowledgeFailure;
     const result = challengingReducer(state, storage, action);
 
     itTransitionsTo(result, 'Challenging.Failure');

--- a/packages/wallet/src/redux/protocols/challenging/__tests__/reducer.test.ts
+++ b/packages/wallet/src/redux/protocols/challenging/__tests__/reducer.test.ts
@@ -79,25 +79,56 @@ describe('OPPONENT RESPONDS', () => {
   });
 });
 
-// describe('challenge-times-out ', () => {
-//   const scenario = scenarios.challengeTimesOut;
-//   const { storage } = scenario;
+describe('CHALLENGE TIMES OUT AND IS DEFUNDED ', () => {
+  const scenario = scenarios.challengeTimesOutAndIsDefunded;
+  const { storage } = scenario;
 
-//   describe('when in WaitForResponseOrTimeout', () => {
-//     const state = scenario.waitForResponseOrTimeout;
-//     const action = scenario.challengeTimedOut;
-//     const result = challengingReducer(state, storage, action);
-//     itTransitionsTo(result, 'Challenging.AcknowledgeTimeout');
-//   });
+  describe('when in WaitForResponseOrTimeout', () => {
+    const { state, action } = scenario.waitForResponseOrTimeout;
+    const result = challengingReducer(state, storage, action);
+    itTransitionsTo(result, 'Challenging.AcknowledgeTimeout');
+  });
 
-//   describe('when in AcknowledgeTimeout', () => {
-//     const state = scenario.acknowledgeTimeout;
-//     const action = scenario.timeoutAcknowledged;
-//     const result = challengingReducer(state, storage, action);
+  describe('when in AcknowledgeTimeout', () => {
+    const { state, action } = scenario.acknowledgeTimeout;
+    const result = challengingReducer(state, storage, action);
 
-//     itTransitionsTo(result, 'Challenging.SuccessClosed');
-//   });
-// });
+    itTransitionsTo(result, 'Challenging.WaitForDefund');
+  });
+
+  describe('when in WaitForDefund', () => {
+    const { state, action } = scenario.challengerWaitForDefund;
+    const result = challengingReducer(state, storage, action);
+
+    itTransitionsTo(result, 'Challenging.AcknowledgeSuccess');
+  });
+
+  describe('when in Acknowledge Success', () => {
+    const { state, action } = scenario.acknowledgeSuccess;
+    const result = challengingReducer(state, storage, action);
+
+    itTransitionsTo(result, 'Challenging.SuccessClosed');
+  });
+});
+
+describe('CHALLENGE TIMES OUT AND IS not DEFUNDED ', () => {
+  const scenario = scenarios.challengeTimesOutAndIsNotDefunded;
+  const { storage } = scenario;
+
+  describe('when in WaitForDefund', () => {
+    const { state, action } = scenario.challengerWaitForDefund;
+    const result = challengingReducer(state, storage, action);
+
+    itTransitionsTo(result, 'Challenging.AcknowledgeSuccess');
+  });
+
+  describe('when in Acknowledge Success', () => {
+    const { state, action } = scenario.acknowledgeClosedButNotDefunded;
+    const result = challengingReducer(state, storage, action);
+
+    itTransitionsTo(result, 'Challenging.SuccessClosed');
+  });
+});
 
 describe('CHANNEL DOESNT EXIST  ', () => {
   const scenario = scenarios.channelDoesntExist;

--- a/packages/wallet/src/redux/protocols/challenging/__tests__/reducer.test.ts
+++ b/packages/wallet/src/redux/protocols/challenging/__tests__/reducer.test.ts
@@ -119,10 +119,10 @@ describe('CHALLENGE TIMES OUT AND IS not DEFUNDED ', () => {
     const { state, action } = scenario.challengerWaitForDefund;
     const result = challengingReducer(state, storage, action);
 
-    itTransitionsTo(result, 'Challenging.AcknowledgeSuccess');
+    itTransitionsTo(result, 'Challenging.AcknowledgeClosedButNotDefunded');
   });
 
-  describe('when in Acknowledge Success', () => {
+  describe('when in AcknowledgeSuccessClosedButNotDefunded', () => {
     const { state, action } = scenario.acknowledgeClosedButNotDefunded;
     const result = challengingReducer(state, storage, action);
 
@@ -255,6 +255,9 @@ describe('TRANSACTION FAILS  ', () => {
 });
 
 function itTransitionsTo(result: ReturnVal, type: ChallengingStateType) {
+  if (!result.state) {
+    console.log(result);
+  }
   it(`transitions to ${type}`, () => {
     expect(result.state.type).toEqual(type);
   });

--- a/packages/wallet/src/redux/protocols/challenging/__tests__/reducer.test.ts
+++ b/packages/wallet/src/redux/protocols/challenging/__tests__/reducer.test.ts
@@ -107,7 +107,7 @@ describe('CHALLENGE TIMES OUT AND IS DEFUNDED ', () => {
     const { state, action } = scenario.acknowledgeSuccess;
     const result = challengingReducer(state, storage, action);
 
-    itTransitionsTo(result, 'Challenging.SuccessClosed');
+    itTransitionsTo(result, 'Challenging.SuccessClosedAndDefunded');
   });
 });
 
@@ -126,7 +126,7 @@ describe('CHALLENGE TIMES OUT AND IS not DEFUNDED ', () => {
     const { state, action } = scenario.acknowledgeClosedButNotDefunded;
     const result = challengingReducer(state, storage, action);
 
-    itTransitionsTo(result, 'Challenging.SuccessClosed');
+    itTransitionsTo(result, 'Challenging.SuccessClosedButNotDefunded');
   });
 });
 

--- a/packages/wallet/src/redux/protocols/challenging/__tests__/scenarios.ts
+++ b/packages/wallet/src/redux/protocols/challenging/__tests__/scenarios.ts
@@ -9,7 +9,7 @@ import {
   partiallyOpenChannelFromCommitment,
 } from '../../../channel-store/channel-state/__tests__';
 import {
-  challengeExpiredEvent,
+  // challengeExpiredEvent,
   respondWithMoveEvent,
   challengeExpirySetEvent,
 } from '../../../actions';
@@ -60,19 +60,19 @@ const waitForTransactionFailure = states.waitForTransaction({
   transactionSubmission: tsPreFailure,
 });
 const waitForResponseOrTimeout = states.waitForResponseOrTimeout({ ...defaults, expiryTime: 0 });
-const acknowledgeTimeout = states.acknowledgeTimeout(defaults);
+// const acknowledgeTimeout = states.acknowledgeTimeout(defaults);
 const acknowledgeResponse = states.acknowledgeResponse(defaults);
 const successOpen = states.successOpen();
-const successClosed = states.successClosed();
+// const successClosed = states.successClosed();
 const acknowledge = (reason: Reason) => states.acknowledgeFailure({ ...defaults, reason });
-const failure = (reason: Reason) => states.failure({ reason });
+// const failure = (reason: Reason) => states.failure({ reason });
 
 // -------
 // Actions
 // -------
 const challengeApproved = actions.challengeApproved(processId);
 const challengeDenied = actions.challengeDenied(processId);
-const challengeTimedOut = challengeExpiredEvent(processId, channelId, 1000);
+// const challengeTimedOut = challengeExpiredEvent(processId, channelId, 1000);
 const transactionSuccessTrigger = tsScenarios.successTrigger;
 const transactionFailureTrigger = tsScenarios.failureTrigger;
 const responseReceived = respondWithMoveEvent(
@@ -82,7 +82,7 @@ const responseReceived = respondWithMoveEvent(
   signedCommitment21.signature,
 );
 const responseAcknowledged = actions.challengeResponseAcknowledged(processId);
-const timeoutAcknowledged = actions.challengeTimeoutAcknowledged(processId);
+// const timeoutAcknowledged = actions.challengeTimeoutAcknowledged(processId);
 const failureAcknowledged = actions.challengeFailureAcknowledged(processId);
 const challengeExpirySet = challengeExpirySetEvent(processId, channelId, 1234);
 // -------
@@ -90,94 +90,123 @@ const challengeExpirySet = challengeExpirySetEvent(processId, channelId, 1234);
 // -------
 export const opponentResponds = {
   ...defaults,
-  // states
-  approveChallenge,
-  waitForTransaction: waitForTransactionSuccess,
-  waitForResponseOrTimeout,
-  acknowledgeResponse,
-  successOpen,
-  // actions
-  challengeApproved,
-  transactionSuccessTrigger,
-  responseReceived,
-  responseAcknowledged,
-  challengeExpirySet,
-
-  challengeCommitment: signedCommitment21,
+  approveChallenge: {
+    state: approveChallenge,
+    action: challengeApproved,
+  },
+  waitForTransaction: {
+    state: waitForTransactionSuccess,
+    action: transactionSuccessTrigger,
+    action2: challengeExpirySet,
+  },
+  waitForResponseOrTimeout: {
+    state: waitForResponseOrTimeout,
+    action1: challengeExpirySet,
+    action2: responseReceived,
+    commitment: signedCommitment21,
+  },
+  acknowledgeResponse: {
+    state: acknowledgeResponse,
+    action: responseAcknowledged,
+  },
+  successOpen: {
+    state: successOpen,
+  },
 };
 
-// Todo: need to figure out how a `ChallengeTimedOut` action should be triggered
-export const challengeTimesOut = {
-  ...defaults,
-  // states
-  waitForResponseOrTimeout,
-  acknowledgeTimeout,
-  successClosed,
-  // actions
-  challengeTimedOut,
-  timeoutAcknowledged,
-};
+// // Todo: need to figure out how a `ChallengeTimedOut` action should be triggered
+// export const challengeTimesOutAndIsDefunded = {
+//   ...defaults,
+//   waitForResponseOrTimeout: {
+//     state: waitForResponseOrTimeout,
+//     action: challengeTimedOut,
+//   },
+//   acknowledgeTimeout: {
+//     state: acknowledgeTimeout,
+//     action: defundChosen,
+//   },
+//   challengerWaitForDefund: {
+//     state: challengerWaitForDefund,
+//     action: defundSuccessTrigger,
+//   },
+//   acknowledgeSuccess: {
+//     state: acknowledgeSuccess,
+//     action: acknowledge,
+//   },
+// };
+
+// export const challengeTimesOutAndIsNotDefunded = {
+//   ...defaults,
+//   challengerWaitForDefund: {
+//     state: challengerWaitForDefund,
+//     action: defundFailureTrigger,
+//   },
+//   acknowledgeSuccess: {
+//     state: acknowledgeClosedButNotDefunded,
+//     action: acknowledged,
+//   },
+// };
 
 export const channelDoesntExist = {
   ...defaults,
   storage: EMPTY_SHARED_DATA,
-  // states
-  acknowledgeFailure: acknowledge('ChannelDoesntExist'),
-  failure: failure('ChannelDoesntExist'),
-  // actions
-  failureAcknowledged,
+  acknowledgeFailure: {
+    state: acknowledge('ChannelDoesntExist'),
+    action: failureAcknowledged,
+  },
 };
 
 export const channelNotFullyOpen = {
   ...defaults,
   storage: storage(partiallyOpen),
-  // states
-  acknowledgeFailure: acknowledge('NotFullyOpen'),
-  failure: failure('NotFullyOpen'),
-  // actions
-  failureAcknowledged,
+  acknowledgeFailure: {
+    state: acknowledge('NotFullyOpen'),
+    action: failureAcknowledged,
+  },
 };
 
 export const alreadyHaveLatest = {
   ...defaults,
   storage: storage(ourTurn),
-  // states
-  acknowledgeFailure: acknowledge('AlreadyHaveLatest'),
-  failure: failure('AlreadyHaveLatest'),
-  // actions
-  failureAcknowledged,
+  acknowledgeFailure: {
+    state: acknowledge('AlreadyHaveLatest'),
+    action: failureAcknowledged,
+  },
 };
 
 export const userDeclinesChallenge = {
   ...defaults,
-  // states
-  approveChallenge,
-  acknowledgeFailure: acknowledge('DeclinedByUser'),
-  failure: failure('DeclinedByUser'),
-  // actions
-  challengeDenied,
-  failureAcknowledged,
+  approveChallenge: {
+    state: approveChallenge,
+    action: challengeDenied,
+  },
+  acknowledgeFailure: {
+    state: acknowledge('DeclinedByUser'),
+    action: failureAcknowledged,
+  },
 };
 
 export const receiveCommitmentWhileApproving = {
   ...defaults,
   storage: storage(ourTurn),
-  // states
-  approveChallenge,
-  acknowledgeFailure: acknowledge('LatestWhileApproving'),
-  failure: failure('LatestWhileApproving'),
-  // actions
-  challengeApproved,
-  failureAcknowledged,
+  approveChallenge: {
+    state: approveChallenge,
+    action: challengeApproved,
+  },
+  acknowledgeFailure: {
+    state: acknowledge('LatestWhileApproving'),
+    action: failureAcknowledged,
+  },
 };
 
 export const transactionFails = {
   ...defaults,
-  // states
-  waitForTransaction: waitForTransactionFailure,
-  acknowledgeFailure: acknowledge('TransactionFailed'),
-  failure: failure('TransactionFailed'),
-  // actions
-  transactionFailureTrigger,
-  failureAcknowledged,
+  waitForTransaction: {
+    state: waitForTransactionFailure,
+    action: transactionFailureTrigger,
+  },
+  acknowledgeFailure: {
+    state: acknowledge('TransactionFailed'),
+    action: failureAcknowledged,
+  },
 };

--- a/packages/wallet/src/redux/protocols/challenging/__tests__/scenarios.ts
+++ b/packages/wallet/src/redux/protocols/challenging/__tests__/scenarios.ts
@@ -14,9 +14,9 @@ import {
   challengeExpirySetEvent,
 } from '../../../actions';
 import {
-  // preSuccessState as defundingPreSuccessState,
+  preSuccessState as defundingPreSuccessState,
   successTrigger as defundingSuccessTrigger,
-  // preFailureState as defundingPreFailureState,
+  preFailureState as defundingPreFailureState,
   failureTrigger as defundingFailureTrigger,
 } from '../../defunding/__tests__';
 
@@ -70,7 +70,14 @@ const acknowledgeTimeout = states.acknowledgeTimeout(defaults);
 const acknowledgeResponse = states.acknowledgeResponse(defaults);
 const successOpen = states.successOpen();
 const acknowledge = (reason: Reason) => states.acknowledgeFailure({ ...defaults, reason });
-const waitForDefund = states.waitForDefund({ ...defaults });
+const waitForDefund1 = states.waitForDefund({
+  ...defaults,
+  defundingState: defundingPreSuccessState,
+});
+const waitForDefund2 = states.waitForDefund({
+  ...defaults,
+  defundingState: defundingPreFailureState,
+});
 const acknowledgeSuccess = states.acknowledgeSuccess({ ...defaults });
 const acknowledgeClosedButNotDefunded = states.AcknowledgeClosedButNotDefunded({ ...defaults });
 
@@ -134,7 +141,7 @@ export const challengeTimesOutAndIsDefunded = {
     action: defundChosen,
   },
   challengerWaitForDefund: {
-    state: waitForDefund,
+    state: waitForDefund1,
     action: defundingSuccessTrigger,
   },
   acknowledgeSuccess: {
@@ -146,7 +153,7 @@ export const challengeTimesOutAndIsDefunded = {
 export const challengeTimesOutAndIsNotDefunded = {
   ...defaults,
   challengerWaitForDefund: {
-    state: waitForDefund,
+    state: waitForDefund2,
     action: defundingFailureTrigger,
   },
   acknowledgeClosedButNotDefunded: {

--- a/packages/wallet/src/redux/protocols/challenging/__tests__/stories.tsx
+++ b/packages/wallet/src/redux/protocols/challenging/__tests__/stories.tsx
@@ -23,51 +23,21 @@ const render = container => () => {
   );
 };
 
-const opponentResponds = {
-  ApproveChallenge: scenarios.opponentResponds.approveChallenge,
-  WaitForTransaction: scenarios.opponentResponds.waitForTransaction,
-  WaitForResponseOrTimeout: scenarios.opponentResponds.waitForResponseOrTimeout,
-  AcknowledgeResponse: scenarios.opponentResponds.acknowledgeResponse,
-};
+addStories(scenarios.opponentResponds, 'Challenging / Opponent responds');
+addStories(
+  scenarios.challengeTimesOutAndIsDefunded,
+  'Challenging / Challenge times out and is defunded',
+);
+addStories(scenarios.channelDoesntExist, "Challenging / Channel doesn't exist");
+addStories(scenarios.channelNotFullyOpen, 'Challenging / Channel not fully open');
+addStories(scenarios.alreadyHaveLatest, 'Challenging / Already have latest state');
+addStories(scenarios.userDeclinesChallenge, 'Challenging / User declines challenge');
+addStories(scenarios.transactionFails, 'Challenging / Transaction fails');
 
-const challengeTimesOut = {
-  WaitForResponseOrTimeout: scenarios.challengeTimesOut.waitForResponseOrTimeout,
-  AcknowledgeTimeout: scenarios.challengeTimesOut.acknowledgeTimeout,
-};
-
-const channelDoesntExist = {
-  AcknowledgeFailure: scenarios.channelDoesntExist.acknowledgeFailure,
-};
-
-const channelNotFullyOpen = {
-  AcknowledgeFailure: scenarios.channelNotFullyOpen.acknowledgeFailure,
-};
-
-const alreadyHaveLatest = {
-  AcknowledgeFailure: scenarios.alreadyHaveLatest.acknowledgeFailure,
-};
-
-const userDeclinesChallenge = {
-  ApproveChallenge: scenarios.userDeclinesChallenge.approveChallenge,
-  AcknowledgeFailure: scenarios.userDeclinesChallenge.acknowledgeFailure,
-};
-
-const transactionFails = {
-  WaitForTransaction: scenarios.transactionFails.waitForTransaction,
-  AcknowledgeFailure: scenarios.transactionFails.acknowledgeFailure,
-};
-
-addStories(opponentResponds, 'Challenging / Opponent responds');
-addStories(challengeTimesOut, 'Challenging / Challenge times out');
-addStories(channelDoesntExist, "Challenging / Channel doesn't exist");
-addStories(channelNotFullyOpen, 'Challenging / Channel not fully open');
-addStories(alreadyHaveLatest, 'Challenging / Already have latest state');
-addStories(userDeclinesChallenge, 'Challenging / User declines challenge');
-addStories(transactionFails, 'Challenging / Transaction fails');
-
-function addStories(collection, chapter) {
-  Object.keys(collection).map(storyName => {
-    const state = collection[storyName];
-    storiesOf(chapter, module).add(storyName, render(<Challenging state={state} />));
+function addStories(scenario, chapter) {
+  Object.keys(scenario).forEach(key => {
+    if (scenario[key].state) {
+      storiesOf(chapter, module).add(key, render(<Challenging state={scenario[key].state} />));
+    }
   });
 }

--- a/packages/wallet/src/redux/protocols/challenging/actions.ts
+++ b/packages/wallet/src/redux/protocols/challenging/actions.ts
@@ -20,7 +20,6 @@ export type ChallengingAction =
   | RespondWithMoveEvent
   | ChallengeExpiredEvent
   | ChallengeExpirySetEvent
-  | ChallengeTimeoutAcknowledged
   | ChallengeResponseAcknowledged
   | ChallengeFailureAcknowledged
   | DefundChosen
@@ -46,11 +45,6 @@ export interface ChallengeApproved {
 
 export interface ChallengeDenied {
   type: typeof CHALLENGE_DENIED;
-  processId: string;
-}
-
-export interface ChallengeTimeoutAcknowledged {
-  type: typeof CHALLENGE_TIMEOUT_ACKNOWLEDGED;
   processId: string;
 }
 
@@ -87,11 +81,6 @@ export const challengeDenied = (processId: string): ChallengeDenied => ({
   processId,
 });
 
-export const challengeTimeoutAcknowledged = (processId: string): ChallengeTimeoutAcknowledged => ({
-  type: CHALLENGE_TIMEOUT_ACKNOWLEDGED,
-  processId,
-});
-
 export const challengeResponseAcknowledged = (
   processId: string,
 ): ChallengeResponseAcknowledged => ({
@@ -120,7 +109,6 @@ export function isChallengingAction(action: ProtocolAction): action is Challengi
     isDefundingAction(action) ||
     action.type === CHALLENGE_APPROVED ||
     action.type === CHALLENGE_DENIED ||
-    action.type === CHALLENGE_TIMEOUT_ACKNOWLEDGED ||
     action.type === CHALLENGE_RESPONSE_ACKNOWLEDGED ||
     action.type === CHALLENGE_FAILURE_ACKNOWLEDGED ||
     action.type === CHALLENGE_EXPIRED_EVENT ||

--- a/packages/wallet/src/redux/protocols/challenging/actions.ts
+++ b/packages/wallet/src/redux/protocols/challenging/actions.ts
@@ -10,6 +10,7 @@ import {
   CHALLENGE_EXPIRY_SET_EVENT,
 } from '../../actions';
 import { isTransactionAction, TransactionAction } from '../transaction-submission/actions';
+
 export type ChallengingAction =
   | TransactionAction
   | ChallengeApproved
@@ -20,7 +21,9 @@ export type ChallengingAction =
   | ChallengeExpirySetEvent
   | ChallengeTimeoutAcknowledged
   | ChallengeResponseAcknowledged
-  | ChallengeFailureAcknowledged;
+  | ChallengeFailureAcknowledged
+  | DefundChosen
+  | Acknowledged;
 
 // ------------
 // Action types
@@ -30,6 +33,8 @@ export const CHALLENGE_DENIED = 'CHALLENGE.DENIED';
 export const CHALLENGE_TIMEOUT_ACKNOWLEDGED = 'CHALLENGE.TIMEOUT_ACKNOWLEDGED';
 export const CHALLENGE_RESPONSE_ACKNOWLEDGED = 'CHALLENGE.RESPONSE_ACKNOWLEDGED';
 export const CHALLENGE_FAILURE_ACKNOWLEDGED = 'CHALLENGE.FAILURE_ACKNOWLEDGED';
+export const DEFUND_CHOSEN = 'CHALLENGE.DEFUND_CHOSEN';
+export const ACKNOWLEDGED = 'CHALLENGE.ACKNOWLEDGED';
 // -------
 // Actions
 // -------
@@ -55,6 +60,16 @@ export interface ChallengeResponseAcknowledged {
 
 export interface ChallengeFailureAcknowledged {
   type: typeof CHALLENGE_FAILURE_ACKNOWLEDGED;
+  processId: string;
+}
+
+export interface DefundChosen {
+  type: typeof DEFUND_CHOSEN;
+  processId: string;
+}
+
+export interface Acknowledged {
+  type: typeof ACKNOWLEDGED;
   processId: string;
 }
 
@@ -85,6 +100,16 @@ export const challengeResponseAcknowledged = (
 
 export const challengeFailureAcknowledged = (processId: string): ChallengeFailureAcknowledged => ({
   type: CHALLENGE_FAILURE_ACKNOWLEDGED,
+  processId,
+});
+
+export const defundChosen = (processId: string): DefundChosen => ({
+  type: DEFUND_CHOSEN,
+  processId,
+});
+
+export const acknowledged = (processId: string): Acknowledged => ({
+  type: ACKNOWLEDGED,
   processId,
 });
 

--- a/packages/wallet/src/redux/protocols/challenging/actions.ts
+++ b/packages/wallet/src/redux/protocols/challenging/actions.ts
@@ -10,6 +10,7 @@ import {
   CHALLENGE_EXPIRY_SET_EVENT,
 } from '../../actions';
 import { isTransactionAction, TransactionAction } from '../transaction-submission/actions';
+import { isDefundingAction } from '../defunding/actions';
 
 export type ChallengingAction =
   | TransactionAction
@@ -116,6 +117,7 @@ export const acknowledged = (processId: string): Acknowledged => ({
 export function isChallengingAction(action: ProtocolAction): action is ChallengingAction {
   return (
     isTransactionAction(action) ||
+    isDefundingAction(action) ||
     action.type === CHALLENGE_APPROVED ||
     action.type === CHALLENGE_DENIED ||
     action.type === CHALLENGE_TIMEOUT_ACKNOWLEDGED ||
@@ -124,6 +126,8 @@ export function isChallengingAction(action: ProtocolAction): action is Challengi
     action.type === CHALLENGE_EXPIRED_EVENT ||
     action.type === RESPOND_WITH_MOVE_EVENT ||
     action.type === REFUTED_EVENT ||
-    action.type === CHALLENGE_EXPIRY_SET_EVENT
+    action.type === CHALLENGE_EXPIRY_SET_EVENT ||
+    action.type === DEFUND_CHOSEN ||
+    action.type === ACKNOWLEDGED
   );
 }

--- a/packages/wallet/src/redux/protocols/challenging/container.tsx
+++ b/packages/wallet/src/redux/protocols/challenging/container.tsx
@@ -8,6 +8,7 @@ import ApproveChallenge from './components/approve-challenge';
 import { TransactionSubmission } from '../transaction-submission';
 import Acknowledge from '../shared-components/acknowledge';
 import WaitForResponseOrTimeout from './components/wait-for-response-or-timeout';
+import { Defunding } from '../defunding/container';
 
 interface Props {
   state: NonTerminalChallengingState;
@@ -15,7 +16,8 @@ interface Props {
   deny: (processId: string) => void;
   failureAcknowledged: (processId: string) => void;
   responseAcknowledged: (processId: string) => void;
-  timeoutAcknowledged: (processId: string) => void;
+  acknowledged: (processId: string) => void;
+  defundChosen: (processId: string) => void;
 }
 
 class ChallengingContainer extends PureComponent<Props> {
@@ -26,7 +28,8 @@ class ChallengingContainer extends PureComponent<Props> {
       approve,
       failureAcknowledged,
       responseAcknowledged,
-      timeoutAcknowledged,
+      acknowledged,
+      defundChosen,
     } = this.props;
     const processId = state.processId;
     switch (state.type) {
@@ -52,7 +55,7 @@ class ChallengingContainer extends PureComponent<Props> {
           <Acknowledge
             title="Challenge timed out!"
             description="The challenge timed out. You can now reclaim your funds."
-            acknowledge={() => timeoutAcknowledged(processId)}
+            acknowledge={() => defundChosen(processId)}
           />
         );
       case 'Challenging.AcknowledgeFailure':
@@ -63,6 +66,24 @@ class ChallengingContainer extends PureComponent<Props> {
             title="Challenge not possible"
             description={description}
             acknowledge={() => failureAcknowledged(processId)}
+          />
+        );
+      case 'Challenging.WaitForDefund':
+        return <Defunding state={state.defundingState} />;
+      case 'Challenging.AcknowledgeClosedButNotDefunded':
+        return (
+          <Acknowledge
+            title="Defunding failed!"
+            description="The channel was closed but not defunded."
+            acknowledge={() => acknowledged(processId)}
+          />
+        );
+      case 'Challenging.AcknowledgeSuccess':
+        return (
+          <Acknowledge
+            title="Success!"
+            description="The channel was closed and defunded."
+            acknowledge={() => acknowledged(processId)}
           />
         );
       default:
@@ -95,7 +116,8 @@ const mapDispatchToProps = {
   deny: actions.challengeDenied,
   failureAcknowledged: actions.challengeFailureAcknowledged,
   responseAcknowledged: actions.challengeResponseAcknowledged,
-  timeoutAcknowledged: actions.challengeTimeoutAcknowledged,
+  acknowledged: actions.acknowledged,
+  defundChosen: actions.defundChosen,
 };
 
 export const Challenging = connect(

--- a/packages/wallet/src/redux/protocols/challenging/readme.md
+++ b/packages/wallet/src/redux/protocols/challenging/readme.md
@@ -30,7 +30,7 @@ linkStyle default interpolate basis
   AF --> |FailureAcknowledged| F((Failure))
   WFT --> |TransactionSuccess| WFRT(WaitForResponseOrTimeout)
   WFT --> |TransactionFailure| AF
-  WFRT --> |BlockMined??| AT(AcknowledgeTimeout)
+  WFRT --> |CHALLENGE_EXPIRED| AT(AcknowledgeTimeout)
   AT --> |DefundChosen| D(WaitForDefund)
   D   --> |defunding protocol succeeded| AS(AcknowledgeSuccess)
   D   --> |defunding protocol failed| ACBND(AcknowledgeClosedButNotDefunded)
@@ -45,7 +45,7 @@ linkStyle default interpolate basis
   class S,CE logic;
   class SP,SCD,SCBND Success;
   class F Failure;
-  class D WaitForChildProtocol;
+  class WFT,D WaitForChildProtocol;
 ```
 
 Note:

--- a/packages/wallet/src/redux/protocols/challenging/readme.md
+++ b/packages/wallet/src/redux/protocols/challenging/readme.md
@@ -31,6 +31,7 @@ linkStyle default interpolate basis
   WFT --> |TransactionSuccess| WFRT(WaitForResponseOrTimeout)
   WFT --> |TransactionFailure| AF
   WFRT --> |CHALLENGE_EXPIRED| AT(AcknowledgeTimeout)
+  WFRT -->|ChallengeExpirySetEvent| WFRT
   AT --> |DefundChosen| D(WaitForDefund)
   D   --> |defunding protocol succeeded| AS(AcknowledgeSuccess)
   D   --> |defunding protocol failed| ACBND(AcknowledgeClosedButNotDefunded)

--- a/packages/wallet/src/redux/protocols/challenging/readme.md
+++ b/packages/wallet/src/redux/protocols/challenging/readme.md
@@ -35,7 +35,7 @@ linkStyle default interpolate basis
   D   --> |defunding protocol succeeded| AS(AcknowledgeSuccess)
   D   --> |defunding protocol failed| ACBND(AcknowledgeClosedButNotDefunded)
   ACBND -->|Acknowledged| SCBND((ClosedButNotDefunded))
-  AS -->|AcknowledgeSuccess| SCD((ClosedAndDefunded))
+  AS -->|Acknowledged| SCD((ClosedAndDefunded))
   WFRT --> |ChallengeResponseReceived| AR(AcknowledgeResponse)
   AR --> |ResponseAcknowledged| SP((Open))
   classDef logic fill:#efdd20;

--- a/packages/wallet/src/redux/protocols/challenging/readme.md
+++ b/packages/wallet/src/redux/protocols/challenging/readme.md
@@ -34,8 +34,8 @@ linkStyle default interpolate basis
   AT --> |DefundChosen| D(WaitForDefund)
   D   --> |defunding protocol succeeded| AS(AcknowledgeSuccess)
   D   --> |defunding protocol failed| ACBND(AcknowledgeClosedButNotDefunded)
-  ACBND -->|Acknowledged| SC((Closed))
-  AS -->|AcknowledgeSuccess| SC((Closed))
+  ACBND -->|Acknowledged| SCBND((ClosedButNotDefunded))
+  AS -->|AcknowledgeSuccess| SCD((ClosedAndDefunded))
   WFRT --> |ChallengeResponseReceived| AR(AcknowledgeResponse)
   AR --> |ResponseAcknowledged| SP((Open))
   classDef logic fill:#efdd20;
@@ -43,12 +43,10 @@ linkStyle default interpolate basis
   classDef Failure fill:#f45941;
   classDef WaitForChildProtocol stroke:#333,stroke-width:4px,color:#ffff,fill:#333;
   class S,CE logic;
-  class SP,SC Success;
+  class SP,SCD,SCBND Success;
   class F Failure;
   class D WaitForChildProtocol;
 ```
-
-<!-- style D stroke:#333,stroke-width:4px -->
 
 Note:
 
@@ -62,8 +60,8 @@ To test all paths through the state machine we will the following scenarios:
 
 1. **Opponent responds**: `ApproveChallenge` -> `WaitForTransaction` -> `WaitForResponseOrTimeout`
    -> `AcknowledgeResponse` -> `Open`
-2. **Challenge times out and is defunded**: `WaitForResponseOrTimeout` -> `AcknowledgeTimeout` -> `ChallengerWaitForDefund` -> `AcknowledgeSuccess` -> `Closed`
-3. **Challenge times out and is not defunded**: `ChallengerWaitForDefund` -> `AcknowledgeClosedButNotDefunded` -> `Closed`
+2. **Challenge times out and is defunded**: `WaitForResponseOrTimeout` -> `AcknowledgeTimeout` -> `ChallengerWaitForDefund` -> `AcknowledgeSuccess` -> `ClosedAndDefunded`
+3. **Challenge times out and is not defunded**: `ChallengerWaitForDefund` -> `AcknowledgeClosedButNotDefunded` -> `ClosedButNotDefunded`
 4. **Channel doesn't exist**: `AcknowledgeFailure` -> `Failure`
    - Challenge requested for `channelId` that doesn't exist in the wallet.
 5. **Channel not fully open**: `AcknowledgeFailure` -> `Failure`

--- a/packages/wallet/src/redux/protocols/challenging/readme.md
+++ b/packages/wallet/src/redux/protocols/challenging/readme.md
@@ -31,7 +31,7 @@ linkStyle default interpolate basis
   WFT --> |TransactionSuccess| WFRT(WaitForResponseOrTimeout)
   WFT --> |TransactionFailure| AF
   WFRT --> |BlockMined??| AT(AcknowledgeTimeout)
-  AT --> |DefundChosen| D(ChallengerWaitForDefund)
+  AT --> |DefundChosen| D(WaitForDefund)
   D   --> |defunding protocol succeeded| AS(AcknowledgeSuccess)
   D   --> |defunding protocol failed| ACBND(AcknowledgeClosedButNotDefunded)
   ACBND -->|Acknowledged| SC((Closed))

--- a/packages/wallet/src/redux/protocols/challenging/readme.md
+++ b/packages/wallet/src/redux/protocols/challenging/readme.md
@@ -34,7 +34,7 @@ linkStyle default interpolate basis
   AT --> |DefundChosen| D(ChallengerWaitForDefund)
   D   --> |defunding protocol succeeded| AS(AcknowledgeSuccess)
   D   --> |defunding protocol failed| ACBND(AcknowledgeClosedButNotDefunded)
-  ACBND -->|AcknowledgeSuccess| SC((Closed))
+  ACBND -->|Acknowledged| SC((Closed))
   AS -->|AcknowledgeSuccess| SC((Closed))
   WFRT --> |ChallengeResponseReceived| AR(AcknowledgeResponse)
   AR --> |ResponseAcknowledged| SP((Open))
@@ -62,13 +62,14 @@ To test all paths through the state machine we will the following scenarios:
 
 1. **Opponent responds**: `ApproveChallenge` -> `WaitForTransaction` -> `WaitForResponseOrTimeout`
    -> `AcknowledgeResponse` -> `Open`
-2. **Challenge times out**: `WaitForResponseOrTimeout` -> `AcknowledgeTimeout` -> `Closed`
-3. **Channel doesn't exist**: `AcknowledgeFailure` -> `Failure`
+2. **Challenge times out and is defunded**: `WaitForResponseOrTimeout` -> `AcknowledgeTimeout` -> `ChallengerWaitForDefund` -> `AcknowledgeSuccess` -> `Closed`
+3. **Challenge times out and is not defunded**: `ChallengerWaitForDefund` -> `AcknowledgeClosedButNotDefunded` -> `Closed`
+4. **Channel doesn't exist**: `AcknowledgeFailure` -> `Failure`
    - Challenge requested for `channelId` that doesn't exist in the wallet.
-4. **Channel not fully open**: `AcknowledgeFailure` -> `Failure`
+5. **Channel not fully open**: `AcknowledgeFailure` -> `Failure`
    - Challenge requested for channel which only has one state (two are needed to challenge).
-5. **Already have latest commitment**: `AcknowledgeFailure` -> `Failure`
-6. **User declines challenge**: `ApproveChallenge` -> `AcknowledgeFailure` -> `Failure`
-7. **Receive commitment while approving**: `ApproveChallenge` -> `AcknowledgeFailure`
+6. **Already have latest commitment**: `AcknowledgeFailure` -> `Failure`
+7. **User declines challenge**: `ApproveChallenge` -> `AcknowledgeFailure` -> `Failure`
+8. **Receive commitment while approving**: `ApproveChallenge` -> `AcknowledgeFailure`
    - The opponent's commitment arrives while the user is approving the challenge
-8. **Transaction fails**: `WaitForTransaction` -> `AcknowledgeFailure` -> `Failure`
+9. **Transaction fails**: `WaitForTransaction` -> `AcknowledgeFailure` -> `Failure`

--- a/packages/wallet/src/redux/protocols/challenging/states.ts
+++ b/packages/wallet/src/redux/protocols/challenging/states.ts
@@ -124,7 +124,10 @@ export function isChallengingState(state: ProtocolState): state is ChallengingSt
     state.type === 'Challenging.Failure' ||
     state.type === 'Challenging.SuccessOpen' ||
     state.type === 'Challenging.SuccessClosedAndDefunded' ||
-    state.type === 'Challenging.SuccessClosedButNotDefunded'
+    state.type === 'Challenging.SuccessClosedButNotDefunded' ||
+    state.type === 'Challenging.WaitForDefund' ||
+    state.type === 'Challenging.AcknowledgeSuccess' ||
+    state.type === 'Challenging.AcknowledgeClosedButNotDefunded'
   );
 }
 

--- a/packages/wallet/src/redux/protocols/challenging/states.ts
+++ b/packages/wallet/src/redux/protocols/challenging/states.ts
@@ -1,6 +1,7 @@
 import { Properties as P } from '../../utils';
 import { NonTerminalTransactionSubmissionState } from '../transaction-submission';
 import { ProtocolState } from '..';
+import { DefundingState } from '../defunding';
 
 export type ChallengingState = NonTerminalState | TerminalState;
 export type ChallengingStateType = ChallengingState['type'];
@@ -73,6 +74,7 @@ export interface WaitForDefund {
   type: 'Challenging.WaitForDefund';
   processId: string;
   channelId: string;
+  defundingState: DefundingState;
 }
 
 export interface AcknowledgeClosedButNotDefunded {
@@ -179,8 +181,8 @@ export function acknowledgeFailure(p: P<AcknowledgeFailure>): AcknowledgeFailure
 }
 
 export function waitForDefund(p: P<WaitForDefund>): WaitForDefund {
-  const { processId, channelId } = p;
-  return { type: 'Challenging.WaitForDefund', processId, channelId };
+  const { processId, channelId, defundingState } = p;
+  return { type: 'Challenging.WaitForDefund', processId, channelId, defundingState };
 }
 
 export function AcknowledgeClosedButNotDefunded(

--- a/packages/wallet/src/redux/protocols/challenging/states.ts
+++ b/packages/wallet/src/redux/protocols/challenging/states.ts
@@ -16,7 +16,11 @@ export type NonTerminalState =
   | AcknowledgeClosedButNotDefunded
   | AcknowledgeSuccess;
 
-export type TerminalState = SuccessOpen | SuccessClosed | Failure;
+export type TerminalState =
+  | SuccessOpen
+  | SuccessClosedAndDefunded
+  | SuccessClosedButNotDefunded
+  | Failure;
 
 export type FailureReason =
   | 'ChannelDoesntExist'
@@ -91,8 +95,12 @@ export interface SuccessOpen {
   type: 'Challenging.SuccessOpen';
 }
 
-export interface SuccessClosed {
-  type: 'Challenging.SuccessClosed';
+export interface SuccessClosedAndDefunded {
+  type: 'Challenging.SuccessClosedAndDefunded';
+}
+
+export interface SuccessClosedButNotDefunded {
+  type: 'Challenging.SuccessClosedButNotDefunded';
 }
 
 // -------
@@ -113,7 +121,8 @@ export function isChallengingState(state: ProtocolState): state is ChallengingSt
     state.type === 'Challenging.AcknowledgeResponse' ||
     state.type === 'Challenging.Failure' ||
     state.type === 'Challenging.SuccessOpen' ||
-    state.type === 'Challenging.SuccessClosed'
+    state.type === 'Challenging.SuccessClosedAndDefunded' ||
+    state.type === 'Challenging.SuccessClosedButNotDefunded'
   );
 }
 
@@ -121,7 +130,8 @@ export function isTerminal(state: ChallengingState): state is TerminalState {
   return (
     state.type === 'Challenging.Failure' ||
     state.type === 'Challenging.SuccessOpen' ||
-    state.type === 'Challenging.SuccessClosed'
+    state.type === 'Challenging.SuccessClosedAndDefunded' ||
+    state.type === 'Challenging.SuccessClosedButNotDefunded'
   );
 }
 
@@ -190,8 +200,12 @@ export function failure(p: P<Failure>): Failure {
   return { type: 'Challenging.Failure', reason };
 }
 
-export function successClosed(): SuccessClosed {
-  return { type: 'Challenging.SuccessClosed' };
+export function successClosedAndDefunded(): SuccessClosedAndDefunded {
+  return { type: 'Challenging.SuccessClosedAndDefunded' };
+}
+
+export function successClosedButNotDefunded(): SuccessClosedButNotDefunded {
+  return { type: 'Challenging.SuccessClosedButNotDefunded' };
 }
 
 export function successOpen(): SuccessOpen {

--- a/packages/wallet/src/redux/protocols/challenging/states.ts
+++ b/packages/wallet/src/redux/protocols/challenging/states.ts
@@ -11,7 +11,10 @@ export type NonTerminalState =
   | WaitForResponseOrTimeout
   | AcknowledgeTimeout
   | AcknowledgeResponse
-  | AcknowledgeFailure;
+  | AcknowledgeFailure
+  | WaitForDefund
+  | AcknowledgeClosedButNotDefunded
+  | AcknowledgeSuccess;
 
 export type TerminalState = SuccessOpen | SuccessClosed | Failure;
 
@@ -58,6 +61,24 @@ export interface AcknowledgeFailure {
 }
 export interface AcknowledgeResponse {
   type: 'Challenging.AcknowledgeResponse';
+  processId: string;
+  channelId: string;
+}
+
+export interface WaitForDefund {
+  type: 'Challenging.WaitForDefund';
+  processId: string;
+  channelId: string;
+}
+
+export interface AcknowledgeClosedButNotDefunded {
+  type: 'Challenging.AcknowledgeClosedButNotDefunded';
+  processId: string;
+  channelId: string;
+}
+
+export interface AcknowledgeSuccess {
+  type: 'Challenging.AcknowledgeSuccess';
   processId: string;
   channelId: string;
 }
@@ -145,6 +166,23 @@ export function acknowledgeTimeout(p: P<AcknowledgeTimeout>): AcknowledgeTimeout
 export function acknowledgeFailure(p: P<AcknowledgeFailure>): AcknowledgeFailure {
   const { processId, channelId, reason } = p;
   return { type: 'Challenging.AcknowledgeFailure', processId, channelId, reason };
+}
+
+export function waitForDefund(p: P<WaitForDefund>): WaitForDefund {
+  const { processId, channelId } = p;
+  return { type: 'Challenging.WaitForDefund', processId, channelId };
+}
+
+export function AcknowledgeClosedButNotDefunded(
+  p: P<AcknowledgeClosedButNotDefunded>,
+): AcknowledgeClosedButNotDefunded {
+  const { processId, channelId } = p;
+  return { type: 'Challenging.AcknowledgeClosedButNotDefunded', processId, channelId };
+}
+
+export function acknowledgeSuccess(p: P<AcknowledgeSuccess>): AcknowledgeSuccess {
+  const { processId, channelId } = p;
+  return { type: 'Challenging.AcknowledgeSuccess', processId, channelId };
 }
 
 export function failure(p: P<Failure>): Failure {

--- a/packages/wallet/src/redux/protocols/concluding/instigator/readme.md
+++ b/packages/wallet/src/redux/protocols/concluding/instigator/readme.md
@@ -20,6 +20,7 @@ The protocol is implemented with the following state machine
 
 ```mermaid
 graph TD
+linkStyle default interpolate basis
   S((Start)) --> E{Channel Exists?}
   E --> |No| AF(InstigatorAcknowledgeFailure)
   AF -->|ACKNOWLEDGED| F((Failure))
@@ -33,12 +34,14 @@ graph TD
   D   --> |defunding protocol succeeded| AS(InstigatorAcknowledgeSuccess)
   AS -->  |ACKNOWLEDGED| SS((Success))
   D   --> |defunding protocol failed| AF(InstigatorAcknowledgeFailure)
-  style S  fill:#efdd20
-  style E  fill:#efdd20
-  style MT fill:#efdd20
-  style SS fill:#58ef21
-  style F  fill:#f45941
-  style D stroke:#333,stroke-width:4px
+  classDef logic fill:#efdd20;
+  classDef Success fill:#58ef21;
+  classDef Failure fill:#f45941;
+  classDef WaitForChildProtocol stroke:#333,stroke-width:4px,color:#ffff,fill:#333;
+  class S,E,MT logic;
+  class SS Success;
+  class F Failure;
+  class D WaitForChildProtocol;
 ```
 
 ## Scenarios

--- a/packages/wallet/src/redux/protocols/concluding/responder/readme.md
+++ b/packages/wallet/src/redux/protocols/concluding/responder/readme.md
@@ -33,12 +33,14 @@ linkStyle default interpolate basis
   D   --> |defunding protocol succeeded| AS(ResponderAcknowledgeSuccess)
   AS -->  |ACKNOWLEDGED| SS((Success))
   D   --> |defunding protocol failed| AF(ResponderAcknowledgeFailure)
-  style S  fill:#efdd20
-  style E  fill:#efdd20
-  style MT fill:#efdd20
-  style SS fill:#58ef21
-  style F  fill:#f45941
-  style D stroke:#333,stroke-width:4px
+  classDef logic fill:#efdd20;
+  classDef Success fill:#58ef21;
+  classDef Failure fill:#f45941;
+  classDef WaitForChildProtocol stroke:#333,stroke-width:4px,color:#ffff,fill:#333;
+  class S,E,MT logic;
+  class SS Success;
+  class F Failure;
+  class D WaitForChildProtocol;
 ```
 
 ## Scenarios

--- a/packages/wallet/src/redux/protocols/defunding/readme.md
+++ b/packages/wallet/src/redux/protocols/defunding/readme.md
@@ -23,13 +23,14 @@ linkStyle default interpolate basis
   WP-->|Withdrawal protocol failure|F((failure))
   LDP-->|Indirect de-funding protocol failure|F((failure))
 
-  style S  fill:#efdd20
-  style ICC  fill:#efdd20
-  style ID fill:#efdd20
-  style Su fill:#58ef21
-  style F  fill:#f45941
-  style WP stroke:#333,stroke-width:4px
-  style LDP stroke:#333,stroke-width:4px
+  classDef logic fill:#efdd20;
+  classDef Success fill:#58ef21;
+  classDef Failure fill:#f45941;
+  classDef WaitForChildProtocol stroke:#333,stroke-width:4px,color:#ffff,fill:#333;
+  class S,ICC,ID logic;
+  class Su Success;
+  class F Failure;
+  class WP,LDP WaitForChildProtocol;
 ```
 
 ## Notes

--- a/packages/wallet/src/redux/protocols/direct-funding/components/funding-step.tsx
+++ b/packages/wallet/src/redux/protocols/direct-funding/components/funding-step.tsx
@@ -20,6 +20,7 @@ const fundingStepByState = (state: directFundingState.DirectFundingState): Step 
     case directFundingState.NOT_SAFE_TO_DEPOSIT:
       return Step.NOT_SAFE_TO_DEPOSIT;
     case directFundingState.WAIT_FOR_DEPOSIT_TRANSACTION:
+      return Step.WAIT_FOR_DEPOSIT_TRANSACTION;
     case directFundingState.WAIT_FOR_FUNDING_AND_POST_FUND_SETUP:
       return Step.WAITING_FOR_FUNDING_CONFIRMATION;
     case directFundingState.FUNDING_SUCCESS:

--- a/packages/wallet/src/redux/protocols/funding/player-a/__tests__/stories.tsx
+++ b/packages/wallet/src/redux/protocols/funding/player-a/__tests__/stories.tsx
@@ -32,7 +32,7 @@ addStories(scenarios.cancelledByOpponent, 'Funding / Player A / Cancelled by opp
 function addStories(scenario, chapter) {
   Object.keys(scenario.states).forEach(key => {
     if (!isTerminal(scenario.states[key])) {
-      storiesOf(chapter, module).add(key, render(<Funding state={scenario.states[key]} />));
+      storiesOf(chapter, module).add(key, render(<Funding state={scenario.states[key].state} />));
     }
   });
 }

--- a/packages/wallet/src/redux/protocols/funding/player-b/__tests__/stories.tsx
+++ b/packages/wallet/src/redux/protocols/funding/player-b/__tests__/stories.tsx
@@ -32,7 +32,7 @@ addStories(scenarios.cancelledByOpponent, 'Funding / Player B / Cancelled by opp
 function addStories(scenario, chapter) {
   Object.keys(scenario.states).forEach(key => {
     if (!isTerminal(scenario.states[key])) {
-      storiesOf(chapter, module).add(key, render(<Funding state={scenario.states[key]} />));
+      storiesOf(chapter, module).add(key, render(<Funding state={scenario.states[key].state} />));
     }
   });
 }

--- a/packages/wallet/src/redux/protocols/responding/__tests__/reducer.test.ts
+++ b/packages/wallet/src/redux/protocols/responding/__tests__/reducer.test.ts
@@ -191,20 +191,6 @@ describe('select response happy-path scenario', () => {
   });
 });
 
-describe('user declines scenario', () => {
-  const scenario = scenarios.userDeclines;
-  const { sharedData } = scenario;
-
-  describe(`when in ${states.WAIT_FOR_APPROVAL}`, () => {
-    const state = scenario.waitForApproval;
-    const action = scenario.reject;
-
-    const result = respondingReducer(state, sharedData, action);
-
-    itTransitionsToFailure(result, scenario.failure);
-  });
-});
-
 describe('transaction failed scenario', () => {
   const scenario = scenarios.transactionFails;
   const { sharedData } = scenario;

--- a/packages/wallet/src/redux/protocols/responding/__tests__/reducer.test.ts
+++ b/packages/wallet/src/redux/protocols/responding/__tests__/reducer.test.ts
@@ -60,13 +60,13 @@ const itSetsChallengeCommitment = (
   });
 };
 
-describe('respond with existing move happy-path scenario', () => {
+describe('RESPOND WITH EXISTING MOVE HAPPY-PATH', () => {
   const scenario = scenarios.respondWithExistingCommitmentHappyPath;
-  const { sharedData, processId } = scenario;
+  const { sharedData, processId, channelId } = scenario;
 
   describe('when initializing', () => {
     const { challengeCommitment } = scenario;
-    const result = initialize(processId, sharedData, challengeCommitment);
+    const result = initialize(processId, channelId, sharedData, challengeCommitment);
 
     itTransitionsTo(result, states.WAIT_FOR_APPROVAL);
     itSendsThisDisplayEventType(result.sharedData, SHOW_WALLET);
@@ -100,13 +100,13 @@ describe('respond with existing move happy-path scenario', () => {
   });
 });
 
-describe('refute happy-path scenario', () => {
+describe('REFUTE HAPPY-PATH ', () => {
   const scenario = scenarios.refuteHappyPath;
-  const { sharedData, processId } = scenario;
+  const { sharedData, processId, channelId } = scenario;
 
   describe('when initializing', () => {
     const { challengeCommitment } = scenario;
-    const result = initialize(processId, sharedData, challengeCommitment);
+    const result = initialize(processId, channelId, sharedData, challengeCommitment);
 
     itTransitionsTo(result, states.WAIT_FOR_APPROVAL);
     itSetsChallengeCommitment(result, scenario.challengeCommitment);
@@ -139,12 +139,12 @@ describe('refute happy-path scenario', () => {
   });
 });
 
-describe('select response happy-path scenario', () => {
+describe('SELECT RESPONSE HAPPY-PATH ', () => {
   const scenario = scenarios.requireResponseHappyPath;
-  const { sharedData, processId } = scenario;
+  const { sharedData, processId, channelId } = scenario;
 
   describe('when initializing', () => {
-    const result = initialize(processId, sharedData, scenario.challengeCommitment);
+    const result = initialize(processId, channelId, sharedData, scenario.challengeCommitment);
 
     itTransitionsTo(result, states.WAIT_FOR_APPROVAL);
     itSetsChallengeCommitment(result, scenario.challengeCommitment);
@@ -191,7 +191,7 @@ describe('select response happy-path scenario', () => {
   });
 });
 
-describe('transaction failed scenario', () => {
+describe('TRANSACTION FAILED ', () => {
   const scenario = scenarios.transactionFails;
   const { sharedData } = scenario;
 
@@ -202,4 +202,50 @@ describe('transaction failed scenario', () => {
     const result = respondingReducer(state, sharedData, action);
     itTransitionsToFailure(result, scenario.failure);
   });
+});
+
+describe('CHALLENGE EXPIRES --> DEFUNDED', () => {
+  const scenario = scenarios.challengeExpiresChannelDefunded;
+  const { sharedData } = scenario;
+
+  describe(`when in ${states.WAIT_FOR_RESPONSE}`, () => {
+    const state = scenario.waitForResponse;
+    const action = scenario.challengeTimedOut;
+
+    const result = respondingReducer(state, sharedData, action);
+    itTransitionsTo(result, states.ACKNOWLEDGE_TIMEOUT);
+  });
+
+  describe(`when in ${states.ACKNOWLEDGE_TIMEOUT}`, () => {
+    const state = scenario.waitForDefund1;
+    const action = scenario.defundChosen;
+
+    const result = respondingReducer(state, sharedData, action);
+    itTransitionsTo(result, states.ACKNOWLEDGE_DEFUNDING_SUCCESS);
+  });
+
+  describe(`when in ${states.ACKNOWLEDGE_DEFUNDING_SUCCESS}`, () => {
+    const state = scenario.acknowledgeDefundingSuccess;
+    const action = scenario.acknowledged;
+
+    const result = respondingReducer(state, sharedData, action);
+    itTransitionsTo(result, states.CLOSED_AND_DEFUNDED);
+  });
+});
+
+describe('transaction failed ', () => {
+  const scenario = scenarios.transactionFails;
+  const { sharedData } = scenario;
+
+  describe(`when in ${states.WAIT_FOR_TRANSACTION}`, () => {
+    const state = scenario.waitForTransaction;
+    const action = scenario.transactionFailed;
+
+    const result = respondingReducer(state, sharedData, action);
+    itTransitionsToFailure(result, scenario.failure);
+  });
+});
+
+describe.skip('CHALLENGE EXPIRES --> not DEFUNDED', () => {
+  /* */
 });

--- a/packages/wallet/src/redux/protocols/responding/__tests__/reducer.test.ts
+++ b/packages/wallet/src/redux/protocols/responding/__tests__/reducer.test.ts
@@ -217,8 +217,16 @@ describe('CHALLENGE EXPIRES --> DEFUNDED', () => {
   });
 
   describe(`when in ${states.ACKNOWLEDGE_TIMEOUT}`, () => {
-    const state = scenario.waitForDefund1;
+    const state = scenario.acknowledgeTimeout;
     const action = scenario.defundChosen;
+
+    const result = respondingReducer(state, sharedData, action);
+    itTransitionsTo(result, states.WAIT_FOR_DEFUND);
+  });
+
+  describe(`when in ${states.WAIT_FOR_DEFUND}`, () => {
+    const state = scenario.waitForDefund1;
+    const action = scenario.defundingSuccessTrigger;
 
     const result = respondingReducer(state, sharedData, action);
     itTransitionsTo(result, states.ACKNOWLEDGE_DEFUNDING_SUCCESS);
@@ -233,19 +241,23 @@ describe('CHALLENGE EXPIRES --> DEFUNDED', () => {
   });
 });
 
-describe('transaction failed ', () => {
-  const scenario = scenarios.transactionFails;
+describe('CHALLENGE EXPIRES --> not DEFUNDED', () => {
+  const scenario = scenarios.challengeExpiresButChannelNotDefunded;
   const { sharedData } = scenario;
 
-  describe(`when in ${states.WAIT_FOR_TRANSACTION}`, () => {
-    const state = scenario.waitForTransaction;
-    const action = scenario.transactionFailed;
+  describe(`when in ${states.WAIT_FOR_DEFUND}`, () => {
+    const state = scenario.waitForDefund2;
+    const action = scenario.defundingFailureTrigger;
 
     const result = respondingReducer(state, sharedData, action);
-    itTransitionsToFailure(result, scenario.failure);
+    itTransitionsTo(result, states.ACKNOWLEDGE_CLOSED_BUT_NOT_DEFUNDED);
   });
-});
 
-describe.skip('CHALLENGE EXPIRES --> not DEFUNDED', () => {
-  /* */
+  describe(`when in ${states.ACKNOWLEDGE_CLOSED_BUT_NOT_DEFUNDED}`, () => {
+    const state = scenario.acknowledgeClosedButNotDefunded;
+    const action = scenario.acknowledged;
+
+    const result = respondingReducer(state, sharedData, action);
+    itTransitionsTo(result, states.CLOSED_BUT_NOT_DEFUNDED);
+  });
 });

--- a/packages/wallet/src/redux/protocols/responding/__tests__/scenarios.ts
+++ b/packages/wallet/src/redux/protocols/responding/__tests__/scenarios.ts
@@ -74,7 +74,6 @@ const waitForTransaction = states.waitForTransaction(props);
 const waitForAcknowledgement = states.waitForAcknowledgement(props);
 const waitForResponse = states.waitForResponse(props);
 const success = states.success();
-const userRejectedFailure = states.failure(states.FailureReason.UserRejected);
 const transactionFailedFailure = states.failure(states.FailureReason.TransactionFailure);
 const transactionConfirmed = transactionActions.transactionConfirmed(processId);
 const transactionFailed = transactionActions.transactionFailed(processId);
@@ -82,7 +81,6 @@ const transactionFailed = transactionActions.transactionFailed(processId);
 // Actions
 // ------
 const approve = actions.respondApproved(processId);
-const reject = actions.respondRejected(processId);
 const acknowledge = actions.respondSuccessAcknowledged(processId);
 const responseProvided = actions.responseProvided(processId, testScenarios.gameCommitment3);
 
@@ -135,15 +133,6 @@ export const requireResponseHappyPath = {
   responseProvided,
   transactionConfirmed,
   acknowledge,
-};
-
-export const userDeclines = {
-  ...props,
-  // States
-  waitForApproval: waitForApprovalRequiresResponse,
-  failure: userRejectedFailure,
-  // Action
-  reject,
 };
 
 export const transactionFails = {

--- a/packages/wallet/src/redux/protocols/responding/__tests__/scenarios.ts
+++ b/packages/wallet/src/redux/protocols/responding/__tests__/scenarios.ts
@@ -60,7 +60,7 @@ const refuteChannelState = {
 const transactionSubmissionState = transactionScenarios.preSuccessState;
 const processId = 'process-id.123';
 const sharedData: SharedData = { ...EMPTY_SHARED_DATA, channelStore };
-const props = { processId, transactionSubmissionState, sharedData };
+const props = { processId, transactionSubmissionState, sharedData, channelId };
 
 // ------
 // States
@@ -93,8 +93,8 @@ const waitForDefund2 = states.waitForDefund({
   ...props,
   defundingState: defundingPreFailureState,
 });
-const acknowledgeDefundingSuccess = states.acknowledgeDefundingSuccess;
-const acknowledgeClosedButNotDefunded = states.acknowledgeClosedButNotDefunded;
+const acknowledgeDefundingSuccess = states.acknowledgeDefundingSuccess({ ...props });
+const acknowledgeClosedButNotDefunded = states.acknowledgeClosedButNotDefunded({ ...props });
 // ------
 // Actions
 // ------
@@ -103,6 +103,7 @@ const acknowledge = actions.respondSuccessAcknowledged(processId);
 const responseProvided = actions.responseProvided(processId, testScenarios.gameCommitment3);
 const defundChosen = actions.defundChosen(processId);
 const acknowledged = actions.acknowledged(processId);
+const challengeTimedOut = challengeExpiredEvent(processId, channelId, 1000);
 
 // ---------
 // Scenarios
@@ -174,10 +175,10 @@ export const challengeExpiresChannelDefunded = {
   waitForDefund1,
   acknowledgeDefundingSuccess,
   // Actions
-  challengeExpiredEvent,
+  challengeTimedOut,
   defundChosen,
   defundingSuccessTrigger,
-  acknowledge,
+  acknowledged,
 };
 
 export const challengeExpiresButChannelNotDefunded = {

--- a/packages/wallet/src/redux/protocols/responding/__tests__/scenarios.ts
+++ b/packages/wallet/src/redux/protocols/responding/__tests__/scenarios.ts
@@ -6,6 +6,13 @@ import { EMPTY_SHARED_DATA, SharedData } from '../../../state';
 
 import { ChannelState, ChannelStore } from '../../../channel-store';
 import * as transactionActions from '../../transaction-submission/actions';
+import { challengeExpiredEvent } from '../../../actions';
+import {
+  preSuccessState as defundingPreSuccessState,
+  successTrigger as defundingSuccessTrigger,
+  preFailureState as defundingPreFailureState,
+  failureTrigger as defundingFailureTrigger,
+} from '../../defunding/__tests__';
 
 // ---------
 // Test data
@@ -77,12 +84,25 @@ const success = states.success();
 const transactionFailedFailure = states.failure(states.FailureReason.TransactionFailure);
 const transactionConfirmed = transactionActions.transactionConfirmed(processId);
 const transactionFailed = transactionActions.transactionFailed(processId);
+const acknowledgeTimeout = states.acknowledgeTimeOut(props);
+const waitForDefund1 = states.waitForDefund({
+  ...props,
+  defundingState: defundingPreSuccessState,
+});
+const waitForDefund2 = states.waitForDefund({
+  ...props,
+  defundingState: defundingPreFailureState,
+});
+const acknowledgeDefundingSuccess = states.acknowledgeDefundingSuccess;
+const acknowledgeClosedButNotDefunded = states.acknowledgeClosedButNotDefunded;
 // ------
 // Actions
 // ------
 const approve = actions.respondApproved(processId);
 const acknowledge = actions.respondSuccessAcknowledged(processId);
 const responseProvided = actions.responseProvided(processId, testScenarios.gameCommitment3);
+const defundChosen = actions.defundChosen(processId);
+const acknowledged = actions.acknowledged(processId);
 
 // ---------
 // Scenarios
@@ -144,4 +164,28 @@ export const transactionFails = {
   // Actions
   approve,
   transactionFailed,
+};
+
+export const challengeExpiresChannelDefunded = {
+  ...props,
+  // States
+  waitForResponse,
+  acknowledgeTimeout,
+  waitForDefund1,
+  acknowledgeDefundingSuccess,
+  // Actions
+  challengeExpiredEvent,
+  defundChosen,
+  defundingSuccessTrigger,
+  acknowledge,
+};
+
+export const challengeExpiresButChannelNotDefunded = {
+  ...props,
+  // States
+  waitForDefund2,
+  acknowledgeClosedButNotDefunded,
+  // Actions
+  defundingFailureTrigger,
+  acknowledged,
 };

--- a/packages/wallet/src/redux/protocols/responding/__tests__/scenarios.ts
+++ b/packages/wallet/src/redux/protocols/responding/__tests__/scenarios.ts
@@ -84,7 +84,7 @@ const success = states.success();
 const transactionFailedFailure = states.failure(states.FailureReason.TransactionFailure);
 const transactionConfirmed = transactionActions.transactionConfirmed(processId);
 const transactionFailed = transactionActions.transactionFailed(processId);
-const acknowledgeTimeout = states.acknowledgeTimeOut(props);
+const acknowledgeTimeout = states.acknowledgeTimeout(props);
 const waitForDefund1 = states.waitForDefund({
   ...props,
   defundingState: defundingPreSuccessState,

--- a/packages/wallet/src/redux/protocols/responding/__tests__/stories.tsx
+++ b/packages/wallet/src/redux/protocols/responding/__tests__/stories.tsx
@@ -45,11 +45,6 @@ const requireResponseHappyPathStories = {
   Success: scenarios.requireResponseHappyPath.success,
 };
 
-const userDeclinesStories = {
-  WaitForApproval: scenarios.userDeclines.waitForApproval,
-  Failure: scenarios.userDeclines.failure,
-};
-
 const transactionFailureStories = {
   WaitForApproval: scenarios.transactionFails.waitForApproval,
   WaitForTransaction: scenarios.transactionFails.waitForTransaction,
@@ -60,7 +55,6 @@ addStories(respondWithExistingMoveHappyPathStories, 'Responding / Respond with E
 addStories(requireResponseHappyPathStories, 'Responding / Requires new Response');
 addStories(refuteHappyPathStories, 'Responding / Refute challenge');
 addStories(transactionFailureStories, 'Responding / Transaction fails');
-addStories(userDeclinesStories, 'Responding / User rejects responding ');
 
 function addStories(collection, chapter) {
   Object.keys(collection).map(storyName => {

--- a/packages/wallet/src/redux/protocols/responding/actions.ts
+++ b/packages/wallet/src/redux/protocols/responding/actions.ts
@@ -5,23 +5,16 @@ import { ProtocolAction, isTransactionAction } from '../../actions';
 
 export type RespondingAction =
   | RespondApproved
-  | RespondRejected
   | ResponseProvided
   | RespondSuccessAcknowledged
   | TransactionAction;
 
 export const RESPOND_APPROVED = 'WALLET.RESPOND_APPROVED';
-export const RESPOND_REJECTED = 'WALLET.RESPOND_REJECTED';
 export const RESPONSE_PROVIDED = 'WALLET.RESPONSE_PROVIDED';
 export const RESPOND_SUCCESS_ACKNOWLEDGED = 'WALLET.RESPOND_SUCCESS_ACKNOWLEDGED';
 
 export interface RespondApproved extends BaseProcessAction {
   type: typeof RESPOND_APPROVED;
-  processId: string;
-}
-
-export interface RespondRejected extends BaseProcessAction {
-  type: typeof RESPOND_REJECTED;
   processId: string;
 }
 
@@ -45,11 +38,6 @@ export const respondApproved = (processId: string): RespondApproved => ({
   processId,
 });
 
-export const respondRejected = (processId: string): RespondRejected => ({
-  type: RESPOND_REJECTED,
-  processId,
-});
-
 export const respondSuccessAcknowledged = (processId: string): RespondSuccessAcknowledged => ({
   type: RESPOND_SUCCESS_ACKNOWLEDGED,
   processId,
@@ -65,7 +53,6 @@ export function isRespondingAction(action: ProtocolAction): action is Responding
   return (
     isTransactionAction(action) ||
     action.type === RESPOND_APPROVED ||
-    action.type === RESPOND_REJECTED ||
     action.type === RESPONSE_PROVIDED ||
     action.type === RESPOND_SUCCESS_ACKNOWLEDGED
   );

--- a/packages/wallet/src/redux/protocols/responding/actions.ts
+++ b/packages/wallet/src/redux/protocols/responding/actions.ts
@@ -69,6 +69,16 @@ export const responseProvided = (processId: string, commitment: Commitment): Res
   commitment,
 });
 
+export const defundChosen = (processId: string): DefundChosen => ({
+  type: DEFUND_CHOSEN,
+  processId,
+});
+
+export const acknowledged = (processId: string): Acknowledged => ({
+  type: ACKNOWLEDGED,
+  processId,
+});
+
 export function isRespondingAction(action: ProtocolAction): action is RespondingAction {
   return (
     isTransactionAction(action) ||

--- a/packages/wallet/src/redux/protocols/responding/actions.ts
+++ b/packages/wallet/src/redux/protocols/responding/actions.ts
@@ -9,6 +9,7 @@ import {
   CHALLENGE_EXPIRY_SET_EVENT,
   CHALLENGE_EXPIRED_EVENT,
 } from '../../actions';
+import { isDefundingAction } from '../defunding/actions';
 
 export type RespondingAction =
   | RespondApproved
@@ -84,6 +85,7 @@ export const acknowledged = (processId: string): Acknowledged => ({
 export function isRespondingAction(action: ProtocolAction): action is RespondingAction {
   return (
     isTransactionAction(action) ||
+    isDefundingAction(action) ||
     action.type === RESPOND_APPROVED ||
     action.type === RESPONSE_PROVIDED ||
     action.type === RESPOND_SUCCESS_ACKNOWLEDGED ||

--- a/packages/wallet/src/redux/protocols/responding/actions.ts
+++ b/packages/wallet/src/redux/protocols/responding/actions.ts
@@ -6,6 +6,8 @@ import {
   isTransactionAction,
   ChallengeExpiredEvent,
   ChallengeExpirySetEvent,
+  CHALLENGE_EXPIRY_SET_EVENT,
+  CHALLENGE_EXPIRED_EVENT,
 } from '../../actions';
 
 export type RespondingAction =
@@ -85,6 +87,8 @@ export function isRespondingAction(action: ProtocolAction): action is Responding
     action.type === RESPOND_APPROVED ||
     action.type === RESPONSE_PROVIDED ||
     action.type === RESPOND_SUCCESS_ACKNOWLEDGED ||
+    action.type === CHALLENGE_EXPIRY_SET_EVENT ||
+    action.type === CHALLENGE_EXPIRED_EVENT ||
     action.type === DEFUND_CHOSEN ||
     action.type === ACKNOWLEDGED
   );

--- a/packages/wallet/src/redux/protocols/responding/actions.ts
+++ b/packages/wallet/src/redux/protocols/responding/actions.ts
@@ -1,17 +1,28 @@
 import { BaseProcessAction } from '../actions';
 import { Commitment } from '../../../domain';
 import { TransactionAction } from '../transaction-submission/actions';
-import { ProtocolAction, isTransactionAction } from '../../actions';
+import {
+  ProtocolAction,
+  isTransactionAction,
+  ChallengeExpiredEvent,
+  ChallengeExpirySetEvent,
+} from '../../actions';
 
 export type RespondingAction =
   | RespondApproved
   | ResponseProvided
   | RespondSuccessAcknowledged
-  | TransactionAction;
+  | TransactionAction
+  | ChallengeExpiredEvent
+  | ChallengeExpirySetEvent
+  | DefundChosen
+  | Acknowledged;
 
 export const RESPOND_APPROVED = 'WALLET.RESPOND_APPROVED';
 export const RESPONSE_PROVIDED = 'WALLET.RESPONSE_PROVIDED';
 export const RESPOND_SUCCESS_ACKNOWLEDGED = 'WALLET.RESPOND_SUCCESS_ACKNOWLEDGED';
+export const DEFUND_CHOSEN = 'WALLET.RESPOND.DEFUND_CHOSEN';
+export const ACKNOWLEDGED = 'WALLET.RESPOND.ACKNOWLEDGED';
 
 export interface RespondApproved extends BaseProcessAction {
   type: typeof RESPOND_APPROVED;
@@ -26,6 +37,15 @@ export interface ResponseProvided extends BaseProcessAction {
 
 export interface RespondSuccessAcknowledged extends BaseProcessAction {
   type: typeof RESPOND_SUCCESS_ACKNOWLEDGED;
+  processId: string;
+}
+
+export interface DefundChosen extends BaseProcessAction {
+  type: typeof DEFUND_CHOSEN;
+  processId: string;
+}
+export interface Acknowledged extends BaseProcessAction {
+  type: typeof ACKNOWLEDGED;
   processId: string;
 }
 
@@ -54,6 +74,8 @@ export function isRespondingAction(action: ProtocolAction): action is Responding
     isTransactionAction(action) ||
     action.type === RESPOND_APPROVED ||
     action.type === RESPONSE_PROVIDED ||
-    action.type === RESPOND_SUCCESS_ACKNOWLEDGED
+    action.type === RESPOND_SUCCESS_ACKNOWLEDGED ||
+    action.type === DEFUND_CHOSEN ||
+    action.type === ACKNOWLEDGED
   );
 }

--- a/packages/wallet/src/redux/protocols/responding/components/wait-for-approval.tsx
+++ b/packages/wallet/src/redux/protocols/responding/components/wait-for-approval.tsx
@@ -3,19 +3,17 @@ import Button from 'reactstrap/lib/Button';
 
 interface Props {
   approve: () => void;
-  deny: () => void;
 }
 export default class WaitForApproval extends React.PureComponent<Props> {
   render() {
-    const { approve, deny } = this.props;
+    const { approve } = this.props;
     return (
       <Fragment>
         <h1>Challenge Detected</h1>
         <div>
           <p>You have been challenged! </p>
           <p>Would you like to respond?</p>
-          <Button onClick={approve}>Approve</Button>
-          <Button onClick={deny}>Deny</Button>
+          <Button onClick={approve}>Respond</Button>
         </div>
       </Fragment>
     );

--- a/packages/wallet/src/redux/protocols/responding/container.tsx
+++ b/packages/wallet/src/redux/protocols/responding/container.tsx
@@ -15,13 +15,12 @@ import { connect } from 'react-redux';
 interface Props {
   state: states.RespondingState;
   respondApproved: (processId: string) => void;
-  respondRejected: (processId: string) => void;
   respondSuccessAcknowledged: (processId: string) => void;
   responseProvided: (processId: string, commitment: Commitment) => void;
 }
 class RespondingContainer extends PureComponent<Props> {
   render() {
-    const { state, respondSuccessAcknowledged, respondApproved, respondRejected } = this.props;
+    const { state, respondSuccessAcknowledged, respondApproved } = this.props;
     switch (state.type) {
       case states.WAIT_FOR_ACKNOWLEDGEMENT:
         return (
@@ -32,12 +31,7 @@ class RespondingContainer extends PureComponent<Props> {
           />
         );
       case states.WAIT_FOR_APPROVAL:
-        return (
-          <WaitForApproval
-            approve={() => respondApproved(state.processId)}
-            deny={() => respondRejected(state.processId)}
-          />
-        );
+        return <WaitForApproval approve={() => respondApproved(state.processId)} />;
       case states.WAIT_FOR_RESPONSE:
         // TODO: Should this ever been seen? We expect protocol above this to figure out getting the response
         return <div>Waiting for response</div>;
@@ -60,7 +54,6 @@ class RespondingContainer extends PureComponent<Props> {
 
 const mapDispatchToProps = {
   respondApproved: actions.respondApproved,
-  respondRejected: actions.respondRejected,
   responseProvided: actions.responseProvided,
   respondSuccessAcknowledged: actions.respondSuccessAcknowledged,
 };

--- a/packages/wallet/src/redux/protocols/responding/container.tsx
+++ b/packages/wallet/src/redux/protocols/responding/container.tsx
@@ -3,24 +3,31 @@ import * as actions from './actions';
 import { PureComponent } from 'react';
 import { Commitment } from '../../../domain';
 import React from 'react';
-import Success from '../shared-components/success';
-import Failure from '../shared-components/failure';
 import { unreachable } from '../../../utils/reducer-utils';
 import Acknowledge from '../shared-components/acknowledge';
 import WaitForApproval from './components/wait-for-approval';
 import { TransactionSubmission } from '../../protocols/transaction-submission/container';
+import { Defunding } from '../defunding/container';
 
 import { connect } from 'react-redux';
 
 interface Props {
-  state: states.RespondingState;
+  state: states.NonTerminalRespondingState;
   respondApproved: (processId: string) => void;
   respondSuccessAcknowledged: (processId: string) => void;
   responseProvided: (processId: string, commitment: Commitment) => void;
+  acknowledged: (processId: string) => void;
+  defundChosen: (processId: string) => void;
 }
 class RespondingContainer extends PureComponent<Props> {
   render() {
-    const { state, respondSuccessAcknowledged, respondApproved } = this.props;
+    const {
+      state,
+      respondSuccessAcknowledged,
+      respondApproved,
+      acknowledged,
+      defundChosen,
+    } = this.props;
     switch (state.type) {
       case states.WAIT_FOR_ACKNOWLEDGEMENT:
         return (
@@ -42,10 +49,32 @@ class RespondingContainer extends PureComponent<Props> {
             transactionName="Respond"
           />
         );
-      case states.FAILURE:
-        return <Failure name="respond" reason={state.reason} />;
-      case states.SUCCESS:
-        return <Success name="respond" />;
+      case states.ACKNOWLEDGE_CLOSED_BUT_NOT_DEFUNDED:
+        return (
+          <Acknowledge
+            title="Defunding failed!"
+            description="The channel was closed but not defunded."
+            acknowledge={() => acknowledged(state.processId)}
+          />
+        );
+      case states.ACKNOWLEDGE_DEFUNDING_SUCCESS:
+        return (
+          <Acknowledge
+            title="Defunding success!"
+            description="The channel was closed and defunded."
+            acknowledge={() => acknowledged(state.processId)}
+          />
+        );
+      case states.ACKNOWLEDGE_TIMEOUT:
+        return (
+          <Acknowledge
+            title="Challende timeout!"
+            description="You failed to respond to a challenge in time. Defund the channel now?"
+            acknowledge={() => defundChosen(state.processId)}
+          />
+        );
+      case states.WAIT_FOR_DEFUND:
+        return <Defunding state={state.defundingState} />;
       default:
         return unreachable(state);
     }
@@ -56,6 +85,8 @@ const mapDispatchToProps = {
   respondApproved: actions.respondApproved,
   responseProvided: actions.responseProvided,
   respondSuccessAcknowledged: actions.respondSuccessAcknowledged,
+  acknowledged: actions.acknowledged,
+  defundChosen: actions.defundChosen,
 };
 
 export const Responding = connect(

--- a/packages/wallet/src/redux/protocols/responding/readme.md
+++ b/packages/wallet/src/redux/protocols/responding/readme.md
@@ -23,15 +23,24 @@ linkStyle default interpolate basis
   WFAp--> |Approve| HC{Commitment<br/>exists?}
   HC --> |Yes| WFT(WaitForTransaction)
   HC --> |No| WFR(WaitForResponse)
-  WFR-->|ResponseProvided| WFT(WaitForTransaction)
+  WFR -->|ResponseProvided| WFT(WaitForTransaction)
+  WFR -->|CHALLENGE_EXPIRED| AT(AcknowledgeTimeOut)
+  AT -->|DEFUND_CHOSEN| WFD(WaitForDefund)
+  WFD --> |defunding protocol succeeded| AS(AcknowledgeSuccess)
+  WFD --> |defunding protocol failed| ACBND(AcknowledgeClosedButNotDefunded)
   WFT --> |TransactionSubmitted| WFAc(WaitForAcknowledgement)
   WFAc-->|Acknowledged| S((success))
   WFT --> |TransactionFailed| F((failure))
-
-  style St  fill:#efdd20
-  style HC  fill:#efdd20
-  style S fill:#58ef21
-  style F  fill:#f45941
+  ACBND -->|Acknowledged| FCBND((ClosedButNotDefunded))
+  AS -->|Acknowledged| FCD((ClosedAndDefunded))
+  classDef logic fill:#efdd20;
+  classDef Success fill:#58ef21;
+  classDef Failure fill:#f45941;
+  classDef WaitForChildProtocol stroke:#333,stroke-width:4px,color:#ffff,fill:#333;
+  class St,HC logic;
+  class S Success;
+  class F,FCD,FCBND Failure;
+  class WFT,WFD WaitForChildProtocol;
 ```
 
 Notes:

--- a/packages/wallet/src/redux/protocols/responding/readme.md
+++ b/packages/wallet/src/redux/protocols/responding/readme.md
@@ -18,15 +18,20 @@ Out of scope (for the time being):
 
 ```mermaid
 graph TD
+linkStyle default interpolate basis
   St((start)) --> WFAp(WaitForApproval)
   WFAp--> |Approve| HC{Commitment<br/>exists?}
   HC --> |Yes| WFT(WaitForTransaction)
   HC --> |No| WFR(WaitForResponse)
   WFR-->|ResponseProvided| WFT(WaitForTransaction)
-  WFAp-->|Rejected| F((failure))
   WFT --> |TransactionSubmitted| WFAc(WaitForAcknowledgement)
   WFAc-->|Acknowledged| S((success))
   WFT --> |TransactionFailed| F((failure))
+
+  style St  fill:#efdd20
+  style HC  fill:#efdd20
+  style S fill:#58ef21
+  style F  fill:#f45941
 ```
 
 Notes:
@@ -41,5 +46,4 @@ Notes:
 1. Respond With Existing Commitment Happy Path: WaitForApproval->WaitForTransaction->WaitForAcknowledgement->success
 2. Refute Happy Path: WaitForApproval->WaitForTransaction->WaitForAcknowledgement->success
 3. Select Response Happy Path: WaitForApproval->WaitForResponse->WaitForTransaction->WaitForAcknowledgement->success
-4. User declines: WaitForApproval->failure
-5. Transaction fails: WaitForApproval->WaitForTransaction->failure
+4. Transaction fails: WaitForApproval->WaitForTransaction->failure

--- a/packages/wallet/src/redux/protocols/responding/readme.md
+++ b/packages/wallet/src/redux/protocols/responding/readme.md
@@ -23,6 +23,7 @@ linkStyle default interpolate basis
   WFAp--> |Approve| HC{Commitment<br/>exists?}
   HC --> |Yes| WFT(WaitForTransaction)
   HC --> |No| WFR(WaitForResponse)
+  WFR -->|ChallengeExpirySetEvent| WFR
   WFR -->|ResponseProvided| WFT(WaitForTransaction)
   WFR -->|CHALLENGE_EXPIRED| AT(AcknowledgeTimeOut)
   AT -->|DEFUND_CHOSEN| WFD(WaitForDefund)

--- a/packages/wallet/src/redux/protocols/responding/readme.md
+++ b/packages/wallet/src/redux/protocols/responding/readme.md
@@ -27,7 +27,7 @@ linkStyle default interpolate basis
   WFR -->|ResponseProvided| WFT(WaitForTransaction)
   WFR -->|CHALLENGE_EXPIRED| AT(AcknowledgeTimeOut)
   AT -->|DEFUND_CHOSEN| WFD(WaitForDefund)
-  WFD --> |defunding protocol succeeded| AS(AcknowledgeSuccess)
+  WFD --> |defunding protocol succeeded| AS(AcknowledgeDefundingSuccess)
   WFD --> |defunding protocol failed| ACBND(AcknowledgeClosedButNotDefunded)
   WFT --> |TransactionSubmitted| WFAc(WaitForAcknowledgement)
   WFAc-->|Acknowledged| S((success))
@@ -53,7 +53,11 @@ Notes:
 
 ## Test Scenarios
 
-1. Respond With Existing Commitment Happy Path: WaitForApproval->WaitForTransaction->WaitForAcknowledgement->success
-2. Refute Happy Path: WaitForApproval->WaitForTransaction->WaitForAcknowledgement->success
-3. Select Response Happy Path: WaitForApproval->WaitForResponse->WaitForTransaction->WaitForAcknowledgement->success
-4. Transaction fails: WaitForApproval->WaitForTransaction->failure
+1. Respond With Existing Commitment Happy Path: `WaitForApproval`->`WaitForTransaction`->`WaitForAcknowledgement`->`success`
+2. Refute Happy Path: `WaitForApproval`->`WaitForTransaction`->`WaitForAcknowledgement`->`success`
+3. Select Response Happy Path: `WaitForApproval`->`WaitForResponse`->`WaitForTransaction`->`WaitForAcknowledgement`->`success`
+4. Transaction fails: `WaitForApproval`->`WaitForTransaction`->`failure`
+5. Challenge expires and channel defunded:
+   `WaitForResponse`->`AcknowledgeTimeout`-> `WaitForDefund` -> `AcknowledgeDefundingSuccess` -> `ClosedAndDefunded`
+6. Challenge expires and channel NOT defunded:
+   `WaitForDefund` -> `AcknowledgeClosedButNotDefunded` -> `ClosedButNotDefunded`

--- a/packages/wallet/src/redux/protocols/responding/reducer.ts
+++ b/packages/wallet/src/redux/protocols/responding/reducer.ts
@@ -147,11 +147,6 @@ const waitForApprovalReducer = (
 
         return transitionToWaitForTransaction(transaction, protocolState, sharedData);
       }
-    case actions.RESPOND_REJECTED:
-      return {
-        protocolState: states.failure(states.FailureReason.UserRejected),
-        sharedData,
-      };
     default:
       return { protocolState, sharedData };
   }

--- a/packages/wallet/src/redux/protocols/responding/reducer.ts
+++ b/packages/wallet/src/redux/protocols/responding/reducer.ts
@@ -11,7 +11,7 @@ import {
   initialize as initTransactionState,
   transactionReducer,
 } from '../transaction-submission/reducer';
-import { SharedData, signAndStore } from '../../state';
+import { SharedData, signAndStore, registerChannelToMonitor } from '../../state';
 import { isTransactionAction } from '../transaction-submission/actions';
 import {
   isTerminal,
@@ -41,7 +41,7 @@ export const initialize = (
 ): ProtocolStateWithSharedData<states.RespondingState> => {
   return {
     protocolState: states.waitForApproval({ processId, channelId, challengeCommitment }),
-    sharedData: showWallet(sharedData),
+    sharedData: showWallet(registerChannelToMonitor(sharedData, processId, channelId)),
   };
 };
 

--- a/packages/wallet/src/redux/protocols/responding/state.ts
+++ b/packages/wallet/src/redux/protocols/responding/state.ts
@@ -2,6 +2,7 @@ import { NonTerminalTransactionSubmissionState as NonTerminalTSState } from '../
 import { Properties } from '../../utils';
 import { Commitment } from '../../../domain';
 import { ProtocolState } from '..';
+import { DefundingState } from '../defunding';
 
 export type RespondingState = NonTerminalRespondingState | Success | Failure;
 
@@ -59,6 +60,7 @@ export interface AcknowledgeTimeout {
 export interface WaitForDefund {
   type: typeof WAIT_FOR_DEFUND;
   processId: string;
+  defundingState: DefundingState;
 }
 
 export interface AcknowledgeDefundingSuccess {
@@ -144,8 +146,8 @@ export function acknowledgeTimeOut(properties: Properties<AcknowledgeTimeout>): 
 }
 
 export function waitForDefund(properties: Properties<WaitForDefund>): WaitForDefund {
-  const { processId } = properties;
-  return { type: WAIT_FOR_DEFUND, processId };
+  const { processId, defundingState } = properties;
+  return { type: WAIT_FOR_DEFUND, processId, defundingState };
 }
 
 export function acknowledgeDefundingSuccess(

--- a/packages/wallet/src/redux/protocols/responding/state.ts
+++ b/packages/wallet/src/redux/protocols/responding/state.ts
@@ -173,7 +173,7 @@ export function waitForResponse(properties: Properties<WaitForResponse>): WaitFo
   return { type: WAIT_FOR_RESPONSE, processId, channelId };
 }
 
-export function acknowledgeTimeOut(properties: Properties<AcknowledgeTimeout>): AcknowledgeTimeout {
+export function acknowledgeTimeout(properties: Properties<AcknowledgeTimeout>): AcknowledgeTimeout {
   const { processId, channelId } = properties;
   return { type: ACKNOWLEDGE_TIMEOUT, processId, channelId };
 }

--- a/packages/wallet/src/redux/protocols/responding/state.ts
+++ b/packages/wallet/src/redux/protocols/responding/state.ts
@@ -4,7 +4,12 @@ import { Commitment } from '../../../domain';
 import { ProtocolState } from '..';
 import { DefundingState } from '../defunding';
 
-export type RespondingState = NonTerminalRespondingState | Success | Failure;
+export type RespondingState =
+  | NonTerminalRespondingState
+  | Success
+  | ClosedAndDefunded
+  | ClosedButNotDefunded
+  | Failure;
 
 export type NonTerminalRespondingState =
   | WaitForApproval
@@ -24,57 +29,75 @@ export const WAIT_FOR_APPROVAL = 'Responding.WaitForApproval';
 export const WAIT_FOR_TRANSACTION = 'Responding.WaitForTransaction';
 export const WAIT_FOR_ACKNOWLEDGEMENT = 'Responding.WaitForAcknowledgement';
 export const WAIT_FOR_RESPONSE = 'Responding.WaitForResponse';
-export const ACKNOWLEDGE_TIMEOUT = 'Responding.AcknowledgeTimeOut';
+export const ACKNOWLEDGE_TIMEOUT = 'Responding.AcknowledgeTimeout';
 export const WAIT_FOR_DEFUND = 'Responding.WaitForDefund';
 export const ACKNOWLEDGE_DEFUNDING_SUCCESS = 'Responding.AcknowledgeDefundingSuccess';
 export const ACKNOWLEDGE_CLOSED_BUT_NOT_DEFUNDED = 'Responding.AcknowledgeClosedButNotDefunded';
+export const CLOSED_AND_DEFUNDED = 'Responding.ClosedAndDefunded';
+export const CLOSED_BUT_NOT_DEFUNDED = 'Responding.ClosedButNotDefunded';
 export const FAILURE = 'Responding.Failure';
 export const SUCCESS = 'Responding.Success';
 
 export interface WaitForApproval {
   type: typeof WAIT_FOR_APPROVAL;
   processId: string;
+  channelId: string;
   challengeCommitment: Commitment;
 }
 
 export interface WaitForTransaction {
   type: typeof WAIT_FOR_TRANSACTION;
   processId: string;
+  channelId: string;
   transactionSubmissionState: NonTerminalTSState;
 }
 export interface WaitForAcknowledgement {
   type: typeof WAIT_FOR_ACKNOWLEDGEMENT;
   processId: string;
+  channelId: string;
 }
 
 export interface WaitForResponse {
   type: typeof WAIT_FOR_RESPONSE;
   processId: string;
+  channelId: string;
 }
 
 export interface AcknowledgeTimeout {
   type: typeof ACKNOWLEDGE_TIMEOUT;
   processId: string;
+  channelId: string;
 }
 
 export interface WaitForDefund {
   type: typeof WAIT_FOR_DEFUND;
   processId: string;
   defundingState: DefundingState;
+  channelId: string;
 }
 
 export interface AcknowledgeDefundingSuccess {
   type: typeof ACKNOWLEDGE_DEFUNDING_SUCCESS;
   processId: string;
+  channelId: string;
 }
 
 export interface AcknowledgeClosedButNotDefunded {
   type: typeof ACKNOWLEDGE_CLOSED_BUT_NOT_DEFUNDED;
   processId: string;
+  channelId: string;
 }
 export interface Failure {
   type: typeof FAILURE;
   reason: string;
+}
+
+export interface ClosedAndDefunded {
+  type: typeof CLOSED_AND_DEFUNDED;
+}
+
+export interface ClosedButNotDefunded {
+  type: typeof CLOSED_BUT_NOT_DEFUNDED;
 }
 
 export interface Success {
@@ -96,6 +119,8 @@ export function isRespondingState(state: ProtocolState): state is RespondingStat
     state.type === ACKNOWLEDGE_DEFUNDING_SUCCESS ||
     state.type === ACKNOWLEDGE_CLOSED_BUT_NOT_DEFUNDED ||
     state.type === FAILURE ||
+    state.type === CLOSED_AND_DEFUNDED ||
+    state.type === CLOSED_BUT_NOT_DEFUNDED ||
     state.type === SUCCESS
   );
 }
@@ -106,8 +131,15 @@ export function isNonTerminalRespondingState(
   return isRespondingState(state) && !isTerminal(state);
 }
 
-export function isTerminal(state: RespondingState): state is Failure | Success {
-  return state.type === FAILURE || state.type === SUCCESS;
+export function isTerminal(
+  state: RespondingState,
+): state is ClosedAndDefunded | ClosedButNotDefunded | Success {
+  return (
+    state.type === CLOSED_AND_DEFUNDED ||
+    state.type === FAILURE ||
+    state.type === SUCCESS ||
+    state.type === CLOSED_BUT_NOT_DEFUNDED
+  );
 }
 
 // -------
@@ -115,53 +147,54 @@ export function isTerminal(state: RespondingState): state is Failure | Success {
 // -------
 
 export function waitForApproval(properties: Properties<WaitForApproval>): WaitForApproval {
-  const { processId, challengeCommitment } = properties;
-  return { type: WAIT_FOR_APPROVAL, processId, challengeCommitment };
+  const { processId, challengeCommitment, channelId } = properties;
+  return { type: WAIT_FOR_APPROVAL, processId, channelId, challengeCommitment };
 }
 
 export function waitForTransaction(properties: Properties<WaitForTransaction>): WaitForTransaction {
-  const { processId, transactionSubmissionState } = properties;
+  const { processId, transactionSubmissionState, channelId } = properties;
   return {
     type: WAIT_FOR_TRANSACTION,
     transactionSubmissionState,
     processId,
+    channelId,
   };
 }
 
 export function waitForAcknowledgement(
   properties: Properties<WaitForAcknowledgement>,
 ): WaitForAcknowledgement {
-  const { processId } = properties;
-  return { type: WAIT_FOR_ACKNOWLEDGEMENT, processId };
+  const { processId, channelId } = properties;
+  return { type: WAIT_FOR_ACKNOWLEDGEMENT, processId, channelId };
 }
 
 export function waitForResponse(properties: Properties<WaitForResponse>): WaitForResponse {
-  const { processId } = properties;
-  return { type: WAIT_FOR_RESPONSE, processId };
+  const { processId, channelId } = properties;
+  return { type: WAIT_FOR_RESPONSE, processId, channelId };
 }
 
 export function acknowledgeTimeOut(properties: Properties<AcknowledgeTimeout>): AcknowledgeTimeout {
-  const { processId } = properties;
-  return { type: ACKNOWLEDGE_TIMEOUT, processId };
+  const { processId, channelId } = properties;
+  return { type: ACKNOWLEDGE_TIMEOUT, processId, channelId };
 }
 
 export function waitForDefund(properties: Properties<WaitForDefund>): WaitForDefund {
-  const { processId, defundingState } = properties;
-  return { type: WAIT_FOR_DEFUND, processId, defundingState };
+  const { processId, defundingState, channelId } = properties;
+  return { type: WAIT_FOR_DEFUND, processId, defundingState, channelId };
 }
 
 export function acknowledgeDefundingSuccess(
   properties: Properties<AcknowledgeDefundingSuccess>,
 ): AcknowledgeDefundingSuccess {
-  const { processId } = properties;
-  return { type: ACKNOWLEDGE_DEFUNDING_SUCCESS, processId };
+  const { processId, channelId } = properties;
+  return { type: ACKNOWLEDGE_DEFUNDING_SUCCESS, processId, channelId };
 }
 
 export function acknowledgeClosedButNotDefunded(
   properties: Properties<AcknowledgeClosedButNotDefunded>,
 ): AcknowledgeClosedButNotDefunded {
-  const { processId } = properties;
-  return { type: ACKNOWLEDGE_CLOSED_BUT_NOT_DEFUNDED, processId };
+  const { processId, channelId } = properties;
+  return { type: ACKNOWLEDGE_CLOSED_BUT_NOT_DEFUNDED, processId, channelId };
 }
 
 export function success(): Success {
@@ -170,4 +203,11 @@ export function success(): Success {
 
 export function failure(reason: FailureReason): Failure {
   return { type: FAILURE, reason };
+}
+
+export function closedAndDefunded(): ClosedAndDefunded {
+  return { type: CLOSED_AND_DEFUNDED };
+}
+export function closedButNotDefunded(): ClosedButNotDefunded {
+  return { type: CLOSED_BUT_NOT_DEFUNDED };
 }

--- a/packages/wallet/src/redux/protocols/responding/state.ts
+++ b/packages/wallet/src/redux/protocols/responding/state.ts
@@ -2,23 +2,31 @@ import { NonTerminalTransactionSubmissionState as NonTerminalTSState } from '../
 import { Properties } from '../../utils';
 import { Commitment } from '../../../domain';
 import { ProtocolState } from '..';
+
 export type RespondingState = NonTerminalRespondingState | Success | Failure;
 
 export type NonTerminalRespondingState =
   | WaitForApproval
   | WaitForTransaction
   | WaitForAcknowledgement
-  | WaitForResponse;
+  | WaitForResponse
+  | AcknowledgeTimeout
+  | WaitForDefund
+  | AcknowledgeDefundingSuccess
+  | AcknowledgeClosedButNotDefunded;
 
 export const enum FailureReason {
   TransactionFailure = 'Transaction failed',
-  UserRejected = 'User rejected',
 }
 
 export const WAIT_FOR_APPROVAL = 'Responding.WaitForApproval';
 export const WAIT_FOR_TRANSACTION = 'Responding.WaitForTransaction';
 export const WAIT_FOR_ACKNOWLEDGEMENT = 'Responding.WaitForAcknowledgement';
 export const WAIT_FOR_RESPONSE = 'Responding.WaitForResponse';
+export const ACKNOWLEDGE_TIMEOUT = 'Responding.AcknowledgeTimeOut';
+export const WAIT_FOR_DEFUND = 'Responding.WaitForDefund';
+export const ACKNOWLEDGE_DEFUNDING_SUCCESS = 'Responding.AcknowledgeDefundingSuccess';
+export const ACKNOWLEDGE_CLOSED_BUT_NOT_DEFUNDED = 'Responding.AcknowledgeClosedButNotDefunded';
 export const FAILURE = 'Responding.Failure';
 export const SUCCESS = 'Responding.Success';
 
@@ -43,6 +51,25 @@ export interface WaitForResponse {
   processId: string;
 }
 
+export interface AcknowledgeTimeout {
+  type: typeof ACKNOWLEDGE_TIMEOUT;
+  processId: string;
+}
+
+export interface WaitForDefund {
+  type: typeof WAIT_FOR_DEFUND;
+  processId: string;
+}
+
+export interface AcknowledgeDefundingSuccess {
+  type: typeof ACKNOWLEDGE_DEFUNDING_SUCCESS;
+  processId: string;
+}
+
+export interface AcknowledgeClosedButNotDefunded {
+  type: typeof ACKNOWLEDGE_CLOSED_BUT_NOT_DEFUNDED;
+  processId: string;
+}
 export interface Failure {
   type: typeof FAILURE;
   reason: string;
@@ -56,19 +83,16 @@ export interface Success {
 // Helpers
 // -------
 
-// export const WAIT_FOR_APPROVAL = 'WaitForApproval';
-// export const WAIT_FOR_TRANSACTION = 'WaitForTransaction';
-// export const WAIT_FOR_ACKNOWLEDGEMENT = 'WaitForAcknowledgement';
-// export const WAIT_FOR_RESPONSE = 'WaitForResponse';
-// export const FAILURE = 'Failure';
-// export const SUCCESS = 'Success';
-
 export function isRespondingState(state: ProtocolState): state is RespondingState {
   return (
     state.type === WAIT_FOR_APPROVAL ||
     state.type === WAIT_FOR_TRANSACTION ||
     state.type === WAIT_FOR_ACKNOWLEDGEMENT ||
     state.type === WAIT_FOR_RESPONSE ||
+    state.type === ACKNOWLEDGE_TIMEOUT ||
+    state.type === WAIT_FOR_DEFUND ||
+    state.type === ACKNOWLEDGE_DEFUNDING_SUCCESS ||
+    state.type === ACKNOWLEDGE_CLOSED_BUT_NOT_DEFUNDED ||
     state.type === FAILURE ||
     state.type === SUCCESS
   );
@@ -112,6 +136,30 @@ export function waitForAcknowledgement(
 export function waitForResponse(properties: Properties<WaitForResponse>): WaitForResponse {
   const { processId } = properties;
   return { type: WAIT_FOR_RESPONSE, processId };
+}
+
+export function acknowledgeTimeOut(properties: Properties<AcknowledgeTimeout>): AcknowledgeTimeout {
+  const { processId } = properties;
+  return { type: ACKNOWLEDGE_TIMEOUT, processId };
+}
+
+export function waitForDefund(properties: Properties<WaitForDefund>): WaitForDefund {
+  const { processId } = properties;
+  return { type: WAIT_FOR_DEFUND, processId };
+}
+
+export function acknowledgeDefundingSuccess(
+  properties: Properties<AcknowledgeDefundingSuccess>,
+): AcknowledgeDefundingSuccess {
+  const { processId } = properties;
+  return { type: ACKNOWLEDGE_DEFUNDING_SUCCESS, processId };
+}
+
+export function acknowledgeClosedButNotDefunded(
+  properties: Properties<AcknowledgeClosedButNotDefunded>,
+): AcknowledgeClosedButNotDefunded {
+  const { processId } = properties;
+  return { type: ACKNOWLEDGE_CLOSED_BUT_NOT_DEFUNDED, processId };
 }
 
 export function success(): Success {

--- a/packages/wallet/src/redux/reducer.ts
+++ b/packages/wallet/src/redux/reducer.ts
@@ -202,7 +202,12 @@ function initializeNewProtocol(
       return { protocolState, sharedData };
     }
     case actions.protocol.CHALLENGE_CREATED:
-      return challengeResponseProtocol.initialize(processId, incomingSharedData, action.commitment);
+      return challengeResponseProtocol.initialize(
+        processId,
+        action.channelId,
+        incomingSharedData,
+        action.commitment,
+      );
     case actions.protocol.INITIALIZE_CHANNEL:
       return applicationProtocol.initialize(incomingSharedData);
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -9461,17 +9461,6 @@ grpc@1.20.0:
     node-pre-gyp "^0.12.0"
     protobufjs "^5.0.3"
 
-grpc@^1.16.1:
-  version "1.20.3"
-  resolved "https://registry.yarnpkg.com/grpc/-/grpc-1.20.3.tgz#a74d36718f1e89c4a64f2fb9441199c3c8f78978"
-  integrity sha512-GsEsi0NVj6usS/xor8pF/xDbDiwZQR59aZl5NUZ59Sy2bdPQFZ3UePr5wevZjHboirRCIQCKRI1cCgvSWUe2ag==
-  dependencies:
-    lodash.camelcase "^4.3.0"
-    lodash.clone "^4.5.0"
-    nan "^2.13.2"
-    node-pre-gyp "^0.13.0"
-    protobufjs "^5.0.3"
-
 gzip-size@5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/gzip-size/-/gzip-size-5.0.0.tgz#a55ecd99222f4c48fd8c01c625ce3b349d0a0e80"
@@ -13402,22 +13391,6 @@ node-pre-gyp@^0.12.0:
   version "0.12.0"
   resolved "https://registry.yarnpkg.com/node-pre-gyp/-/node-pre-gyp-0.12.0.tgz#39ba4bb1439da030295f899e3b520b7785766149"
   integrity sha512-4KghwV8vH5k+g2ylT+sLTjy5wmUOb9vPhnM8NHvRf9dHmnW/CndrFXy2aRPaPST6dugXSdHXfeaHQm77PIz/1A==
-  dependencies:
-    detect-libc "^1.0.2"
-    mkdirp "^0.5.1"
-    needle "^2.2.1"
-    nopt "^4.0.1"
-    npm-packlist "^1.1.6"
-    npmlog "^4.0.2"
-    rc "^1.2.7"
-    rimraf "^2.6.1"
-    semver "^5.3.0"
-    tar "^4"
-
-node-pre-gyp@^0.13.0:
-  version "0.13.0"
-  resolved "https://registry.yarnpkg.com/node-pre-gyp/-/node-pre-gyp-0.13.0.tgz#df9ab7b68dd6498137717838e4f92a33fc9daa42"
-  integrity sha512-Md1D3xnEne8b/HGVQkZZwV27WUi1ZRuZBij24TNaZwUPU3ZAFtvT6xxJGaUVillfmMKnn5oD1HoGsp2Ftik7SQ==
   dependencies:
     detect-libc "^1.0.2"
     mkdirp "^0.5.1"


### PR DESCRIPTION
In the event of a challenge timing out:
- [x] Challenger should be given option to Defund
- [x] Responder should be given option to Defund (even though it is perhaps unlikely they will cooperate, in the first instance we could assume that they come back online for this)

Here 'option' means "an offer you can't refuse".

TODO: 
- [x] the challenge could expire while the responder is choosing their move, or even submitting/waiting on their transaction. Deal with all these cases. 

(possibly in a separate PR)
- [ ] Indirect Defunding itself should allow for a challenge
- [ ] and to show a 'hint' if the app channel was closed via a challenge timeout