### PR TITLE
Allow `Application-` to continue when instigator cancels conclude

### DIFF
--- a/packages/rps/src/redux/message-service/saga.ts
+++ b/packages/rps/src/redux/message-service/saga.ts
@@ -270,6 +270,7 @@ function* handleWalletMessage(walletMessage: WalletRequest, state: gameStates.Pl
         yield put(gameActions.messageSent());
         yield put(gameActions.exitToLobby());
       } else {
+        yield put(gameActions.messageSent());
         if (concludeResponse.reason !== 'UserDeclined') {
           throw new Error(concludeResponse.error);
         }

--- a/packages/wallet/src/redux/protocols/application/__tests__/scenarios.ts
+++ b/packages/wallet/src/redux/protocols/application/__tests__/scenarios.ts
@@ -70,7 +70,7 @@ const receiveOurInvalidCommitment = actions.ownCommitmentReceived({
   commitment: signedCommitment20.commitment,
 });
 
-const concludeRequested = actions.concludeRequested({ processId: APPLICATION_PROCESS_ID });
+const concluded = actions.concluded({ processId: APPLICATION_PROCESS_ID });
 
 // -------
 // SharedData
@@ -101,7 +101,7 @@ export const receivingACloseRequest = {
   ongoing: {
     state: ongoing,
     sharedData: ourTurnSharedData,
-    action: concludeRequested,
+    action: concluded,
   },
 };
 

--- a/packages/wallet/src/redux/protocols/application/actions.ts
+++ b/packages/wallet/src/redux/protocols/application/actions.ts
@@ -17,8 +17,8 @@ export interface OpponentCommitmentReceived {
   commitment: Commitment;
   signature: string;
 }
-export interface ConcludeRequested {
-  type: 'WALLET.APPLICATION.CONCLUDE_REQUESTED';
+export interface Concluded {
+  type: 'WALLET.APPLICATION.CONCLUDED';
   processId: string;
 }
 
@@ -45,10 +45,10 @@ export const opponentCommitmentReceived: ActionConstructor<OpponentCommitmentRec
   };
 };
 
