### PR TITLE
Ensure destination field does not change in application channels

### DIFF
--- a/packages/rps/contracts/RockPaperScissorsGame.sol
+++ b/packages/rps/contracts/RockPaperScissorsGame.sol
@@ -16,7 +16,21 @@ contract RockPaperScissorsGame {
     // Reveal -> Start
     //
 
-    function validTransition(Commitment.CommitmentStruct memory _old, Commitment.CommitmentStruct memory _new) public pure returns (bool) {
+    modifier destinationUnchanged(Commitment.CommitmentStruct memory _old, Commitment.CommitmentStruct memory _new) {
+        address[] memory oldDestination = _old.destination;
+        address[] memory newDestination = _new.destination;
+        require(
+            keccak256(abi.encodePacked(oldDestination)) ==
+            keccak256(abi.encodePacked(newDestination)),
+            "The destination field must not change");
+        _;
+    }
+
+    function validTransition(Commitment.CommitmentStruct memory _old, Commitment.CommitmentStruct memory _new)
+    public
+    destinationUnchanged(_old,_new)
+    pure
+    returns (bool) {
         RockPaperScissorsCommitment.RPSCommitmentStruct memory oldCommitment = RockPaperScissorsCommitment.fromFrameworkCommitment(_old);
         RockPaperScissorsCommitment.RPSCommitmentStruct memory newCommitment = RockPaperScissorsCommitment.fromFrameworkCommitment(_new);
 

--- a/packages/rps/src/contract-tests/rock-paper-scissors.test.ts
+++ b/packages/rps/src/contract-tests/rock-paper-scissors.test.ts
@@ -103,6 +103,23 @@ describe('Rock paper Scissors', () => {
     );
   });
 
+  it('disallows transitions where destination changes', async () => {
+    const coreCommitment1 = asCoreCommitment({ ...propose });
+    const coreCommitment2 = asCoreCommitment({
+      ...accept,
+      destination: ['0x6Ecbe1DB9EF729CBe972C83Fb886247691Fb6beb'],
+    });
+    expect.assertions(1);
+    await expectRevert(
+      () =>
+        rpsContract.validTransition(
+          asEthersObject(coreCommitment1),
+          asEthersObject(coreCommitment2),
+        ),
+      'The destination field must not change',
+    );
+  });
+
   it('disallows a stake that the players cannot afford', async () => {
     const coreCommitment1 = asCoreCommitment(postFundSetupB2);
     const coreCommitment2 = asCoreCommitment(propose3);

--- a/packages/tictactoe/contracts/TicTacToeGame.sol
+++ b/packages/tictactoe/contracts/TicTacToeGame.sol
@@ -32,7 +32,16 @@ contract TicTacToeGame {
     //
     // PlayAgainMeSecond -> XPlaying
 
-    function validTransition(bytes _old, bytes _new) public pure returns (bool) {
+    modifier destinationUnchanged(bytes _old, bytes _new) {
+// If running on Nitro Adjudicator, this modifier should be filled out accordingly
+        _;
+    }
+
+    function validTransition(bytes _old, bytes _new)
+    public
+    destinationUnchanged(_old,_new)
+    pure
+    returns (bool) {
         if (_old.positionType() == TicTacToeState.PositionType.XPlaying) {
 
             if (_new.positionType() == TicTacToeState.PositionType.OPlaying) {

--- a/packages/tictactoe/src/contract-tests/ttt-game.test.ts
+++ b/packages/tictactoe/src/contract-tests/ttt-game.test.ts
@@ -91,4 +91,18 @@ describe('TicTacToeGame', () => {
       'Could not match to a valid transition.',
     );
   });
+
+  // use this test if running on Nitro adjudicator
+  it.skip('disallows transitions where destination changes', async () => {
+    const coreCommitment1 = { ...playing1 };
+    const coreCommitment2 = {
+      ...playing2,
+      destination: ['0x6Ecbe1DB9EF729CBe972C83Fb886247691Fb6beb'],
+    };
+    expect.assertions(1);
+    await expectRevert(
+      () => tttContract.validTransition(encode(coreCommitment1), encode(coreCommitment2)),
+      'The destination field must not change',
+    );
+  });
 });


### PR DESCRIPTION
The `destination` field was introduced with Nitro (to allow the a channel to allocate to non-participant addresses) -- but our apps are only safe under the old ForceMove protocol since no checks on `destination` are performed inside `validTransition`. There is an attack where I overwrite `destination` with my own address as the single beneficiary, and I can then transfer more funds than I am entitled to into my own account. 