### PR TITLE
Nest Dispute under Application

### DIFF
--- a/packages/wallet/notes/index.md
+++ b/packages/wallet/notes/index.md
@@ -35,7 +35,7 @@ graph TD
     A{Application}--> D
     F{Funding}--> idF(IndirectFunding)
 
-    D{Dispute}--> TS
+    D(Dispute)--> TS
 
 
     C{Concluding}-->CU(ConsensusUpdate)
@@ -60,7 +60,7 @@ graph TD
 
     classDef OrphanProtocol stroke:#333,stroke-width:4px,fill:#0000;
 
-    class A,F,D,C,Df TopLevelProtocol
+    class A,F,C,Df TopLevelProtocol
     class AC,ECF,LTU,NLC,PC,VF OrphanProtocol
 
 

--- a/packages/wallet/notes/index.md
+++ b/packages/wallet/notes/index.md
@@ -32,7 +32,7 @@
 graph TD
   linkStyle default interpolate basis
 
-    A{Application}
+    A{Application}--> D
     F{Funding}--> idF(IndirectFunding)
 
     D{Dispute}--> TS

--- a/packages/wallet/src/redux/actions.ts
+++ b/packages/wallet/src/redux/actions.ts
@@ -10,7 +10,6 @@ import {
   TransactionAction as TA,
   isTransactionAction as isTA,
 } from './protocols/transaction-submission/actions';
-import { DisputeAction, isDisputeAction } from './protocols/dispute';
 
 import { ConcludingAction, isConcludingAction } from './protocols/concluding';
 import { ApplicationAction } from './protocols/application/actions';
@@ -206,12 +205,11 @@ export type CommonAction = MessageReceived | CommitmentReceived;
 
 export type ProtocolAction =
   // only list top level protocol actions
