### PR TITLE
Validate Transitions

### DIFF
--- a/packages/wallet/src/redux/sagas/__tests__/message-listener.test.ts
+++ b/packages/wallet/src/redux/sagas/__tests__/message-listener.test.ts
@@ -25,9 +25,9 @@ describe('message listener', () => {
 
   // todo: is OWN_POSITION_RECEIVED actually easier to think about than SIGNATURE_REQUEST?
   it('converts SIGNATURE_REQUEST into OWN_POSITION_RECEIVED', () => {
-    const output = saga.next({ data: incoming.signCommitmentRequest(scenarios.gameCommitment1) })
-      .value;
-    saga.next(); // the take
+    saga.next({ data: incoming.signCommitmentRequest(scenarios.gameCommitment1) });
+
+    const output = saga.next().value; // the take
 
     expect(output).toEqual(
       put(
@@ -37,13 +37,14 @@ describe('message listener', () => {
         }),
       ),
     );
+    saga.next();
   });
 
   it('converts VALIDATION_REQUEST into OPPONENT_POSITION_RECEIVED', () => {
-    const output = saga.next({
+    saga.next({
       data: incoming.validateCommitmentRequest(scenarios.gameCommitment1, 'signature'),
-    }).value;
-    saga.next(); // the take
+    });
+    const output = saga.next().value; // the take
 
     expect(output).toEqual(
       put(
@@ -54,5 +55,6 @@ describe('message listener', () => {
         }),
       ),
     );
+    saga.next();
   });
 });

--- a/packages/wallet/src/redux/sagas/message-listener.ts
+++ b/packages/wallet/src/redux/sagas/message-listener.ts
@@ -1,4 +1,4 @@
-import { take, put } from 'redux-saga/effects';
+import { take, put, select } from 'redux-saga/effects';
 import * as incoming from 'magmo-wallet-client/lib/wallet-instructions';
 
 import * as actions from '../actions';
@@ -6,9 +6,11 @@ import { eventChannel } from 'redux-saga';
 import * as application from '../protocols/application/reducer';
 import { isRelayableAction, WalletProtocol } from '../../communication';
 import { responseProvided } from '../protocols/dispute/responder/actions';
-import { getChannelId } from '../../domain';
+import { getChannelId, Commitment, SignedCommitment } from '../../domain';
 import { concluded } from '../protocols/application/actions';
