### PR TITLE
Add clearedToSend flag to advanceChannelState

### DIFF
--- a/packages/wallet/src/redux/actions.ts
+++ b/packages/wallet/src/redux/actions.ts
@@ -14,6 +14,7 @@ import { ConcludingAction, isConcludingAction } from './protocols/concluding';
 import { ApplicationAction } from './protocols/application/actions';
 import { ActionConstructor } from './utils';
 import { Commitment } from '../domain';
+import { AdvanceChannelAction } from './protocols/advance-channel/actions';
 
 export * from './protocols/transaction-submission/actions';
 export { CommitmentReceived, commitmentReceived };
@@ -204,6 +205,7 @@ export function isProtocolAction(action: WalletAction): action is ProtocolAction
 }
 
 export type WalletAction =
+  | AdvanceChannelAction
   | AdjudicatorKnown
   | AdjudicatorEventAction
   | BlockMined

--- a/packages/wallet/src/redux/protocols/advance-channel/__tests__/reducer.test.ts
+++ b/packages/wallet/src/redux/protocols/advance-channel/__tests__/reducer.test.ts
@@ -281,6 +281,14 @@ describe('when not cleared to send', () => {
     itSendsNoMessage(result);
     itIsClearedToSend(protocolState);
   });
+
+  describe('when cleared to send, but the commitment was already sent', () => {
+    const { state, sharedData, action } = scenario.clearedToSendAndAlreadySent;
+    const { protocolState, sharedData: result } = reducer(state, sharedData, action);
+
+    itTransitionsTo(protocolState, 'AdvanceChannel.CommitmentSent');
+    itSendsNoMessage(result);
+  });
 });
 
 function itIsClearedToSend(protocolState: states.AdvanceChannelState) {

--- a/packages/wallet/src/redux/protocols/advance-channel/__tests__/reducer.test.ts
+++ b/packages/wallet/src/redux/protocols/advance-channel/__tests__/reducer.test.ts
@@ -251,15 +251,46 @@ describe('when not cleared to send', () => {
     itTransitionsTo(protocolState, 'AdvanceChannel.NotSafeToSend');
     itSendsNoMessage(result);
     itStoresThisCommitment(result, commitments[2]);
+    itIsNotClearedToSend(protocolState);
   });
 
-  describe('when cleared to send', () => {
+  describe('when cleared to send, and it is safe to send', () => {
     const { state, sharedData, action, commitments } = scenario.clearedToSend;
-
     const { protocolState, sharedData: result } = reducer(state, sharedData, action);
 
     itTransitionsTo(protocolState, 'AdvanceChannel.CommitmentSent');
     itStoresThisCommitment(result, commitments[2]);
     expectTheseCommitmentsSent(result, commitments);
   });
+
+  describe('when cleared to send, and it is unsafe to send', () => {
+    const { state, sharedData, action, commitments } = scenario.clearedToSendButUnsafe;
+    const { protocolState, sharedData: result } = reducer(state, sharedData, action);
+
+    itTransitionsTo(protocolState, 'AdvanceChannel.NotSafeToSend');
+    itStoresThisCommitment(result, commitments[1]);
+    itSendsNoMessage(result);
+    itIsClearedToSend(protocolState);
+  });
+
+  describe('when cleared to send, and the channel is unknown', () => {
+    const { state, sharedData, action } = scenario.clearedToSendButChannelUnknown;
+    const { protocolState, sharedData: result } = reducer(state, sharedData, action);
+
+    itTransitionsTo(protocolState, 'AdvanceChannel.ChannelUnknown');
+    itSendsNoMessage(result);
+    itIsClearedToSend(protocolState);
+  });
 });
+
+function itIsClearedToSend(protocolState: states.AdvanceChannelState) {
+  it('is cleared to send', () => {
+    expect(protocolState).toMatchObject({ clearedToSend: true });
+  });
+}
+
+function itIsNotClearedToSend(protocolState: states.AdvanceChannelState) {
+  it('is cleared to send', () => {
+    expect(protocolState).toMatchObject({ clearedToSend: false });
+  });
+}

--- a/packages/wallet/src/redux/protocols/advance-channel/__tests__/reducer.test.ts
+++ b/packages/wallet/src/redux/protocols/advance-channel/__tests__/reducer.test.ts
@@ -234,3 +234,32 @@ describe('sending postFundSetup as Hub', () => {
     expectTheseCommitmentsSent(result, commitments);
   });
 });
