### PR TITLE
Relay multiple actions in an ordered batch

### DIFF
--- a/packages/rps/src/redux/message-service/saga.ts
+++ b/packages/rps/src/redux/message-service/saga.ts
@@ -66,7 +66,7 @@ export function* sendWalletMessageSaga() {
         console.error(err);
       }
     } else {
-      yield fork(
+      yield call(
         reduxSagaFirebase.database.create,
         `/messages/${to.toLowerCase()}`,
         sanitizeMessageForFirebase(messageToSend),

--- a/packages/server/src/app/handlers/handle-new-process-action.ts
+++ b/packages/server/src/app/handlers/handle-new-process-action.ts
@@ -19,6 +19,7 @@ export async function handleNewProcessAction(ctx) {
     case 'WALLET.COMMON.COMMITMENTS_RECEIVED':
     case 'WALLET.NEW_PROCESS.DEFUND_REQUESTED':
     case 'WALLET.CONCLUDING.KEEP_LEDGER_CHANNEL_APPROVED':
+    case 'WALLET.MULTIPLE_RELAYABLE_ACTIONS':
       return ctx;
     case 'WALLET.NEW_PROCESS.CONCLUDE_INSTIGATED':
       return handleConcludeInstigated(ctx, action);

--- a/packages/server/src/app/handlers/handle-ongoing-process-action.ts
+++ b/packages/server/src/app/handlers/handle-ongoing-process-action.ts
@@ -23,6 +23,7 @@ export async function handleOngoingProcessAction(ctx) {
     case 'WALLET.FUNDING.STRATEGY_APPROVED':
     case 'WALLET.CONCLUDING.KEEP_LEDGER_CHANNEL_APPROVED':
     case 'WALLET.NEW_PROCESS.DEFUND_REQUESTED':
+    case 'WALLET.MULTIPLE_RELAYABLE_ACTIONS':
       return ctx;
     case 'WALLET.COMMON.COMMITMENT_RECEIVED':
       return handleCommitmentReceived(ctx, action);

--- a/packages/wallet/src/communication/actions.ts
+++ b/packages/wallet/src/communication/actions.ts
@@ -6,6 +6,16 @@ import { ActionConstructor } from '../redux/utils';
 import { Commitments } from '../redux/channel-store';
 import { DefundRequested } from '../redux/protocols/actions';
 
+export interface MultipleRelayableActions {
+  type: 'WALLET.MULTIPLE_RELAYABLE_ACTIONS';
+  actions: RelayableAction[];
+}
+
+export const multipleRelayableActions: ActionConstructor<MultipleRelayableActions> = p => ({
+  ...p,
+  type: 'WALLET.MULTIPLE_RELAYABLE_ACTIONS',
+});
+
 export interface BaseProcessAction {
   processId: string;
   type: string;
@@ -16,6 +26,7 @@ export interface BaseProcessAction {
 // -------
 // Actions
 // -------
+
 export interface StrategyProposed extends BaseProcessAction {
   type: 'WALLET.FUNDING.STRATEGY_PROPOSED';
   strategy: FundingStrategy;
@@ -107,7 +118,8 @@ export type RelayableAction =
   | CommitmentReceived
   | CommitmentsReceived
   | DefundRequested
-  | KeepLedgerChannelApproved;
+  | KeepLedgerChannelApproved
+  | MultipleRelayableActions;
 
 export function isRelayableAction(action: WalletAction): action is RelayableAction {
   return (
@@ -117,6 +129,7 @@ export function isRelayableAction(action: WalletAction): action is RelayableActi
     action.type === 'WALLET.COMMON.COMMITMENT_RECEIVED' ||
     action.type === 'WALLET.NEW_PROCESS.DEFUND_REQUESTED' ||
     action.type === 'WALLET.CONCLUDING.KEEP_LEDGER_CHANNEL_APPROVED' ||
-    action.type === 'WALLET.COMMON.COMMITMENTS_RECEIVED'
+    action.type === 'WALLET.COMMON.COMMITMENTS_RECEIVED' ||
+    action.type === 'WALLET.MULTIPLE_RELAYABLE_ACTIONS'
   );
 }

--- a/packages/wallet/src/redux/__tests__/helpers.ts
+++ b/packages/wallet/src/redux/__tests__/helpers.ts
@@ -4,6 +4,7 @@ import { Commitment, SignedCommitment, getChannelId } from '../../domain';
 import { QueuedTransaction, OutboxState, MessageOutbox } from '../outbox/state';
 import { SharedData } from '../state';
 import { ProtocolStateWithSharedData } from '../protocols';
+import { RelayableAction } from 'src/communication';
 
 type SideEffectState =
   | StateWithSideEffects<any>
@@ -196,6 +197,17 @@ function getOutboxState(state: SideEffectState, outboxBranch: 'messageOutbox'): 
   throw new Error('Invalid state');
 }
 
+export const expectTheseActionsRelayed = (state: SideEffectState, actions: RelayableAction[]) => {
+  expectSideEffect('messageOutbox', state, item =>
+    expect(item.messagePayload.actions).toEqual(actions),
+  );
+};
+
+export const itRelaysTheseActions = (state: SideEffectState, actions: RelayableAction[]) => {
+  it(`relays the correct actions`, () => {
+    expectTheseActionsRelayed(state, actions);
+  });
+};
 export const itSendsATransaction = (state: SideEffectState) => {
   it(`sends a transaction`, () => {
     expectSideEffect('transactionOutbox', state, item => expect(item).toBeDefined());

--- a/packages/wallet/src/redux/protocols/indirect-defunding/__tests__/reducer.test.ts
+++ b/packages/wallet/src/redux/protocols/indirect-defunding/__tests__/reducer.test.ts
@@ -4,6 +4,7 @@ import { ProtocolStateWithSharedData } from '../..';
 import { getLastMessage } from '../../../state';
 import { SignedCommitment } from '../../../../domain';
 import { initialize, indirectDefundingReducer } from '../reducer';
+import { itRelaysTheseActions } from '../../../__tests__/helpers';
 
 describe('player A happy path', () => {
   const scenario = scenarios.playerAHappyPath;
@@ -14,6 +15,7 @@ describe('player A happy path', () => {
     store,
     proposedAllocation,
     proposedDestination,
+    relayActions,
   } = scenario.initialParams;
 
   describe('when initializing', () => {
@@ -26,7 +28,7 @@ describe('player A happy path', () => {
       store,
     );
     itTransitionsTo(result, 'IndirectDefunding.WaitForLedgerUpdate');
-    itSendsMessage(result, scenario.initialParams.reply);
+    itRelaysTheseActions(result, relayActions);
   });
 
   describe('when in WaitForLedgerUpdate', () => {

--- a/packages/wallet/src/redux/protocols/indirect-defunding/__tests__/scenarios.ts
+++ b/packages/wallet/src/redux/protocols/indirect-defunding/__tests__/scenarios.ts
@@ -13,6 +13,7 @@ import { setChannels, EMPTY_SHARED_DATA, SharedData } from '../../../state';
 import { channelFromCommitments } from '../../../channel-store/channel-state/__tests__';
 import { bsPrivateKey } from '../../../../communication/__tests__/commitments';
 import * as globalActions from '../../../actions';
+import { defundRequested } from '../../actions';
 
 const processId = 'processId';
 
@@ -144,7 +145,12 @@ export const playerAHappyPath = {
   initialParams: {
     store: initialStore,
     ...props,
-    reply: ledger6,
+    relayActions: [
+      defundRequested({
+        channelId,
+      }),
+      globalActions.commitmentReceived({ processId, signedCommitment: ledger6 }),
+    ],
   },
   waitForLedgerUpdate: {
     state: playerAWaitForUpdate,

--- a/packages/wallet/src/redux/sagas/__tests__/multiple-action-dispatcher.test.ts
+++ b/packages/wallet/src/redux/sagas/__tests__/multiple-action-dispatcher.test.ts
@@ -15,7 +15,9 @@ describe('multiple action dispatcher', () => {
   });
 
   it('waits for multiple actions to arrive', () => {
-    expect(saga.next().value).toEqual(take('WALLET.MULTIPLE_ACTIONS'));
+    expect(saga.next().value).toEqual(
+      take(['WALLET.MULTIPLE_ACTIONS', 'WALLET.MULTIPLE_RELAYABLE_ACTIONS']),
+    );
   });
 
   it('puts the actions in order', () => {

--- a/packages/wallet/src/redux/sagas/multiple-action-dispatcher.ts
+++ b/packages/wallet/src/redux/sagas/multiple-action-dispatcher.ts
@@ -3,7 +3,10 @@ import { take, put } from 'redux-saga/effects';
 
 export function* multipleActionDispatcher() {
   while (true) {
-    const multipleWalletActions: MultipleWalletActions = yield take('WALLET.MULTIPLE_ACTIONS');
+    const multipleWalletActions: MultipleWalletActions = yield take([
+      'WALLET.MULTIPLE_ACTIONS',
+      'WALLET.MULTIPLE_RELAYABLE_ACTIONS',
+    ]);
     yield multipleWalletActions.actions.map(action => put(action));
   }
 }


### PR DESCRIPTION
This PR improves the way in which I can relay multiple whitelisted actions to my opponent's wallet. 

The order such actions are `put` is important (for example when I wish to _first_ start a new process in my opponent's wallet, and _then_ for that process to consume a `CommitmentReceived`).

Previously, the actions were queued and then relayed by the app in order: but they might get `put` out of order depending on asynchronous reads/writes to/from firebase.*

In this PR, the actions are batched in an array into a `MultipleRelayableActions` action. This is the only action that is relayed and routed through firebase. A saga running in the recipient wallet then dispatches these batched actions non-concurrently (i.e. in a set order). 

Also included: a helper function for testing this behaviour (accepts an array of actions).

*it may in fact be the case that (or at least possible to ensure that) the actions are relayed, written, read and put in order using the current approach (without using the batch approach of this PR) https://firebase.google.com/docs/database/admin/retrieve-data . Nevertheless it could be argued that
 1. this is not easy to confirm, and 
 2. it is not as easy to test