### PR TITLE
Clear the Library folder on build

### DIFF
--- a/packages/wallet/package.json
+++ b/packages/wallet/package.json
@@ -9,7 +9,7 @@
   "scripts": {
     "start": "npm run clearContracts && node scripts/start.js",
     "build": "run-s clearContracts build:typescript build:webpack",
-    "build:typescript": "npx tsc",
+    "build:typescript": "yarn run clearLib && npx tsc",
     "build:webpack": "node scripts/build.js",
     "prepare": "npx tsc",
     "test": "run-s prettier:check 'test:app --all'",
@@ -24,7 +24,8 @@
     "ganache:start": "NODE_ENV=development npx start-ganache",
     "postinstall": "rm -f node_modules/web3/index.d.ts",
     "storybook": "start-storybook -p 9001 -c .storybook",
-    "clearContracts": "rm -rf ./build/contracts"
+    "clearContracts": "rm -rf ./build/contracts",
+    "clearLib": "rm -rf ./lib"
   },
   "dependencies": {
     "@firebase/app-types": "^0.3.2",


### PR DESCRIPTION
This fixes #534.

 I spent some time trying to figure out why the `.d.ts` files were being included from the `lib` folder but didn't manage to figure it out.

This avoids the problem by clearing the `lib` folder before building. 