+
+describe('when not cleared to send', () => {
+  const scenario = scenarios.notClearedToSend;
+  const { processId, commitmentType } = scenario;
+
+  describe('when initializing', () => {
+    const { sharedData, commitments, args } = scenario.initialize;
+    const { protocolState, sharedData: result } = initialize(
+      processId,
+      sharedData,
+      commitmentType,
+      args,
+    );
+
+    itTransitionsTo(protocolState, 'AdvanceChannel.NotSafeToSend');
+    itSendsNoMessage(result);
+    itStoresThisCommitment(result, commitments[2]);
+  });
+
+  describe('when cleared to send', () => {
+    const { state, sharedData, action, commitments } = scenario.clearedToSend;
+
+    const { protocolState, sharedData: result } = reducer(state, sharedData, action);
+
+    itTransitionsTo(protocolState, 'AdvanceChannel.CommitmentSent');
+    itStoresThisCommitment(result, commitments[2]);
+    expectTheseCommitmentsSent(result, commitments);
+  });
+});

--- a/packages/wallet/src/redux/protocols/advance-channel/__tests__/scenarios.ts
+++ b/packages/wallet/src/redux/protocols/advance-channel/__tests__/scenarios.ts
@@ -349,4 +349,23 @@ export const notClearedToSend = {
     action: clearSending,
     commitments: commitments3,
   },
+  clearedToSendButUnsafe: {
+    state: {
+      ...notSafeToSendB,
+      commitmentType: CommitmentType.PostFundSetup,
+      clearedToSend: false,
+    },
+    sharedData: bSentPreFundCommitment,
+    action: clearSending,
+    commitments: commitments1,
+  },
+  clearedToSendButChannelUnknown: {
+    state: {
+      ...channelUnknownB,
+      commitmentType: CommitmentType.PreFundSetup,
+      clearedToSend: false,
+    },
+    sharedData: emptySharedData,
+    action: clearSending,
+  },
 };

--- a/packages/wallet/src/redux/protocols/advance-channel/__tests__/scenarios.ts
+++ b/packages/wallet/src/redux/protocols/advance-channel/__tests__/scenarios.ts
@@ -6,6 +6,7 @@ import { channelFromCommitments } from '../../../channel-store/channel-state/__t
 import * as scenarios from '../../../__tests__/test-scenarios';
 import { commitmentsReceived } from '../../../../communication';
 import { CommitmentType } from '../../../../domain';
+import { clearedToSend } from '../actions';
 
 // ---------
 // Test data
@@ -164,6 +165,9 @@ const receivePostFundSetupFromHub = commitmentsReceived({
   processId,
   signedCommitments: commitments5,
 });
+const clearSending = clearedToSend({
+  processId,
+});
 // ---------
 // Scenarios
 // ---------
@@ -320,5 +324,25 @@ export const existingChannelAsHub = {
     sharedData: hubSentPreFundCommitment,
     action: receivePostFundSetupFromB,
     commitments: commitments5,
+  },
+};
+
+export const notClearedToSend = {
+  ...propsA,
+  commitmentType: CommitmentType.PostFundSetup,
+  initialize: {
+    args: { ...existingArgsA, clearedToSend: false },
+    sharedData: aReceivedPrefundSetup,
+    commitments: commitments2,
+  },
+  clearedToSend: {
+    state: {
+      ...commitmentSentA,
+      commitmentType: CommitmentType.PostFundSetup,
+      clearedToSend: false,
+    },
+    sharedData: aReceivedPrefundSetup,
+    action: clearSending,
+    commitments: commitments3,
   },
 };

--- a/packages/wallet/src/redux/protocols/advance-channel/__tests__/scenarios.ts
+++ b/packages/wallet/src/redux/protocols/advance-channel/__tests__/scenarios.ts
@@ -76,6 +76,10 @@ const commitments5 = [signedCommitment3, signedCommitment4, signedCommitment5];
 // ----
 // States
 // ------