-
+import * as selectors from '../selectors';
+import * as contractUtils from '../../utils/contract-utils';
+import { appAttributesFromBytes } from 'fmg-nitro-adjudicator';
 export function* messageListener() {
   const postMessageEventChannel = eventChannel(emitter => {
     window.addEventListener('message', (event: MessageEvent) => {
@@ -56,6 +58,8 @@ export function* messageListener() {
             actions.protocol.initializeChannel({ channelId: getChannelId(action.commitment) }),
           );
         }
+        yield validateAgainstLatestCommitment(action.commitment);
+
         yield put(
           actions.application.ownCommitmentReceived({
             processId: application.APPLICATION_PROCESS_ID,
@@ -69,6 +73,8 @@ export function* messageListener() {
             actions.protocol.initializeChannel({ channelId: getChannelId(action.commitment) }),
           );
         }
+        yield validateAgainstLatestCommitment(action.commitment);
+
         yield put(
           actions.application.opponentCommitmentReceived({
             processId: application.APPLICATION_PROCESS_ID,
@@ -84,13 +90,74 @@ export function* messageListener() {
         yield put(responseProvided({ processId, commitment: action.commitment }));
         break;
       case incoming.RECEIVE_MESSAGE:
-        yield put(handleIncomingMessage(action));
-        if (handleIncomingMessage(action).type === 'WALLET.NEW_PROCESS.CONCLUDE_INSTIGATED') {
+        const messageAction = handleIncomingMessage(action);
+        if (messageAction.type === 'WALLET.COMMON.COMMITMENT_RECEIVED') {
+          yield validateAgainstLatestCommitment(messageAction.signedCommitment.commitment);
+        }
+        if (messageAction.type === 'WALLET.COMMON.COMMITMENTS_RECEIVED') {
+          yield validateTransitionForCommitments(messageAction.signedCommitments);
+        }
+
+        yield put(messageAction);
+        if (messageAction.type === 'WALLET.NEW_PROCESS.CONCLUDE_INSTIGATED') {
           yield put(concluded({ processId: application.APPLICATION_PROCESS_ID }));
         }
         break;
       default:
     }
+  }
+}
+
+function* validateTransitionForCommitments(signedCommitments: SignedCommitment[]) {
+  const channelId = getChannelId(signedCommitments[0].commitment);
+  // If we're receiving the first commitment there's nothing stored to validate against
+  if (signedCommitments[0].commitment.turnNum > 0) {
+    const latestStoredCommitment: Commitment = yield select(
+      selectors.getLastCommitmentForChannel,
+      channelId,
+    );
+    const newCommitments = signedCommitments.filter(
+      signedCommitment => signedCommitment.commitment.turnNum > latestStoredCommitment.turnNum,
+    );
+    if (newCommitments.length > 0) {
+      let fromCommitment = latestStoredCommitment;
+      let toCommitment = newCommitments[0].commitment;
+      yield validateTransition(fromCommitment, toCommitment);
+
+      for (let i = 1; i < signedCommitments.length; i++) {
+        fromCommitment = signedCommitments[i - 1].commitment;
+        toCommitment = signedCommitments[i].commitment;
+        yield validateTransition(fromCommitment, toCommitment);
+      }
+    }
+  }
+}
+function* validateAgainstLatestCommitment(incomingCommitment: Commitment) {
+  // If we're receiving the first commitment there's nothing stored to validate against
+  if (incomingCommitment.turnNum > 0) {
+    const channelId = getChannelId(incomingCommitment);
+    const fromCommitment: Commitment = yield select(
+      selectors.getLastCommitmentForChannel,
+      channelId,
+    );
+    yield validateTransition(fromCommitment, incomingCommitment);
+  }
+}
+
+function* validateTransition(fromCommitment: Commitment, toCommitment: Commitment) {
+  const validTransition = yield contractUtils.validateTransition(fromCommitment, toCommitment);
+  if (!validTransition) {
+    const fromAppAttributes = appAttributesFromBytes(fromCommitment.appAttributes);
+    const toAppAttributes = appAttributesFromBytes(toCommitment.appAttributes);
+    throw new Error(
+      `Invalid transition. From Commitment: ${JSON.stringify({
+        ...fromCommitment,
+        appAttributes: fromAppAttributes,
+      })} To Commitment: ${JSON.stringify({
+        ...toCommitment,
+        appAttributes: toAppAttributes,
+      })}`,
+    );
   }
 }
 

--- a/packages/wallet/src/redux/sagas/message-listener.ts
+++ b/packages/wallet/src/redux/sagas/message-listener.ts
@@ -110,8 +110,9 @@ export function* messageListener() {
 
 function* validateTransitionForCommitments(signedCommitments: SignedCommitment[]) {
   const channelId = getChannelId(signedCommitments[0].commitment);
-  // If we're receiving the first commitment there's nothing stored to validate against
-  if (signedCommitments[0].commitment.turnNum > 0) {
+
+  const storedCommitmentExists = yield select(selectors.doesACommitmentExistForChannel, channelId);
+  if (storedCommitmentExists) {
     const latestStoredCommitment: Commitment = yield select(
       selectors.getLastCommitmentForChannel,
       channelId,

--- a/packages/wallet/src/redux/selectors.ts
+++ b/packages/wallet/src/redux/selectors.ts
@@ -1,8 +1,9 @@
-import { OpenChannelState, ChannelState, isFullyOpen } from './channel-store';
+import { OpenChannelState, ChannelState, isFullyOpen, getLastCommitment } from './channel-store';
 import * as walletStates from './state';
 import { SharedData, FundingState } from './state';
 import { WalletProtocol } from '../communication';
 import { CONSENSUS_LIBRARY_ADDRESS } from '../constants';
+import { Commitment } from '../domain';
 
 export const getOpenedChannelState = (state: SharedData, channelId: string): OpenChannelState => {
   const channelStatus = getChannelState(state, channelId);
@@ -18,6 +19,11 @@ export const getChannelState = (state: SharedData, channelId: string): ChannelSt
     throw new Error(`Could not find any initialized channel state for channel ${channelId}.`);
   }
   return channelStatus;
+};
+
+export const getLastCommitmentForChannel = (state: SharedData, channelId: string): Commitment => {
+  const channelState = getChannelState(state, channelId);
+  return getLastCommitment(channelState);
 };
 
 export const getExistingLedgerChannelForParticipants = (

--- a/packages/wallet/src/redux/selectors.ts
+++ b/packages/wallet/src/redux/selectors.ts
@@ -13,6 +13,13 @@ export const getOpenedChannelState = (state: SharedData, channelId: string): Ope
   return channelStatus;
 };
 
+export const doesACommitmentExistForChannel = (state: SharedData, channelId: string): boolean => {
+  return (
+    state.channelStore[channelId] !== undefined &&
+    state.channelStore[channelId].commitments.length > 0
+  );
+};
+
 export const getChannelState = (state: SharedData, channelId: string): ChannelState => {
   const channelStatus = state.channelStore[channelId];
   if (!channelStatus) {


### PR DESCRIPTION
Calls `validateTransition` from the `message-listener` whenever receiving a `commitment`.

Fixes #561.