### PR TITLE
Fix composeConcludeCommitment

### DIFF
--- a/packages/wallet/src/domain/commitments/__tests__/index.ts
+++ b/packages/wallet/src/domain/commitments/__tests__/index.ts
@@ -4,7 +4,6 @@ import { channelID } from 'fmg-core/lib/channel';
 import { CONSENSUS_LIBRARY_ADDRESS } from '../../../constants';
 import { bytesFromAppAttributes } from 'fmg-nitro-adjudicator';
 import { UpdateType } from 'fmg-nitro-adjudicator/lib/consensus-app';
-import { EMPTY_APP_ATTRIBUTES } from '../../../utils/commitment-utils';
 
 export const asPrivateKey = '0xf2f48ee19680706196e2e339e5da3491186e0c4c5030670656b0e0164837257d';
 export const asAddress = '0x5409ED021D9299bf6814279A6A1411A7e866A631';
@@ -58,6 +57,12 @@ interface AppCommitmentParams {
   appAttributes?: string;
 }
 
+const EMPTY_APP_ATTRIBUTES = bytesFromAppAttributes({
+  furtherVotesRequired: 0,
+  updateType: 0,
+  proposedAllocation: [],
+  proposedDestination: [],
+});
 export function appCommitment(params: AppCommitmentParams): SignedCommitment {
   const turnNum = params.turnNum;
   const balances = params.balances || twoThree;

--- a/packages/wallet/src/utils/__tests__/commitment-utils.test.ts
+++ b/packages/wallet/src/utils/__tests__/commitment-utils.test.ts
@@ -1,0 +1,32 @@
+import { appCommitment } from '../../domain/commitments/__tests__';
+import { channelFromCommitments } from '../../redux/channel-store/channel-state/__tests__';
+import * as channelScenarios from '../../redux/__tests__/test-scenarios';
+import { composeConcludeCommitment } from '../commitment-utils';
+import { CommitmentType } from 'fmg-core';
+describe('composeConcludeCommitment', () => {
+  const { asPrivateKey, asAddress } = channelScenarios;
+  const app10 = appCommitment({ turnNum: 10, balances: [] });
+  const app11 = appCommitment({ turnNum: 11, balances: [] });
+  const app12 = appCommitment({ turnNum: 11, balances: [], isFinal: true });
+
+  it('should create a correct conclude commitment from an app commitment', () => {
+    const channelState = channelFromCommitments(app10, app11, asAddress, asPrivateKey);
+    const concludeCommitment = composeConcludeCommitment(channelState);
+    expect(concludeCommitment).toMatchObject({
+      ...app11.commitment,
+      commitmentType: CommitmentType.Conclude,
+      turnNum: app11.commitment.turnNum + 1,
+      commitmentCount: 0,
+    });
+  });
+  it('should create a correct conclude commitment from a conclude commitment', () => {
+    const channelState = channelFromCommitments(app11, app12, asAddress, asPrivateKey);
+    const concludeCommitment = composeConcludeCommitment(channelState);
+    expect(concludeCommitment).toMatchObject({
+      ...app11.commitment,
+      commitmentType: CommitmentType.Conclude,
+      turnNum: app12.commitment.turnNum + 1,
+      commitmentCount: 1,
+    });
+  });
+});

--- a/packages/wallet/src/utils/commitment-utils.ts
+++ b/packages/wallet/src/utils/commitment-utils.ts
@@ -1,10 +1,7 @@
-import { Commitment, CommitmentType, signCommitment2 } from '../domain';
-import { appAttributesFromBytes, bytesFromAppAttributes } from 'fmg-nitro-adjudicator';
+import { Commitment, CommitmentType } from '../domain';
+import { appAttributesFromBytes } from 'fmg-nitro-adjudicator';
 import { PlayerIndex } from '../redux/types';
-import { Channel } from 'fmg-core';
-import { SignedCommitment } from '../domain';
 import { ChannelState } from '../redux/channel-store';
-import { UpdateType } from 'fmg-nitro-adjudicator/lib/consensus-app';
 
 export const hasConsensusBeenReached = (
   lastCommitment: Commitment,
@@ -49,37 +46,6 @@ export const composePostFundCommitment = (
 
   return commitment;
 };
-export const composePreFundCommitment = (
-  channel: Channel,
-  allocation: string[],
-  destination: string[],
-  ourIndex: PlayerIndex,
-  privateKey: string,
-): SignedCommitment => {
-  const appAttributes = bytesFromAppAttributes({
-    proposedAllocation: allocation,
-    proposedDestination: destination,
-    furtherVotesRequired: 0,
-    updateType: UpdateType.Consensus,
-  });
-  const commitment: Commitment = {
-    channel,
-    commitmentType: CommitmentType.PreFundSetup,
-    turnNum: ourIndex,
-    commitmentCount: ourIndex,
-    allocation,
-    destination,
-    appAttributes,
-  };
-  return signCommitment2(commitment, privateKey);
-};
-
-export const EMPTY_APP_ATTRIBUTES = bytesFromAppAttributes({
-  furtherVotesRequired: 0,
-  updateType: 0,
-  proposedAllocation: [],
-  proposedDestination: [],
-});
 
 export const composeConcludeCommitment = (channelState: ChannelState) => {
   const commitmentCount =
@@ -87,7 +53,7 @@ export const composeConcludeCommitment = (channelState: ChannelState) => {
 
   const concludeCommitment: Commitment = {
     ...channelState.lastCommitment.commitment,
-    appAttributes: EMPTY_APP_ATTRIBUTES,
+    appAttributes: channelState.lastCommitment.commitment.appAttributes,
     commitmentType: CommitmentType.Conclude,
     turnNum: channelState.lastCommitment.commitment.turnNum + 1,
     commitmentCount,

--- a/packages/wallet/src/utils/commitment-utils.ts
+++ b/packages/wallet/src/utils/commitment-utils.ts
@@ -53,7 +53,6 @@ export const composeConcludeCommitment = (channelState: ChannelState) => {
 
   const concludeCommitment: Commitment = {
     ...channelState.lastCommitment.commitment,
-    appAttributes: channelState.lastCommitment.commitment.appAttributes,
     commitmentType: CommitmentType.Conclude,
     turnNum: channelState.lastCommitment.commitment.turnNum + 1,
     commitmentCount,


### PR DESCRIPTION
Fixes composeConcludeCommitment so it does not override `appAttributes` with consensus app attributes.