-  FundingAction | DisputeAction | DefundingAction | ApplicationAction | ConcludingAction;
+  FundingAction | DefundingAction | ApplicationAction | ConcludingAction;
 
 export function isProtocolAction(action: WalletAction): action is ProtocolAction {
   return (
     isFundingAction(action) ||
-    isDisputeAction(action) ||
     application.isApplicationAction(action) ||
     isConcludingAction(action) ||
     isDefundingAction(action)

--- a/packages/wallet/src/redux/protocols/actions.ts
+++ b/packages/wallet/src/redux/protocols/actions.ts
@@ -1,5 +1,4 @@
 import { TwoPartyPlayerIndex } from '../types';
-import { Commitment } from '../../domain';
 import { ActionConstructor } from '../utils';
 import { ConcludeInstigated, WalletProtocol } from '../../communication';
 import { WalletAction } from '../actions';
@@ -24,21 +23,6 @@ export interface ConcludeRequested {
   type: 'WALLET.NEW_PROCESS.CONCLUDE_REQUESTED';
   channelId: string;
   protocol: WalletProtocol.Concluding;
-}
-
-export interface CreateChallengeRequested {
-  type: 'WALLET.NEW_PROCESS.CREATE_CHALLENGE_REQUESTED';
-  channelId: string;
-  commitment: Commitment;
-  protocol: WalletProtocol.Dispute;
-}
-
-export interface ChallengeCreated {
-  type: 'WALLET.NEW_PROCESS.CHALLENGE_CREATED';
-  commitment: Commitment;
-  expiresAt: number;
-  channelId: string;
-  protocol: WalletProtocol.Dispute;
 }
 
 export interface DefundRequested {
@@ -67,18 +51,6 @@ export const concludeRequested: ActionConstructor<ConcludeRequested> = p => ({
   protocol: WalletProtocol.Concluding,
 });
 
-export const createChallengeRequested: ActionConstructor<CreateChallengeRequested> = p => ({
-  ...p,
-  type: 'WALLET.NEW_PROCESS.CREATE_CHALLENGE_REQUESTED',
-  protocol: WalletProtocol.Dispute,
-});
-
-export const challengeCreated: ActionConstructor<ChallengeCreated> = p => ({
-  ...p,
-  type: 'WALLET.NEW_PROCESS.CHALLENGE_CREATED',
-  protocol: WalletProtocol.Dispute,
-});
-
 export const defundRequested: ActionConstructor<DefundRequested> = p => ({
   ...p,
   type: 'WALLET.NEW_PROCESS.DEFUND_REQUESTED',
@@ -94,8 +66,6 @@ export type NewProcessAction =
   | FundingRequested
   | ConcludeRequested
   | ConcludeInstigated
-  | CreateChallengeRequested
-  | ChallengeCreated
   | DefundRequested;
 
 export function isNewProcessAction(action: WalletAction): action is NewProcessAction {
@@ -104,8 +74,6 @@ export function isNewProcessAction(action: WalletAction): action is NewProcessAc
     action.type === 'WALLET.NEW_PROCESS.FUNDING_REQUESTED' ||
     action.type === 'WALLET.NEW_PROCESS.CONCLUDE_REQUESTED' ||
     action.type === 'WALLET.NEW_PROCESS.CONCLUDE_INSTIGATED' ||
-    action.type === 'WALLET.NEW_PROCESS.CREATE_CHALLENGE_REQUESTED' ||
-    action.type === 'WALLET.NEW_PROCESS.CHALLENGE_CREATED' ||
     action.type === 'WALLET.NEW_PROCESS.DEFUND_REQUESTED'
   );
 }

--- a/packages/wallet/src/redux/protocols/application/__tests__/reducer.test.ts
+++ b/packages/wallet/src/redux/protocols/application/__tests__/reducer.test.ts
@@ -101,6 +101,54 @@ describe('receiving a close request', () => {
   });
 });
 
+describe('a challenge was requested', () => {
+  const scenario = scenarios.challengeWasRequested;
+
+  describeScenarioStep(scenario.ongoing, () => {
+    const { state, sharedData, action } = scenario.ongoing;
+
+    const result = applicationReducer(state, sharedData, action);
+
+    itTransitionsTo(result, 'Application.WaitForDispute');
+  });
+});
+
+describe('a challenge was detected', () => {
+  const scenario = scenarios.challengeWasDetected;
+
+  describeScenarioStep(scenario.ongoing, () => {
+    const { state, sharedData, action } = scenario.ongoing;
+
+    const result = applicationReducer(state, sharedData, action);
+
+    itTransitionsTo(result, 'Application.WaitForDispute');
+  });
+});
+
+describe('a challenge was responded to', () => {
+  const scenario = scenarios.challengeRespondedTo;
+
+  describeScenarioStep(scenario.waitForDispute, () => {
+    const { state, sharedData, action } = scenario.waitForDispute;
+
+    const result = applicationReducer(state, sharedData, action);
+
+    itTransitionsTo(result, 'Application.Ongoing');
+  });
+});
+
+describe('a challenge expired', () => {
+  const scenario = scenarios.challengeExpired;
+
+  describeScenarioStep(scenario.waitForDispute, () => {
+    const { state, sharedData, action } = scenario.waitForDispute;
+
+    const result = applicationReducer(state, sharedData, action);
+
+    itTransitionsTo(result, 'Application.Success');
+  });
+});
+
 function itTransitionsTo(
   result: ProtocolStateWithSharedData<states.ApplicationState>,
   type: states.ApplicationStateType,

--- a/packages/wallet/src/redux/protocols/application/__tests__/scenarios.ts
+++ b/packages/wallet/src/redux/protocols/application/__tests__/scenarios.ts
@@ -11,6 +11,11 @@ import { ChannelState } from '../../../channel-store';
 import { setChannel, EMPTY_SHARED_DATA } from '../../../state';
 import { channelFromCommitments } from '../../../channel-store/channel-state/__tests__';
 import { APPLICATION_PROCESS_ID } from '../reducer';
+import {
+  challengerPreSuccessOpenState,
+  terminatingAction,
+  challengerPreSuccessClosedState,
+} from '../../dispute';
 
 const {
   signedCommitment19,
@@ -43,6 +48,18 @@ const defaults = { processId, channelId, address, privateKey };
 // ------
 const addressKnown = states.waitForFirstCommitment({ channelId, address, privateKey });
 const ongoing = states.ongoing({ channelId, address, privateKey });
+const waitForDispute1 = states.waitForDispute({
+  channelId,
+  address,
+  privateKey,
+  disputeState: challengerPreSuccessOpenState,
+});
+const waitForDispute2 = states.waitForDispute({
+  channelId,
+  address,
+  privateKey,
+  disputeState: challengerPreSuccessClosedState,
+});
 
 // -------
 // Actions
@@ -74,6 +91,17 @@ const receiveOurInvalidCommitment = actions.ownCommitmentReceived({
 });
 
 const concluded = actions.concluded({ processId: APPLICATION_PROCESS_ID });
+
+const challengeRequested = actions.challengeRequested({ processId, channelId, commitment });
+
+const challengeDetected = actions.challengeDetected({
+  processId,
+  channelId,
+  commitment,
+  expiresAt: 999,
+});
+
+const disputeTerminated = terminatingAction;
 
 // -------
 // SharedData
@@ -141,5 +169,38 @@ export const receivingOurInvalidCommitment = {
     state: ongoing,
     sharedData: ourTurnSharedData,
     action: receiveOurInvalidCommitment,
+  },
+};
+
+export const challengeWasRequested = {
+  ...defaults,
+  ongoing: {
+    state: ongoing,
+    sharedData: ourTurnSharedData,
+    action: challengeRequested,
+  },
+};
+export const challengeWasDetected = {
+  ...defaults,
+  ongoing: {
+    state: ongoing,
+    sharedData: ourTurnSharedData,
+    action: challengeDetected,
+  },
+};
+export const challengeRespondedTo = {
+  ...defaults,
+  waitForDispute: {
+    state: waitForDispute1,
+    sharedData: ourTurnSharedData,
+    action: disputeTerminated,
+  },
+};
+export const challengeExpired = {
+  ...defaults,
+  waitForDispute: {
+    state: waitForDispute2,
+    sharedData: ourTurnSharedData,
+    action: disputeTerminated,
   },
 };

--- a/packages/wallet/src/redux/protocols/application/__tests__/scenarios.ts
+++ b/packages/wallet/src/redux/protocols/application/__tests__/scenarios.ts
@@ -15,7 +15,7 @@ import {
   challengerPreSuccessOpenState,
   terminatingAction,
   challengerPreSuccessClosedState,
-} from '../../dispute';
+} from '../../dispute/challenger';
 
 const {
   signedCommitment19,
@@ -101,7 +101,7 @@ const challengeDetected = actions.challengeDetected({
   expiresAt: 999,
 });
 
-const disputeTerminated = terminatingAction;
+const disputeTerminated = { ...terminatingAction };
 
 // -------
 // SharedData

--- a/packages/wallet/src/redux/protocols/application/actions.ts
+++ b/packages/wallet/src/redux/protocols/application/actions.ts
@@ -1,6 +1,7 @@
 import { Commitment } from '../../../domain';
 import { WalletAction } from '../../actions';
 import { ActionConstructor } from '../../utils';
+import { DisputeAction, isDisputeAction } from '../dispute';
 
 // -------
 // Actions
@@ -87,10 +88,12 @@ export type ApplicationAction =
   | OwnCommitmentReceived
   | ChallengeDetected
   | ChallengeRequested
-  | Concluded;
+  | Concluded
+  | DisputeAction;
 
 export function isApplicationAction(action: WalletAction): action is ApplicationAction {
   return (
+    isDisputeAction(action) ||
     action.type === 'WALLET.APPLICATION.OPPONENT_COMMITMENT_RECEIVED' ||
     action.type === 'WALLET.APPLICATION.OWN_COMMITMENT_RECEIVED' ||
     action.type === 'WALLET.APPLICATION.CHALLENGE_DETECTED' ||

--- a/packages/wallet/src/redux/protocols/application/actions.ts
+++ b/packages/wallet/src/redux/protocols/application/actions.ts
@@ -22,11 +22,13 @@ export interface ChallengeRequested {
   type: 'WALLET.APPLICATION.CHALLENGE_REQUESTED';
   commitment: Commitment;
   processId: string;
+  channelId: string;
 }
 
-export interface ChallengeCreated {
-  type: 'WALLET.APPLICATION.CHALLENGE_CREATED';
+export interface ChallengeDetected {
+  type: 'WALLET.APPLICATION.CHALLENGE_DETECTED';
   processId: string;
+  channelId: string;
   expiresAt: number;
   commitment: Commitment;
 }
@@ -63,9 +65,9 @@ export const challengeRequested: ActionConstructor<ChallengeRequested> = p => ({
   type: 'WALLET.APPLICATION.CHALLENGE_REQUESTED',
 });
 
-export const challengeCreated: ActionConstructor<ChallengeCreated> = p => ({
+export const challengeDetected: ActionConstructor<ChallengeDetected> = p => ({
   ...p,
-  type: 'WALLET.APPLICATION.CHALLENGE_CREATED',
+  type: 'WALLET.APPLICATION.CHALLENGE_Detected',
 });
 
 export const concluded: ActionConstructor<Concluded> = p => {
@@ -83,7 +85,7 @@ export const concluded: ActionConstructor<Concluded> = p => {
 export type ApplicationAction =
   | OpponentCommitmentReceived
   | OwnCommitmentReceived
-  | ChallengeCreated
+  | ChallengeDetected
   | ChallengeRequested
   | Concluded;
 
@@ -91,7 +93,7 @@ export function isApplicationAction(action: WalletAction): action is Application
   return (
     action.type === 'WALLET.APPLICATION.OPPONENT_COMMITMENT_RECEIVED' ||
     action.type === 'WALLET.APPLICATION.OWN_COMMITMENT_RECEIVED' ||
-    action.type === 'WALLET.APPLICATION.CHALLENGE_CREATED' ||
+    action.type === 'WALLET.APPLICATION.CHALLENGE_DETECTED' ||
     action.type === 'WALLET.APPLICATION.CHALLENGE_REQUESTED' ||
     action.type === 'WALLET.APPLICATION.CONCLUDED'
   );

--- a/packages/wallet/src/redux/protocols/application/actions.ts
+++ b/packages/wallet/src/redux/protocols/application/actions.ts
@@ -67,7 +67,7 @@ export const challengeRequested: ActionConstructor<ChallengeRequested> = p => ({
 
 export const challengeDetected: ActionConstructor<ChallengeDetected> = p => ({
   ...p,
-  type: 'WALLET.APPLICATION.CHALLENGE_Detected',
+  type: 'WALLET.APPLICATION.CHALLENGE_DETECTED',
 });
 
 export const concluded: ActionConstructor<Concluded> = p => {

--- a/packages/wallet/src/redux/protocols/application/actions.ts
+++ b/packages/wallet/src/redux/protocols/application/actions.ts
@@ -17,6 +17,16 @@ export interface OpponentCommitmentReceived {
   commitment: Commitment;
   signature: string;
 }
+
+export interface ChallengeRequested {
+  type: 'WALLET.APPLICATION.CHALLENGE_REQUESTED';
+  processId: string;
+}
+
+export interface ChallengeCreated {
+  type: 'WALLET.APPLICATION.CHALLENGE_CREATED';
+  processId: string;
+}
 export interface Concluded {
   type: 'WALLET.APPLICATION.CONCLUDED';
   processId: string;
@@ -45,6 +55,16 @@ export const opponentCommitmentReceived: ActionConstructor<OpponentCommitmentRec
   };
 };
 
+export const createChallengeRequested: ActionConstructor<ChallengeRequested> = p => ({
+  ...p,
+  type: 'WALLET.APPLICATION.CHALLENGE_REQUESTED',
+});
+
+export const challengeCreated: ActionConstructor<ChallengeCreated> = p => ({
+  ...p,
+  type: 'WALLET.APPLICATION.CHALLENGE_CREATED',
+});
+
 export const concluded: ActionConstructor<Concluded> = p => {
   const { processId } = p;
   return {
@@ -57,12 +77,19 @@ export const concluded: ActionConstructor<Concluded> = p => {
 // Unions and Guards
 // -------
 
-export type ApplicationAction = OpponentCommitmentReceived | OwnCommitmentReceived | Concluded;
+export type ApplicationAction =
+  | OpponentCommitmentReceived
+  | OwnCommitmentReceived
+  | ChallengeCreated
+  | ChallengeRequested
+  | Concluded;
 
 export function isApplicationAction(action: WalletAction): action is ApplicationAction {
   return (
     action.type === 'WALLET.APPLICATION.OPPONENT_COMMITMENT_RECEIVED' ||
     action.type === 'WALLET.APPLICATION.OWN_COMMITMENT_RECEIVED' ||
+    action.type === 'WALLET.APPLICATION.CHALLENGE_CREATED' ||
+    action.type === 'WALLET.APPLICATION.CHALLENGE_REQUESTED' ||
     action.type === 'WALLET.APPLICATION.CONCLUDED'
   );
 }

--- a/packages/wallet/src/redux/protocols/application/actions.ts
+++ b/packages/wallet/src/redux/protocols/application/actions.ts
@@ -20,12 +20,15 @@ export interface OpponentCommitmentReceived {
 
 export interface ChallengeRequested {
   type: 'WALLET.APPLICATION.CHALLENGE_REQUESTED';
+  commitment: Commitment;
   processId: string;
 }
 
 export interface ChallengeCreated {
   type: 'WALLET.APPLICATION.CHALLENGE_CREATED';
   processId: string;
+  expiresAt: number;
+  commitment: Commitment;
 }
 export interface Concluded {
   type: 'WALLET.APPLICATION.CONCLUDED';
@@ -55,7 +58,7 @@ export const opponentCommitmentReceived: ActionConstructor<OpponentCommitmentRec
   };
 };
 
-export const createChallengeRequested: ActionConstructor<ChallengeRequested> = p => ({
+export const challengeRequested: ActionConstructor<ChallengeRequested> = p => ({
   ...p,
   type: 'WALLET.APPLICATION.CHALLENGE_REQUESTED',
 });

--- a/packages/wallet/src/redux/protocols/application/container.tsx
+++ b/packages/wallet/src/redux/protocols/application/container.tsx
@@ -1,0 +1,39 @@
+import React from 'react';
+import { PureComponent } from 'react';
+import { connect } from 'react-redux';
+import { Dispute } from '../dispute/container';
+import * as states from './states';
+
+import { unreachable } from '../../../utils/reducer-utils';
+import { isNonTerminalDisputeState } from '../dispute/state';
+
+interface Props {
+  state: states.ApplicationState;
+}
+
+class ApplicationContainer extends PureComponent<Props> {
+  render() {
+    const { state } = this.props;
+
+    switch (state.type) {
+      case 'Application.WaitForDispute':
+        if (isNonTerminalDisputeState(state.disputeState)) {
+          return <Dispute state={state.disputeState} />;
+        }
+        return <div />;
+      case 'Application.Ongoing':
+      case 'Application.Success':
+      case 'Application.WaitForFirstCommitment':
+        return <div />;
+      default:
+        return unreachable(state);
+    }
+  }
+}
+
+const mapDispatchToProps = {};
+
+export const Application = connect(
+  () => ({}),
+  mapDispatchToProps,
+)(ApplicationContainer);

--- a/packages/wallet/src/redux/protocols/application/readme.md
+++ b/packages/wallet/src/redux/protocols/application/readme.md
@@ -40,3 +40,28 @@ Notes:
 - `COMMITMENT_RECEIVED` is shorthand for either `OWN_COMMITMENT_RECEIVED` or `OPPONENT_COMMITMENT_RECEIVED`
 - `CONCLUDED` should get triggered when a conclude is requested _and then sent from the wallet_. This means that the application protocol no longer needs to listen for commitments from the app. In particular, if the conclude is requested and then cancelled, `CONCLUDED` will not be triggered.
 - The application protocol is responsible for sending out signature and validation messages.
+
+## Scenarios
+
+1. **Initializing Application**
+   - `.`--> `WaitForFirstCommitment`
+2. **Starting Application**
+   - `WaitForFirstCommitment` --> `Ongoing`
+3. **Receiving a close request**
+   - `Ongoing` --> `Success`
+4. **Receiving our commitment**
+   - `Ongoing` --> `Ongoing`
+5. **Receiving their commitment**
+   - `Ongoing` --> `Ongoing`
+6. **Receiving their invalid commitment**
+   - `Ongoing` --> `Ongoing`
+7. **Receiving our invalid commitment**
+   - `Ongoing` --> `Ongoing`
+8. **Challenge was requested**
+   - `Ongoing` --> `WaitForDispute`
+9. **Challenge was detected**
+   - `Ongoing` --> `WaitForDispute`
+10. **Challenge responded to**
+    - `WaitForDispute` --> `Ongoing`
+11. **Challenge expired**
+    - `WaitForDispute` --> `Success`

--- a/packages/wallet/src/redux/protocols/application/readme.md
+++ b/packages/wallet/src/redux/protocols/application/readme.md
@@ -17,10 +17,13 @@ The protocol is implemented with the following state machine.
 graph TD
 linkStyle default interpolate basis
   S((start)) --> AK(AddressKnown)
-  AK-->|WALLET.APPLICATION.COMMITMENT_RECEIVED|O(Ongoing)
-  O-->|WALLET.APPLICATION.COMMITMENT_RECEIVED|O(Ongoing)
-  AK-->|WALLET.APPLICATION.CONCLUDED|Su((success))
-  O-->|WALLET.APPLICATION.CONCLUDED|Su((success))
+  AK-->|COMMITMENT_RECEIVED|O(Ongoing)
+  O-->|COMMITMENT_RECEIVED|O(Ongoing)
+  AK-->|CONCLUDED|Su((success))
+  O-->|CONCLUDED|Su((success))
+  O-->|CHALLENGE_CREATED/DETECTED|WFD(WaitForDispute)
+  WFD-->|Response|O
+  WFD-->|Expiry|Su
   classDef logic fill:#efdd20;
   classDef Success fill:#58ef21;
   classDef Failure fill:#f45941;
@@ -28,11 +31,12 @@ linkStyle default interpolate basis
   class S logic;
   class Su Success;
   class F Failure;
-  class C WaitForChildProtocol;
+  class WFD WaitForChildProtocol;
 ```
 
 Notes:
 
+- All action typestrings have had the `WALLET.APPLICATION` prefix suppressed in the above diagram
 - `COMMITMENT_RECEIVED` is shorthand for either `OWN_COMMITMENT_RECEIVED` or `OPPONENT_COMMITMENT_RECEIVED`
 - `CONCLUDED` should get triggered when a conclude is requested _and then sent from the wallet_. This means that the application protocol no longer needs to listen for commitments from the app. In particular, if the conclude is requested and then cancelled, `CONCLUDED` will not be triggered.
 - The application protocol is responsible for sending out signature and validation messages.

--- a/packages/wallet/src/redux/protocols/application/readme.md
+++ b/packages/wallet/src/redux/protocols/application/readme.md
@@ -21,7 +21,7 @@ linkStyle default interpolate basis
   O-->|COMMITMENT_RECEIVED|O(Ongoing)
   AK-->|CONCLUDED|Su((success))
   O-->|CONCLUDED|Su((success))
-  O-->|CHALLENGE_CREATED/DETECTED|WFD(WaitForDispute)
+  O-->|CHALLENGE_REQUESTED/DETECTED|WFD(WaitForDispute)
   WFD-->|Response|O
   WFD-->|Expiry|Su
   classDef logic fill:#efdd20;

--- a/packages/wallet/src/redux/protocols/application/reducer.ts
+++ b/packages/wallet/src/redux/protocols/application/reducer.ts
@@ -162,6 +162,25 @@ function handleDisputeAction(
     return { protocolState, sharedData };
   }
   const newDisputeState = disputeReducer(protocolState.disputeState, sharedData, action);
+  if (
+    newDisputeState.protocolState.type === 'Challenging.SuccessOpen' ||
+    newDisputeState.protocolState.type === 'Challenging.Failure' ||
+    newDisputeState.protocolState.type === 'Responding.Success'
+  ) {
+    return {
+      protocolState: states.ongoing({ ...protocolState }),
+      sharedData: newDisputeState.sharedData,
+    };
+  }
+  if (
+    newDisputeState.protocolState.type === 'Challenging.SuccessClosed' ||
+    newDisputeState.protocolState.type === 'Responding.Failure'
+  ) {
+    return {
+      protocolState: states.success({ ...protocolState }),
+      sharedData: newDisputeState.sharedData,
+    };
+  }
   const newApplicationState = { ...protocolState, disputeState: newDisputeState.protocolState };
   return { protocolState: newApplicationState, sharedData: newDisputeState.sharedData };
 }

--- a/packages/wallet/src/redux/protocols/application/reducer.ts
+++ b/packages/wallet/src/redux/protocols/application/reducer.ts
@@ -122,7 +122,7 @@ function challengeRequestedReducer(
   });
   return {
     protocolState: newProtocolState,
-    sharedData: disputeState.sharedData,
+    sharedData: { ...disputeState.sharedData, currentProcessId: APPLICATION_PROCESS_ID },
   };
 }
 
@@ -145,7 +145,7 @@ function challengeDetectedReducer(
   });
   return {
     protocolState: newProtocolState,
-    sharedData: disputeState.sharedData,
+    sharedData: { ...disputeState.sharedData, currentProcessId: APPLICATION_PROCESS_ID },
   };
 }
 

--- a/packages/wallet/src/redux/protocols/application/reducer.ts
+++ b/packages/wallet/src/redux/protocols/application/reducer.ts
@@ -54,8 +54,8 @@ export function applicationReducer(
       return ownCommitmentReceivedReducer(protocolState, sharedData, action);
     case 'WALLET.APPLICATION.CONCLUDED':
       return { sharedData, protocolState: states.success({}) };
-    case 'WALLET.APPLICATION.CHALLENGE_CREATED':
-      return challengeCreatedReducer(protocolState, sharedData, action);
+    case 'WALLET.APPLICATION.CHALLENGE_DETECTED':
+      return challengeDetectedReducer(protocolState, sharedData, action);
     case 'WALLET.APPLICATION.CHALLENGE_REQUESTED':
       return challengeRequestedReducer(protocolState, sharedData, action);
     default:
@@ -109,10 +109,10 @@ function opponentCommitmentReceivedReducer(
   }
 }
 
-function challengeCreatedReducer(
+function challengeRequestedReducer(
   protocolState: states.NonTerminalApplicationState,
   sharedData: SharedData,
-  action: actions.ChallengeCreated,
+  action: actions.ChallengeRequested,
 ): ProtocolStateWithSharedData<states.ApplicationState> {
   const { channelId, processId } = action;
   const disputeState = dispute.initializeChallenger(channelId, processId, sharedData);
@@ -126,12 +126,12 @@ function challengeCreatedReducer(
   };
 }
 
-function challengeRequestedReducer(
+function challengeDetectedReducer(
   protocolState: states.NonTerminalApplicationState,
   sharedData: SharedData,
-  action: actions.ChallengeRequested,
+  action: actions.ChallengeDetected,
 ): ProtocolStateWithSharedData<states.ApplicationState> {
-  const { channelId, processId, expiryTime, commitment } = action;
+  const { channelId, processId, expiresAt: expiryTime, commitment } = action;
   const disputeState = dispute.initializeResponder(
     processId,
     channelId,

--- a/packages/wallet/src/redux/protocols/application/states.ts
+++ b/packages/wallet/src/redux/protocols/application/states.ts
@@ -1,5 +1,6 @@
 import { StateConstructor } from '../../utils';
 import { DisputeState } from '../dispute/state';
+import { ProtocolState } from '..';
 
 // -------
 // States
@@ -59,4 +60,12 @@ export type ApplicationStateType = ApplicationState['type'];
 
 export function isTerminal(state: ApplicationState): state is Success {
   return state.type === 'Application.Success';
+}
+
+export function isApplicationState(state: ProtocolState): state is ApplicationState {
+  return (
+    state.type === 'Application.WaitForDispute' ||
+    state.type === 'Application.Ongoing' ||
+    state.type === 'Application.WaitForFirstCommitment'
+  );
 }

--- a/packages/wallet/src/redux/protocols/application/states.ts
+++ b/packages/wallet/src/redux/protocols/application/states.ts
@@ -1,4 +1,5 @@
 import { StateConstructor } from '../../utils';
+import { DisputeState } from '../dispute/state';
 
 // -------
 // States
@@ -22,6 +23,7 @@ export interface WaitForDispute {
   channelId: string;
   address: string;
   privateKey: string;
+  disputeState: DisputeState;
 }
 
 export interface Success {
@@ -43,7 +45,7 @@ export const success: StateConstructor<Success> = p => {
   return { ...p, type: 'Application.Success' };
 };
 
-export const WaitForDispute: StateConstructor<WaitForDispute> = p => {
+export const waitForDispute: StateConstructor<WaitForDispute> = p => {
   return { ...p, type: 'Application.WaitForDispute' };
 };
 

--- a/packages/wallet/src/redux/protocols/application/states.ts
+++ b/packages/wallet/src/redux/protocols/application/states.ts
@@ -17,6 +17,13 @@ export interface Ongoing {
   privateKey: string;
 }
 
+export interface WaitForDispute {
+  type: 'Application.WaitForDispute';
+  channelId: string;
+  address: string;
+  privateKey: string;
+}
+
 export interface Success {
   type: 'Application.Success';
 }
@@ -36,12 +43,16 @@ export const success: StateConstructor<Success> = p => {
   return { ...p, type: 'Application.Success' };
 };
 
+export const WaitForDispute: StateConstructor<WaitForDispute> = p => {
+  return { ...p, type: 'Application.WaitForDispute' };
+};
+
 // -------
 // Unions and Guards
 // -------
 
-export type ApplicationState = WaitForFirstCommitment | Ongoing | Success;
-export type NonTerminalApplicationState = WaitForFirstCommitment | Ongoing;
+export type ApplicationState = WaitForFirstCommitment | Ongoing | WaitForDispute | Success;
+export type NonTerminalApplicationState = WaitForFirstCommitment | WaitForDispute | Ongoing;
 export type ApplicationStateType = ApplicationState['type'];
 
 export function isTerminal(state: ApplicationState): state is Success {

--- a/packages/wallet/src/redux/protocols/container.tsx
+++ b/packages/wallet/src/redux/protocols/container.tsx
@@ -1,7 +1,7 @@
 import { PureComponent } from 'react';
 import { ProtocolState } from '.';
 import * as fundingStates from './funding/states';
-import * as DisputeStates from './dispute/state';
+import * as ApplicationStates from './application/states';
 import * as concludingStates from './concluding/states';
 import React from 'react';
 import { Funding } from './funding/container';
@@ -9,9 +9,9 @@ import { Concluding } from './concluding/container';
 import { connect } from 'react-redux';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faSpinner } from '@fortawesome/free-solid-svg-icons';
-import { Challenging } from './dispute/container';
 import { isDefundingState } from './defunding/states';
 import { Defunding } from './defunding';
+import { Application } from './application/container';
 
 interface Props {
   protocolState: ProtocolState;
@@ -25,8 +25,8 @@ class ProtocolContainer extends PureComponent<Props> {
     const { protocolState } = this.props;
     if (fundingStates.isNonTerminalFundingState(protocolState)) {
       return <Funding state={protocolState} />;
-    } else if (DisputeStates.isNonTerminalDisputeState(protocolState)) {
-      return <Challenging state={protocolState} />;
+    } else if (ApplicationStates.isApplicationState(protocolState)) {
+      return <Application state={protocolState} />;
     } else if (concludingStates.isConcludingState(protocolState)) {
       return <Concluding state={protocolState} />;
     } else if (isDefundingState(protocolState)) {

--- a/packages/wallet/src/redux/protocols/dispute/challenger/__tests__/scenarios.ts
+++ b/packages/wallet/src/redux/protocols/dispute/challenger/__tests__/scenarios.ts
@@ -59,8 +59,8 @@ const waitForTransactionFailure = states.waitForTransaction({
   transactionSubmission: tsPreFailure,
 });
 const waitForResponseOrTimeout = states.waitForResponseOrTimeout({ ...defaults, expiryTime: 0 });
-const acknowledgeTimeout = states.acknowledgeTimeout(defaults);
-const acknowledgeResponse = states.acknowledgeResponse(defaults);
+export const acknowledgeTimeout = states.acknowledgeTimeout(defaults);
+export const acknowledgeResponse = states.acknowledgeResponse(defaults);
 const acknowledgeFailure = (reason: Reason) => states.acknowledgeFailure({ ...defaults, reason });
 
 // -------
@@ -78,7 +78,7 @@ const responseReceived = respondWithMoveEvent({
   responseSignature: signedCommitment21.signature,
 });
 const challengeExpirySet = challengeExpirySetEvent({ processId, channelId, expiryTime: 1234 });
-const acknowledged = actions.acknowledged({ processId });
+export const acknowledged = actions.acknowledged({ processId });
 
 // -------
 // Scenarios

--- a/packages/wallet/src/redux/protocols/dispute/challenger/index.ts
+++ b/packages/wallet/src/redux/protocols/dispute/challenger/index.ts
@@ -1,2 +1,8 @@
 export { Challenger } from './container';
 export { initialize, challengerReducer as reducer } from './reducer';
+
+export {
+  acknowledgeResponse as challengerPreSuccessOpenState,
+  acknowledgeTimeout as challengerPreSuccessClosedState,
+  acknowledged as terminatingAction,
+} from './__tests__/scenarios';

--- a/packages/wallet/src/redux/protocols/dispute/container.tsx
+++ b/packages/wallet/src/redux/protocols/dispute/container.tsx
@@ -20,4 +20,4 @@ class DisputeContainer extends PureComponent<Props> {
   }
 }
 
-export const Challenging = connect(() => ({}))(DisputeContainer);
+export const Dispute = connect(() => ({}))(DisputeContainer);

--- a/packages/wallet/src/redux/protocols/dispute/index.ts
+++ b/packages/wallet/src/redux/protocols/dispute/index.ts
@@ -10,3 +10,9 @@ export type DisputeAction = ChallengerAction | ResponderAction;
 export function isDisputeAction(action: WalletAction): action is DisputeAction {
   return isChallengerAction(action) || isResponderAction(action);
 }
+
+export {
+  acknowledgeResponse as challengerPreSuccessOpenState,
+  acknowledgeTimeout as challengerPreSuccessClosedState,
+  acknowledged as terminatingAction,
+} from './challenger/__tests__/scenarios';

--- a/packages/wallet/src/redux/protocols/dispute/index.ts
+++ b/packages/wallet/src/redux/protocols/dispute/index.ts
@@ -10,9 +10,3 @@ export type DisputeAction = ChallengerAction | ResponderAction;
 export function isDisputeAction(action: WalletAction): action is DisputeAction {
   return isChallengerAction(action) || isResponderAction(action);
 }
-
-export {
-  acknowledgeResponse as challengerPreSuccessOpenState,
-  acknowledgeTimeout as challengerPreSuccessClosedState,
-  acknowledged as terminatingAction,
-} from './challenger/__tests__/scenarios';

--- a/packages/wallet/src/redux/protocols/dispute/index.ts
+++ b/packages/wallet/src/redux/protocols/dispute/index.ts
@@ -2,6 +2,9 @@ import { ChallengerAction, isChallengerAction } from './challenger/actions';
 import { ResponderAction, isResponderAction } from './responder/actions';
 import { WalletAction } from '../../../redux/actions';
 
+export { initialize as initializeResponder } from './responder/reducer';
+export { initialize as initializeChallenger } from './challenger/reducer';
+
 export type DisputeAction = ChallengerAction | ResponderAction;
 
 export function isDisputeAction(action: WalletAction): action is DisputeAction {

--- a/packages/wallet/src/redux/protocols/dispute/reducer.ts
+++ b/packages/wallet/src/redux/protocols/dispute/reducer.ts
@@ -6,7 +6,6 @@ import { initialize as responderInitialize, responderReducer } from './responder
 import { initialize as challengerInitialize, challengerReducer } from './challenger/reducer';
 import { isNonTerminalResponderState } from './responder/states';
 import { isResponderAction } from './responder/actions';
-import { ChallengerState } from './challenger/states';
 import { ProtocolAction } from '../../actions';
 import { isChallengerAction } from './challenger/actions';
 
@@ -34,7 +33,7 @@ export const initializeChallengerState = (
 };
 
 export const disputeReducer = (
-  protocolState: ChallengerState,
+  protocolState: DisputeState,
   sharedData: SharedData,
   action: ProtocolAction,
 ): ProtocolStateWithSharedData<DisputeState> => {

--- a/packages/wallet/src/redux/protocols/dispute/reducer.ts
+++ b/packages/wallet/src/redux/protocols/dispute/reducer.ts
@@ -33,7 +33,7 @@ export const initializeChallengerState = (
   return { protocolState, sharedData: updatedSharedData };
 };
 
-export const challengingReducer = (
+export const disputeReducer = (
   protocolState: ChallengerState,
   sharedData: SharedData,
   action: ProtocolAction,

--- a/packages/wallet/src/redux/reducer.ts
+++ b/packages/wallet/src/redux/reducer.ts
@@ -7,11 +7,7 @@ import { ProtocolState } from './protocols';
 import { isNewProcessAction, NewProcessAction } from './protocols/actions';
 import * as applicationProtocol from './protocols/application';
 import * as defundingProtocol from './protocols/defunding';
-import {
-  challengingReducer,
-  initializeChallengerState,
-  initializeResponderState,
-} from './protocols/dispute/reducer';
+import { disputeReducer } from './protocols/dispute/reducer';
 import * as concludingProtocol from './protocols/concluding';
 import * as fundProtocol from './protocols/funding';
 import * as states from './state';
@@ -109,7 +105,7 @@ function routeToProtocolReducer(
         const {
           protocolState: challengingProtocolState,
           sharedData: challengingSharedData,
-        } = challengingReducer(processState.protocolState, states.sharedData(state), action);
+        } = disputeReducer(processState.protocolState, states.sharedData(state), action);
         return updatedState(state, challengingSharedData, processState, challengingProtocolState);
 
       case WalletProtocol.Concluding:
@@ -187,23 +183,6 @@ function initializeNewProtocol(
       );
       return { protocolState, sharedData };
     }
-    case 'WALLET.NEW_PROCESS.CREATE_CHALLENGE_REQUESTED': {
-      const { channelId } = action;
-      const { protocolState, sharedData } = initializeChallengerState(
-        channelId,
-        processId,
-        incomingSharedData,
-      );
-      return { protocolState, sharedData };
-    }
-    case 'WALLET.NEW_PROCESS.CHALLENGE_CREATED':
-      return initializeResponderState(
-        processId,
-        action.channelId,
-        action.expiresAt,
-        incomingSharedData,
-        action.commitment,
-      );
     case 'WALLET.NEW_PROCESS.INITIALIZE_CHANNEL':
       return applicationProtocol.initialize(
         incomingSharedData,

--- a/packages/wallet/src/redux/sagas/challenge-response-initiator.ts
+++ b/packages/wallet/src/redux/sagas/challenge-response-initiator.ts
@@ -1,7 +1,7 @@
 import { ChallengeCreatedEvent } from '../actions';
 import { take, select, put } from 'redux-saga/effects';
 import * as selectors from '../selectors';
-import { challengeCreated } from '../protocols/application/actions';
+import { challengeDetected } from '../protocols/application/actions';
 import { APPLICATION_PROCESS_ID } from '../protocols/application/reducer';
 
 /**
@@ -10,7 +10,7 @@ import { APPLICATION_PROCESS_ID } from '../protocols/application/reducer';
 export function* challengeResponseInitiator() {
   while (true) {
     const action: ChallengeCreatedEvent = yield take('WALLET.ADJUDICATOR.CHALLENGE_CREATED_EVENT');
-    const { commitment, channelId, finalizedAt } = action;
+    const { commitment, channelId, finalizedAt: expiresAt } = action;
 
     const channelState = yield select(selectors.getOpenedChannelState, channelId);
 
@@ -19,7 +19,12 @@ export function* challengeResponseInitiator() {
 
     if (ourCommitment) {
       yield put(
-        challengeCreated({ commitment, expiresAt: finalizedAt, processId: APPLICATION_PROCESS_ID }),
+        challengeDetected({
+          commitment,
+          channelId,
+          processId: APPLICATION_PROCESS_ID,
+          expiresAt,
+        }),
       );
     }
   }

--- a/packages/wallet/src/redux/sagas/challenge-response-initiator.ts
+++ b/packages/wallet/src/redux/sagas/challenge-response-initiator.ts
@@ -1,10 +1,11 @@
 import { ChallengeCreatedEvent } from '../actions';
 import { take, select, put } from 'redux-saga/effects';
 import * as selectors from '../selectors';
-import { challengeCreated } from '../protocols/actions';
+import { challengeCreated } from '../protocols/application/actions';
+import { APPLICATION_PROCESS_ID } from '../protocols/application/reducer';
 
 /**
- * A simple saga that determines if a challenge created event requires the wallet to create a respond process
+ * A simple saga that determines if a challenge created event requires the wallet to initialize a respond protocol
  */
 export function* challengeResponseInitiator() {
   while (true) {
@@ -17,7 +18,9 @@ export function* challengeResponseInitiator() {
     const ourCommitment = commitment.turnNum % numParticipants !== channelState.ourIndex;
 
     if (ourCommitment) {
-      yield put(challengeCreated({ commitment, expiresAt: finalizedAt, channelId }));
+      yield put(
+        challengeCreated({ commitment, expiresAt: finalizedAt, processId: APPLICATION_PROCESS_ID }),
+      );
     }
   }
 }

--- a/packages/wallet/src/redux/sagas/challenge-watcher.ts
+++ b/packages/wallet/src/redux/sagas/challenge-watcher.ts
@@ -4,7 +4,6 @@ import { take, select, put } from 'redux-saga/effects';
 import { AdjudicatorState, getAdjudicatorChannelState } from '../adjudicator-state/state';
 import { getProvider } from '../../utils/contract-utils';
 import { eventChannel } from 'redux-saga';
-import { concluded } from '../protocols/application/actions';
 
 export function* challengeWatcher() {
   const provider = yield getProvider();
@@ -24,7 +23,6 @@ export function* challengeWatcher() {
           yield put(
             actions.challengeExpiredEvent({ processId, channelId, timestamp: block.timestamp }),
           );
-          yield put(concluded({ processId }));
         }
       }
     }

--- a/packages/wallet/src/redux/sagas/message-listener.ts
+++ b/packages/wallet/src/redux/sagas/message-listener.ts
@@ -37,6 +37,7 @@ export function* messageListener() {
           challengeRequested({
             processId: application.APPLICATION_PROCESS_ID, // TODO allow for multiple application Ids
             commitment: action.commitment,
+            channelId: action.channelId,
           }),
         );
         break;

--- a/packages/wallet/src/redux/sagas/message-listener.ts
+++ b/packages/wallet/src/redux/sagas/message-listener.ts
@@ -4,7 +4,7 @@ import * as incoming from 'magmo-wallet-client/lib/wallet-instructions';
 import * as actions from '../actions';
 import { eventChannel } from 'redux-saga';
 import * as application from '../protocols/application/reducer';
-import { isRelayableAction, WalletProtocol } from '../../communication';
+import { isRelayableAction } from '../../communication';
 import { responseProvided } from '../protocols/dispute/responder/actions';
 import { getChannelId, Commitment, SignedCommitment } from '../../domain';
 import * as selectors from '../selectors';
@@ -87,8 +87,7 @@ export function* messageListener() {
         break;
       case incoming.RESPOND_TO_CHALLENGE:
         // TODO: This probably should be in a function
-        const channelId = getChannelId(action.commitment);
-        const processId = `${WalletProtocol.Dispute}-${channelId}`;
+        const processId = application.APPLICATION_PROCESS_ID;
         yield put(responseProvided({ processId, commitment: action.commitment }));
         break;
       case incoming.RECEIVE_MESSAGE:

--- a/packages/wallet/src/redux/sagas/message-listener.ts
+++ b/packages/wallet/src/redux/sagas/message-listener.ts
@@ -7,10 +7,11 @@ import * as application from '../protocols/application/reducer';
 import { isRelayableAction, WalletProtocol } from '../../communication';
 import { responseProvided } from '../protocols/dispute/responder/actions';
 import { getChannelId, Commitment, SignedCommitment } from '../../domain';
-import { concluded } from '../protocols/application/actions';
 import * as selectors from '../selectors';
 import * as contractUtils from '../../utils/contract-utils';
 import { appAttributesFromBytes } from 'fmg-nitro-adjudicator';
+import { concluded, challengeRequested } from '../protocols/application/actions';
+
 export function* messageListener() {
   const postMessageEventChannel = eventChannel(emitter => {
     window.addEventListener('message', (event: MessageEvent) => {
@@ -33,8 +34,8 @@ export function* messageListener() {
         break;
       case incoming.CREATE_CHALLENGE_REQUEST:
         yield put(
-          actions.protocol.createChallengeRequested({
-            channelId: action.channelId,
+          challengeRequested({
+            processId: application.APPLICATION_PROCESS_ID, // TODO allow for multiple application Ids
             commitment: action.commitment,
           }),
         );


### PR DESCRIPTION
This PR moves us toward protocols embedding `dispute`, rather than spawning a new `dispute` process. The guiding principle here is that the parent protocol *should* block while the dispute is in progress, and cannot terminate until `dispute` terminates (since `dispute` can resolve in multiple ways, such as a challenge expiring or being responded to).

Current hierarchy on base branch (master):
![Screenshot 2019-06-28 at 13 25 07](https://user-images.githubusercontent.com/1833419/60341995-283aac00-99a8-11e9-8716-a3fdee2a7d49.png)
new hierarchy:
![Screenshot 2019-06-28 at 13 23 33](https://user-images.githubusercontent.com/1833419/60341923-fcb7c180-99a7-11e9-8e49-4491a2d67da0.png)