+const notSafeToSendA = states.notSafeToSend({
+  ...propsA,
+  commitmentType: CommitmentType.PostFundSetup,
+});
 const commitmentSentA = states.commitmentSent({
   ...propsA,
   commitmentType: CommitmentType.PreFundSetup,
@@ -337,7 +341,7 @@ export const notClearedToSend = {
   },
   clearedToSend: {
     state: {
-      ...commitmentSentA,
+      ...notSafeToSendA,
       commitmentType: CommitmentType.PostFundSetup,
       clearedToSend: false,
     },

--- a/packages/wallet/src/redux/protocols/advance-channel/__tests__/scenarios.ts
+++ b/packages/wallet/src/redux/protocols/advance-channel/__tests__/scenarios.ts
@@ -368,4 +368,14 @@ export const notClearedToSend = {
     sharedData: emptySharedData,
     action: clearSending,
   },
+  clearedToSendAndAlreadySent: {
+    state: {
+      ...commitmentSentB,
+      commitmentType: CommitmentType.PreFundSetup,
+      clearedToSend: true,
+    },
+    sharedData: bSentPreFundCommitment,
+    action: clearSending,
+    commitments: commitments1,
+  },
 };

--- a/packages/wallet/src/redux/protocols/advance-channel/__tests__/scenarios.ts
+++ b/packages/wallet/src/redux/protocols/advance-channel/__tests__/scenarios.ts
@@ -40,6 +40,7 @@ const initializeArgs = {
   channelType,
   appAttributes,
   processId,
+  clearedToSend: true,
 };
 
 const props = {
@@ -191,6 +192,7 @@ const initializeArgsHub = {
 };
 
 const existingArgs = {
+  clearedToSend: true,
   channelId,
   processId,
   commitmentType: CommitmentType.PostFundSetup,

--- a/packages/wallet/src/redux/protocols/advance-channel/actions.ts
+++ b/packages/wallet/src/redux/protocols/advance-channel/actions.ts
@@ -1,8 +1,24 @@
-import { CommitmentsReceived } from '../../../communication';
+import { CommitmentsReceived, BaseProcessAction } from '../../../communication';
 import { WalletAction } from '../../actions';
+import { ActionConstructor } from '../../utils';
 
-export type AdvanceChannelAction = CommitmentsReceived;
+export interface ClearedToSend extends BaseProcessAction {
+  type: 'WALLET.ADVANCE_CHANNEL.CLEARED_TO_SEND';
+}
+
+export type AdvanceChannelAction = CommitmentsReceived | ClearedToSend;
+
+export const clearedToSend: ActionConstructor<ClearedToSend> = p => {
+  const { processId } = p;
+  return {
+    type: 'WALLET.ADVANCE_CHANNEL.CLEARED_TO_SEND',
+    processId,
+  };
+};
 
 export function isAdvanceChannelAction(action: WalletAction): action is AdvanceChannelAction {
-  return action.type === 'WALLET.ADVANCE_CHANNEL.COMMITMENTS_RECEIVED';
+  return (
+    action.type === 'WALLET.ADVANCE_CHANNEL.COMMITMENTS_RECEIVED' ||
+    action.type === 'WALLET.ADVANCE_CHANNEL.CLEARED_TO_SEND'
+  );
 }

--- a/packages/wallet/src/redux/protocols/advance-channel/readme.md
+++ b/packages/wallet/src/redux/protocols/advance-channel/readme.md
@@ -57,14 +57,16 @@ linkStyle default interpolate basis
   STSCO --> |Yes| CS
   STSCO --> |No| NSTS(NotSafeToSend)
   ICO --> |No| FP{First participant?}
-  FP --> |Yes|CS(CommitmentSent)
+  FP --> |Yes|STS
   FP --> |No| CU(ChannelUnknown)
-  RC   -->|No| CS
-  CS   -->|CommitmentReceived| RC
-  CU   -->|CommitmentReceived| RC{Round Complete?}
+  CS   -->|CommitmentReceived| RC{Round Complete?}
   NSTS -->|CommitmentReceived| STS{Safe to send?}
+  CU   -->|CommitmentReceived| STS
+  CU   -->|ClearedToSend| STS
+  NSTS -->|ClearedToSend| STS
   STS -->|YES| RC
   STS -->|NO| NSTS
+  RC   -->|No| CS(CommitmentSent)
   RC   -->|Yes| S((Success))
 
   classDef logic fill:#efdd20;

--- a/packages/wallet/src/redux/protocols/advance-channel/reducer.ts
+++ b/packages/wallet/src/redux/protocols/advance-channel/reducer.ts
@@ -236,7 +236,7 @@ function attemptToAdvanceChannel(
   }
 }
 
-const channelUnknownReducer: ProtocolReducer<states.AdvanceChannelState> = (
+const channelUnknownReducer = (
   protocolState: states.ChannelUnknown,
   sharedData,
   action: CommitmentsReceived,
@@ -285,7 +285,7 @@ function checkCommitments(
   return sharedData;
 }
 
-const notSafeToSendReducer: ProtocolReducer<states.AdvanceChannelState> = (
+const notSafeToSendReducer = (
   protocolState: states.NotSafeToSend,
   sharedData,
   action: CommitmentsReceived,
@@ -298,7 +298,7 @@ const notSafeToSendReducer: ProtocolReducer<states.AdvanceChannelState> = (
   return attemptToAdvanceChannel(sharedData, protocolState, channelId);
 };
 
-const commitmentSentReducer: ProtocolReducer<states.AdvanceChannelState> = (
+const commitmentSentReducer = (
   protocolState: states.CommitmentSent,
   sharedData,
   action: CommitmentsReceived,

--- a/packages/wallet/src/redux/protocols/advance-channel/reducer.ts
+++ b/packages/wallet/src/redux/protocols/advance-channel/reducer.ts
@@ -79,15 +79,20 @@ export const reducer: ProtocolReducer<states.AdvanceChannelState> = (
 };
 
 function clearedToSendReducer(protocolState: states.AdvanceChannelState, sharedData: SharedData) {
-  if (states.commitmentNotSent(protocolState)) {
+  if (protocolState.type === 'AdvanceChannel.NotSafeToSend') {
     protocolState = { ...protocolState, clearedToSend: true };
     if (protocolState.type === 'AdvanceChannel.NotSafeToSend') {
       return attemptToAdvanceChannel(sharedData, protocolState, protocolState.channelId);
     } else {
       return { sharedData, protocolState };
     }
+  } else if (protocolState.type === 'AdvanceChannel.ChannelUnknown') {
+    return {
+      sharedData,
+      protocolState: states.channelUnknown({ ...protocolState, clearedToSend: true }),
+    };
   } else {
-    return { sharedData, protocolState };
+    return { protocolState, sharedData };
   }
 }
 

--- a/packages/wallet/src/redux/protocols/advance-channel/reducer.ts
+++ b/packages/wallet/src/redux/protocols/advance-channel/reducer.ts
@@ -337,7 +337,7 @@ function isSafeToSend({
 
   const channel = getChannel(sharedData.channelStore, channelId);
   const numParticipants = channel.participants.length;
-  return channel.turnNum % numParticipants === (ourIndex - 1) % numParticipants;
+  return (channel.turnNum + 1) % numParticipants === ourIndex;
 }
 
 function channelAdvanced(channel: ChannelState, commitmentType: CommitmentType): boolean {

--- a/packages/wallet/src/redux/protocols/advance-channel/states.ts
+++ b/packages/wallet/src/redux/protocols/advance-channel/states.ts
@@ -22,11 +22,13 @@ export interface ChannelUnknown extends BaseState {
   channelType: string;
   appAttributes: string;
   privateKey: string;
+  clearedToSend: boolean;
 }
 
 export interface NotSafeToSend extends BaseState {
   type: 'AdvanceChannel.NotSafeToSend';
   channelId: string;
+  clearedToSend: boolean;
 }
 
 export interface CommitmentSent extends BaseState {
@@ -57,7 +59,7 @@ const base: StateConstructor<BaseState> = params => {
 };
 
 export const channelUnknown: StateConstructor<ChannelUnknown> = params => {
-  const { privateKey, allocation, destination, channelType, appAttributes } = params;
+  const { privateKey, allocation, destination, channelType, appAttributes, clearedToSend } = params;
   return {
     ...base(params),
     type: 'AdvanceChannel.ChannelUnknown',
@@ -66,6 +68,7 @@ export const channelUnknown: StateConstructor<ChannelUnknown> = params => {
     destination,
     channelType,
     appAttributes,
+    clearedToSend,
   };
 };
 
@@ -74,6 +77,7 @@ export const notSafeToSend: StateConstructor<NotSafeToSend> = params => {
     ...base(params),
     type: 'AdvanceChannel.NotSafeToSend',
     channelId: params.channelId,
+    clearedToSend: params.clearedToSend,
   };
 };
 

--- a/packages/wallet/src/redux/protocols/advance-channel/states.ts
+++ b/packages/wallet/src/redux/protocols/advance-channel/states.ts
@@ -117,14 +117,6 @@ export function isTerminal(state: AdvanceChannelState): state is Failure | Succe
   return state.type === 'AdvanceChannel.Failure' || state.type === 'AdvanceChannel.Success';
 }
 
-export function commitmentNotSent(
-  state: AdvanceChannelState,
-): state is ChannelUnknown | NotSafeToSend {
-  return (
-    state.type === 'AdvanceChannel.ChannelUnknown' || state.type === 'AdvanceChannel.NotSafeToSend'
-  );
-}
-
 export function isAdvanceChannelState(state: ProtocolState): state is AdvanceChannelState {
   return (
     state.type === 'AdvanceChannel.ChannelUnknown' ||

--- a/packages/wallet/src/redux/protocols/advance-channel/states.ts
+++ b/packages/wallet/src/redux/protocols/advance-channel/states.ts
@@ -117,6 +117,14 @@ export function isTerminal(state: AdvanceChannelState): state is Failure | Succe
   return state.type === 'AdvanceChannel.Failure' || state.type === 'AdvanceChannel.Success';
 }
 
+export function commitmentNotSent(
+  state: AdvanceChannelState,
+): state is ChannelUnknown | NotSafeToSend {
+  return (
+    state.type === 'AdvanceChannel.ChannelUnknown' || state.type === 'AdvanceChannel.NotSafeToSend'
+  );
+}
+
 export function isAdvanceChannelState(state: ProtocolState): state is AdvanceChannelState {
   return (
     state.type === 'AdvanceChannel.ChannelUnknown' ||


### PR DESCRIPTION
This lets the directFunding protocol embed an `advanceChannelState`, by allowing the funding protocol to block sending of commitments until the channel is funded.