-export const concludeRequested: ActionConstructor<ConcludeRequested> = p => {
+export const concluded: ActionConstructor<Concluded> = p => {
   const { processId } = p;
   return {
-    type: 'WALLET.APPLICATION.CONCLUDE_REQUESTED',
+    type: 'WALLET.APPLICATION.CONCLUDED',
     processId,
   };
 };
@@ -57,15 +57,12 @@ export const concludeRequested: ActionConstructor<ConcludeRequested> = p => {
 // Unions and Guards
 // -------
 
-export type ApplicationAction =
-  | OpponentCommitmentReceived
-  | OwnCommitmentReceived
-  | ConcludeRequested;
+export type ApplicationAction = OpponentCommitmentReceived | OwnCommitmentReceived | Concluded;
 
 export function isApplicationAction(action: WalletAction): action is ApplicationAction {
   return (
     action.type === 'WALLET.APPLICATION.OPPONENT_COMMITMENT_RECEIVED' ||
     action.type === 'WALLET.APPLICATION.OWN_COMMITMENT_RECEIVED' ||
-    action.type === 'WALLET.APPLICATION.CONCLUDE_REQUESTED'
+    action.type === 'WALLET.APPLICATION.CONCLUDED'
   );
 }

--- a/packages/wallet/src/redux/protocols/application/readme.md
+++ b/packages/wallet/src/redux/protocols/application/readme.md
@@ -19,8 +19,8 @@ linkStyle default interpolate basis
   S((start)) --> AK(AddressKnown)
   AK-->|WALLET.APPLICATION.COMMITMENT_RECEIVED|O(Ongoing)
   O-->|WALLET.APPLICATION.COMMITMENT_RECEIVED|O(Ongoing)
-  AK-->|WALLET.APPLICATION.CONCLUDE_REQUESTED|Su((success))
-  O-->|WALLET.APPLICATION.CONCLUDE_REQUESTED|Su((success))
+  AK-->|WALLET.APPLICATION.CONCLUDED|Su((success))
+  O-->|WALLET.APPLICATION.CONCLUDED|Su((success))
   classDef logic fill:#efdd20;
   classDef Success fill:#58ef21;
   classDef Failure fill:#f45941;
@@ -34,5 +34,5 @@ linkStyle default interpolate basis
 Notes:
 
 - `COMMITMENT_RECEIVED` is shorthand for either `OWN_COMMITMENT_RECEIVED` or `OPPONENT_COMMITMENT_RECEIVED`
-- `CONCLUDE_REQUESTED` should get triggered when a conclude is requested. This means that the application protocol no longer needs to listen for commitments from the app.
+- `CONCLUDED` should get triggered when a conclude is requested _and then sent from the wallet_. This means that the application protocol no longer needs to listen for commitments from the app. In particular, if the conclude is requested and then cancelled, `CONCLUDED` will not be triggered.
 - The application protocol is responsible for sending out signature and validation messages.

--- a/packages/wallet/src/redux/protocols/application/reducer.ts
+++ b/packages/wallet/src/redux/protocols/application/reducer.ts
@@ -1,4 +1,4 @@
-import { SharedData, queueMessage } from '../../state';
+import { SharedData, queueMessage, registerChannelToMonitor } from '../../state';
 import * as states from './states';
 import * as actions from './actions';
 import { ProtocolStateWithSharedData } from '..';
@@ -31,7 +31,7 @@ export function initialize(
 ): ProtocolStateWithSharedData<states.ApplicationState> {
   return {
     protocolState: states.waitForFirstCommitment({ channelId, privateKey, address }),
-    sharedData,
+    sharedData: registerChannelToMonitor(sharedData, APPLICATION_PROCESS_ID, channelId),
   };
 }
 
@@ -51,7 +51,7 @@ export function applicationReducer(
       return opponentCommitmentReceivedReducer(protocolState, sharedData, action);
     case 'WALLET.APPLICATION.OWN_COMMITMENT_RECEIVED':
       return ownCommitmentReceivedReducer(protocolState, sharedData, action);
-    case 'WALLET.APPLICATION.CONCLUDE_REQUESTED':
+    case 'WALLET.APPLICATION.CONCLUDED':
       return { sharedData, protocolState: states.success({}) };
     default:
       return unreachable(action);

--- a/packages/wallet/src/redux/protocols/concluding/instigator/reducer.ts
+++ b/packages/wallet/src/redux/protocols/concluding/instigator/reducer.ts
@@ -132,7 +132,7 @@ function concludingCancelled(protocolState: NonTerminalCState, sharedData: Stora
   }
   return {
     protocolState: failure({ reason: 'ConcludeCancelled' }),
-    sharedData: hideWallet(sharedData),
+    sharedData: sendConcludeFailure(hideWallet(sharedData), 'UserDeclined'),
   };
 }
 

--- a/packages/wallet/src/redux/protocols/concluding/instigator/reducer.ts
+++ b/packages/wallet/src/redux/protocols/concluding/instigator/reducer.ts
@@ -233,7 +233,7 @@ const createAndSendConcludeCommitment = (sharedData: SharedData, channelId: stri
     return queueMessage(sharedDataWithOwnCommitment, messageRelay);
   } else {
     throw new Error(
-      `Direct funding protocol, createAndSendPostFundCommitment, unable to sign commitment: ${
+      `Concluding Instigator protocol, createAndSendConcludeCommitment, unable to sign commitment: ${
         signResult.reason
       }`,
     );

--- a/packages/wallet/src/redux/sagas/adjudicator-watcher.ts
+++ b/packages/wallet/src/redux/sagas/adjudicator-watcher.ts
@@ -5,6 +5,7 @@ import * as actions from '../actions';
 import { ethers } from 'ethers';
 import { fromParameters } from 'fmg-core/lib/commitment';
 import { getAdjudicatorWatcherProcessesForChannel } from '../selectors';
+import { concluded } from '../protocols/application/actions';
 
 enum AdjudicatorEventType {
   ChallengeCreated,
@@ -65,6 +66,7 @@ function* dispatchProcessEventAction(event: AdjudicatorEvent, processId: string)
       break;
     case AdjudicatorEventType.Concluded:
       yield put(actions.concludedEvent({ channelId }));
+      yield put(concluded({ processId }));
       break;
     case AdjudicatorEventType.Refuted:
       yield put(

--- a/packages/wallet/src/redux/sagas/adjudicator-watcher.ts
+++ b/packages/wallet/src/redux/sagas/adjudicator-watcher.ts
@@ -65,8 +65,8 @@ function* dispatchProcessEventAction(event: AdjudicatorEvent, processId: string)
       );
       break;
     case AdjudicatorEventType.Concluded:
-      yield put(actions.concludedEvent({ channelId }));
       yield put(concluded({ processId }));
+      yield put(actions.concludedEvent({ channelId }));
       break;
     case AdjudicatorEventType.Refuted:
       yield put(

--- a/packages/wallet/src/redux/sagas/adjudicator-watcher.ts
+++ b/packages/wallet/src/redux/sagas/adjudicator-watcher.ts
@@ -5,7 +5,6 @@ import * as actions from '../actions';
 import { ethers } from 'ethers';
 import { fromParameters } from 'fmg-core/lib/commitment';
 import { getAdjudicatorWatcherProcessesForChannel } from '../selectors';
-import { concluded } from '../protocols/application/actions';
 
 enum AdjudicatorEventType {
   ChallengeCreated,
@@ -65,7 +64,6 @@ function* dispatchProcessEventAction(event: AdjudicatorEvent, processId: string)
       );
       break;
     case AdjudicatorEventType.Concluded:
-      yield put(concluded({ processId }));
       yield put(actions.concludedEvent({ channelId }));
       break;
     case AdjudicatorEventType.Refuted:

--- a/packages/wallet/src/redux/sagas/challenge-watcher.ts
+++ b/packages/wallet/src/redux/sagas/challenge-watcher.ts
@@ -4,6 +4,7 @@ import { take, select, put } from 'redux-saga/effects';
 import { AdjudicatorState, getAdjudicatorChannelState } from '../adjudicator-state/state';
 import { getProvider } from '../../utils/contract-utils';
 import { eventChannel } from 'redux-saga';
+import { concluded } from '../protocols/application/actions';
 
 export function* challengeWatcher() {
   const provider = yield getProvider();
@@ -20,6 +21,7 @@ export function* challengeWatcher() {
           channelId,
         );
         for (const processId of processIdsToAlert) {
+          yield put(concluded({ processId }));
           yield put(
             actions.challengeExpiredEvent({ processId, channelId, timestamp: block.timestamp }),
           );

--- a/packages/wallet/src/redux/sagas/challenge-watcher.ts
+++ b/packages/wallet/src/redux/sagas/challenge-watcher.ts
@@ -21,10 +21,10 @@ export function* challengeWatcher() {
           channelId,
         );
         for (const processId of processIdsToAlert) {
-          yield put(concluded({ processId }));
           yield put(
             actions.challengeExpiredEvent({ processId, channelId, timestamp: block.timestamp }),
           );
+          yield put(concluded({ processId }));
         }
       }
     }

--- a/packages/wallet/src/redux/sagas/message-listener.ts
+++ b/packages/wallet/src/redux/sagas/message-listener.ts
@@ -27,9 +27,6 @@ export function* messageListener() {
 
       case incoming.CONCLUDE_CHANNEL_REQUEST:
         yield put(actions.protocol.concludeRequested({ channelId: action.channelId }));
-        yield put(
-          actions.application.concludeRequested({ processId: application.APPLICATION_PROCESS_ID }),
-        );
         break;
       case incoming.CREATE_CHALLENGE_REQUEST:
         yield put(

--- a/packages/wallet/src/redux/sagas/message-listener.ts
+++ b/packages/wallet/src/redux/sagas/message-listener.ts
@@ -7,6 +7,7 @@ import * as application from '../protocols/application/reducer';
 import { isRelayableAction, WalletProtocol } from '../../communication';
 import { responseProvided } from '../protocols/dispute/responder/actions';
 import { getChannelId } from '../../domain';
+import { concluded } from '../protocols/application/actions';
 
 export function* messageListener() {
   const postMessageEventChannel = eventChannel(emitter => {
@@ -84,6 +85,9 @@ export function* messageListener() {
         break;
       case incoming.RECEIVE_MESSAGE:
         yield put(handleIncomingMessage(action));
+        if (handleIncomingMessage(action).type === 'WALLET.NEW_PROCESS.CONCLUDE_INSTIGATED') {
+          yield put(concluded({ processId: application.APPLICATION_PROCESS_ID }));
+        }
         break;
       default:
     }

--- a/packages/wallet/src/redux/sagas/message-sender.ts
+++ b/packages/wallet/src/redux/sagas/message-sender.ts
@@ -1,6 +1,7 @@
 import { put } from 'redux-saga/effects';
 import { messageSent } from '../actions';
 import { concluded } from '../protocols/application/actions';
+import { APPLICATION_PROCESS_ID } from '../protocols/application/reducer';
 
 export function* messageSender(message) {
   window.parent.postMessage(message, '*');
@@ -8,7 +9,7 @@ export function* messageSender(message) {
   if (message.messagePayload) {
     const action = message.messagePayload;
     if (action.type === 'WALLET.NEW_PROCESS.CONCLUDE_INSTIGATED') {
-      const processId = `${action.protocol}-${action.channelId}`;
+      const processId = APPLICATION_PROCESS_ID;
       yield put(concluded({ processId }));
     }
   }

--- a/packages/wallet/src/redux/sagas/message-sender.ts
+++ b/packages/wallet/src/redux/sagas/message-sender.ts
@@ -5,7 +5,6 @@ import { APPLICATION_PROCESS_ID } from '../protocols/application/reducer';
 
 export function* messageSender(message) {
   window.parent.postMessage(message, '*');
-  console.log(message);
   if (
     message.messagePayload &&
     message.messagePayload.type === 'WALLET.NEW_PROCESS.CONCLUDE_INSTIGATED'

--- a/packages/wallet/src/redux/sagas/message-sender.ts
+++ b/packages/wallet/src/redux/sagas/message-sender.ts
@@ -1,9 +1,17 @@
 import { put } from 'redux-saga/effects';
 import { messageSent } from '../actions';
+import { concluded } from '../protocols/application/actions';
 
 export function* messageSender(message) {
   window.parent.postMessage(message, '*');
-
+  console.log(message);
+  if (message.messagePayload) {
+    const action = message.messagePayload;
+    if (action.type === 'WALLET.NEW_PROCESS.CONCLUDE_INSTIGATED') {
+      const processId = `${action.protocol}-${action.channelId}`;
+      yield put(concluded({ processId }));
+    }
+  }
   yield put(message);
   yield put(messageSent({}));
 }

--- a/packages/wallet/src/redux/sagas/message-sender.ts
+++ b/packages/wallet/src/redux/sagas/message-sender.ts
@@ -6,12 +6,12 @@ import { APPLICATION_PROCESS_ID } from '../protocols/application/reducer';
 export function* messageSender(message) {
   window.parent.postMessage(message, '*');
   console.log(message);
-  if (message.messagePayload) {
-    const action = message.messagePayload;
-    if (action.type === 'WALLET.NEW_PROCESS.CONCLUDE_INSTIGATED') {
-      const processId = APPLICATION_PROCESS_ID;
-      yield put(concluded({ processId }));
-    }
+  if (
+    message.messagePayload &&
+    message.messagePayload.type === 'WALLET.NEW_PROCESS.CONCLUDE_INSTIGATED'
+  ) {
+    const processId = APPLICATION_PROCESS_ID;
+    yield put(concluded({ processId }));
   }
   yield put(message);
   yield put(messageSent({}));


### PR DESCRIPTION
Previously, the mere request for a conclude was wrapping up the application process. Since the instigator can back out, this is undesired behaviour because the application process needs to continue.

Instead, it should 
- [x] not be wrapped up on a conclude request

and only be wrapped up when 

- [x] the app channel is registered finalized on chain
- [x] a conclude commitment is sent or received (i.e. channel finalized off chain)

~~As far as I can tell, conclude commitments are not verified (at least not in the same way as regular commitments). There is an open question about exactly where and how to dispatch the action that will wrap up the application process, when the channel is finalized off chain.~~

Message sender and listener sagas will inspect the messages, and conditionally put a new `concluded` action, to be routed to the `Application` process, as appropriate.