### PR TITLE
Upgrade fmg-core in rps package

### DIFF
--- a/packages/rps/package.json
+++ b/packages/rps/package.json
@@ -52,7 +52,7 @@
     "enum": "^2.5.0",
     "ethers": "^4.0.7",
     "firebase": "^5.0.4",
-    "fmg-core": "0.5.6",
+    "fmg-core": "0.5.9",
     "fs-extra": "3.0.1",
     "key-mirror": "^1.0.1",
     "lodash": "^4.17.10",


### PR DESCRIPTION
The [recent change](https://github.com/magmo/force-move-protocol/compare/fmg-core@0.5.6...master#diff-0d7546e635886f7575ca1259253096caL10) to the  `channelID` function at packages/fmg-core/src/channel.ts changed the way that channel addresses are computed. 

Applications (i.e. RPS) should use the same function as the wallet, since their working together relies on consistent `channelId`s.
![Screenshot 2019-07-01 at 10 52 57](https://user-images.githubusercontent.com/1833419/60431872-c0c76b00-9bf8-11e9-940f-6e68c91f8205.png)
