### PR TITLE
Existing ledger funding UI

### DIFF
--- a/packages/wallet/notes/index.md
+++ b/packages/wallet/notes/index.md
@@ -40,7 +40,7 @@ graph TD
 
     C{Concluding}-->CU(ConsensusUpdate)
 
-    idF -->  ECF(ExistingLedgerFunding)
+    idF -->  ELF(ExistingLedgerFunding)
     idF --> NLC(NewLedgerChannel)
 
     NLC --> CU(ConsensusUpdate)

--- a/packages/wallet/notes/index.md
+++ b/packages/wallet/notes/index.md
@@ -13,7 +13,7 @@
 - [defunding](../src/redux/protocols/defunding/readme.md)
 - [direct-funding](../src/redux/protocols/direct-funding/readme.md)
 - [dispute](../src/redux/protocols/dispute/readme.md)
-- [existing-channel-funding](../src/redux/protocols/existing-channel-funding/readme.md)
+- [existing-ledger-funding](../src/redux/protocols/existing-ledger-funding/readme.md)
 - [funding](../src/redux/protocols/funding/readme.md)
 - [indirect-defunding](../src/redux/protocols/indirect-defunding/readme.md)
 - [indirect-funding](../src/redux/protocols/indirect-funding/readme.md)
@@ -40,7 +40,7 @@ graph TD
 
     C{Concluding}-->CU(ConsensusUpdate)
 
-    idF -->  ECF(ExistingChannelFunding)
+    idF -->  ECF(ExistingLedgerFunding)
     idF --> NLC(NewLedgerChannel)
 
     NLC --> CU(ConsensusUpdate)

--- a/packages/wallet/src/redux/protocols/consensus-update/components/wait-for-ledger-update.tsx
+++ b/packages/wallet/src/redux/protocols/consensus-update/components/wait-for-ledger-update.tsx
@@ -1,0 +1,17 @@
+import React, { Fragment } from 'react';
+
+interface Props {
+  channelId: string;
+}
+
+export default class WaitForLedgerUpdate extends React.PureComponent<Props> {
+  render() {
+    return (
+      <Fragment>
+        <h1>Preparing for top-up...</h1>
+        Waiting for your opponent to confirm updates to ledger channel:
+        <div className="channel-address">{this.props.channelId}</div>
+      </Fragment>
+    );
+  }
+}

--- a/packages/wallet/src/redux/protocols/consensus-update/container.tsx
+++ b/packages/wallet/src/redux/protocols/consensus-update/container.tsx
@@ -4,6 +4,7 @@ import Failure from '../shared-components/failure';
 import Success from '../shared-components/success';
 import React from 'react';
 import { connect } from 'react-redux';
+import WaitForLedgerUpdate from './components/wait-for-ledger-update';
 
 interface Props {
   state: states.ConsensusUpdateState;
@@ -14,7 +15,7 @@ class ConsensusUpdateContainer extends PureComponent<Props> {
     const { state } = this.props;
     switch (state.type) {
       case 'ConsensusUpdate.WaitForUpdate':
-        return <div>Waiting for ledger updates to be exchanged</div>;
+        return <WaitForLedgerUpdate channelId={state.channelId} />;
       case 'ConsensusUpdate.Failure':
         return <Failure name="consensus update" reason={state.reason} />;
       case 'ConsensusUpdate.Success':

--- a/packages/wallet/src/redux/protocols/direct-funding/container.tsx
+++ b/packages/wallet/src/redux/protocols/direct-funding/container.tsx
@@ -43,7 +43,7 @@ const mapDispatchToProps = {
 
 // why does it think that mapStateToProps can return undefined??
 
-export default connect(
+export const DirectFunding = connect(
   () => ({}),
   mapDispatchToProps,
 )(DirectFundingContainer);

--- a/packages/wallet/src/redux/protocols/existing-ledger-funding/__tests__/scenarios.ts
+++ b/packages/wallet/src/redux/protocols/existing-ledger-funding/__tests__/scenarios.ts
@@ -14,6 +14,7 @@ import { channelFromCommitments } from '../../../channel-store/channel-state/__t
 import * as states from '../states';
 import * as globalActions from '../../../actions';
 import { EXISTING_LEDGER_FUNDING_PROTOCOL_LOCATOR } from '../reducer';
+import { playerAHappyPath } from '../../ledger-top-up/__tests__/scenarios';
 
 const processId = 'processId';
 
@@ -220,6 +221,12 @@ export const playerATopUpNeeded = {
   initialize: {
     sharedData: initialPlayerATopUpNeededSharedData,
     ...props,
+  },
+  waitForLedgerTopUp: {
+    state: states.waitForLedgerTopUp({
+      ...props,
+      ledgerTopUpState: playerAHappyPath.switchOrderAndAddATopUpUpdate.state,
+    }),
   },
 };
 

--- a/packages/wallet/src/redux/protocols/existing-ledger-funding/__tests__/stories.tsx
+++ b/packages/wallet/src/redux/protocols/existing-ledger-funding/__tests__/stories.tsx
@@ -1,0 +1,7 @@
+import { addStoriesFromScenario as addStories } from '../../../../__stories__';
+import * as scenarios from './scenarios';
+
+addStories(
+  scenarios.playerAFullyFundedHappyPath,
+  'Existing Ledger Funding / Player A Fully Funded Happy Path',
+);

--- a/packages/wallet/src/redux/protocols/existing-ledger-funding/__tests__/stories.tsx
+++ b/packages/wallet/src/redux/protocols/existing-ledger-funding/__tests__/stories.tsx
@@ -5,3 +5,4 @@ addStories(
   scenarios.playerAFullyFundedHappyPath,
   'Existing Ledger Funding / Player A Fully Funded Happy Path',
 );
+addStories(scenarios.playerATopUpNeeded, 'Existing Ledger Funding / Player A Top-up needed');

--- a/packages/wallet/src/redux/protocols/existing-ledger-funding/components/wait-for-ledger-update.tsx
+++ b/packages/wallet/src/redux/protocols/existing-ledger-funding/components/wait-for-ledger-update.tsx
@@ -1,0 +1,22 @@
+import React, { Fragment } from 'react';
+
+interface Props {
+  ledgerId: string;
+  channelId: string;
+}
+
+export default class WaitForLedgerUpdate extends React.PureComponent<Props> {
+  render() {
+    return (
+      <Fragment>
+        <h1>Waiting...</h1>
+
+        <p>
+          For your opponent to confirm indirect funding for channel:
+          <div className="channel-address">{this.props.channelId}</div> via ledger channel:
+          <div className="channel-address">{this.props.ledgerId}</div>
+        </p>
+      </Fragment>
+    );
+  }
+}

--- a/packages/wallet/src/redux/protocols/existing-ledger-funding/components/wait-for-ledger-update.tsx
+++ b/packages/wallet/src/redux/protocols/existing-ledger-funding/components/wait-for-ledger-update.tsx
@@ -10,12 +10,9 @@ export default class WaitForLedgerUpdate extends React.PureComponent<Props> {
     return (
       <Fragment>
         <h1>Waiting...</h1>
-
-        <p>
-          For your opponent to confirm indirect funding for channel:
-          <div className="channel-address">{this.props.channelId}</div> via ledger channel:
-          <div className="channel-address">{this.props.ledgerId}</div>
-        </p>
+        For your opponent to confirm indirect funding for channel:
+        <div className="channel-address">{this.props.channelId}</div> via ledger channel:
+        <div className="channel-address">{this.props.ledgerId}</div>
       </Fragment>
     );
   }

--- a/packages/wallet/src/redux/protocols/existing-ledger-funding/components/wait-for-post-fund-setup.tsx
+++ b/packages/wallet/src/redux/protocols/existing-ledger-funding/components/wait-for-post-fund-setup.tsx
@@ -1,0 +1,20 @@
+import React, { Fragment } from 'react';
+
+interface Props {
+  channelId: string;
+}
+
+export default class WaitForPostFundSetup extends React.PureComponent<Props> {
+  render() {
+    return (
+      <Fragment>
+        <h1>Waiting...</h1>
+
+        <p>
+          For your opponent to send a PostFundSetup for channel
+          <div className="channel-address">{this.props.channelId}</div>
+        </p>
+      </Fragment>
+    );
+  }
+}

--- a/packages/wallet/src/redux/protocols/existing-ledger-funding/components/wait-for-post-fund-setup.tsx
+++ b/packages/wallet/src/redux/protocols/existing-ledger-funding/components/wait-for-post-fund-setup.tsx
@@ -9,11 +9,8 @@ export default class WaitForPostFundSetup extends React.PureComponent<Props> {
     return (
       <Fragment>
         <h1>Waiting...</h1>
-
-        <p>
-          For your opponent to send a PostFundSetup for channel
-          <div className="channel-address">{this.props.channelId}</div>
-        </p>
+        For your opponent to send a PostFundSetup for channel
+        <div className="channel-address">{this.props.channelId}</div>
       </Fragment>
     );
   }

--- a/packages/wallet/src/redux/protocols/existing-ledger-funding/container.tsx
+++ b/packages/wallet/src/redux/protocols/existing-ledger-funding/container.tsx
@@ -6,6 +6,7 @@ import { connect } from 'react-redux';
 import { unreachable } from '../../../utils/reducer-utils';
 import WaitForPostFundSetup from './components/wait-for-post-fund-setup';
 import WaitForLedgerUpdate from './components/wait-for-ledger-update';
+import { LedgerTopUp } from '../ledger-top-up/container';
 
 interface Props {
   state: states.ExistingLedgerFundingState;
@@ -16,7 +17,7 @@ class ExistingLedgerFundingContainer extends PureComponent<Props> {
     const { state } = this.props;
     switch (state.type) {
       case 'ExistingLedgerFunding.WaitForLedgerTopUp':
-      // TODO display child container
+        return <LedgerTopUp state={state.ledgerTopUpState} />;
       case 'ExistingLedgerFunding.WaitForLedgerUpdate':
         return <WaitForLedgerUpdate channelId={state.channelId} ledgerId={state.ledgerId} />;
       case 'ExistingLedgerFunding.WaitForPostFundSetup':

--- a/packages/wallet/src/redux/protocols/existing-ledger-funding/container.tsx
+++ b/packages/wallet/src/redux/protocols/existing-ledger-funding/container.tsx
@@ -3,6 +3,7 @@ import { PureComponent } from 'react';
 import React from 'react';
 
 import { connect } from 'react-redux';
+import { unreachable } from 'src/utils/reducer-utils';
 
 interface Props {
   state: states.ExistingLedgerFundingState;
@@ -11,7 +12,16 @@ interface Props {
 class ExistingLedgerFundingContainer extends PureComponent<Props> {
   render() {
     const { state } = this.props;
-    return <div>{state.type}</div>;
+    switch (state.type) {
+      case 'ExistingLedgerFunding.WaitForLedgerTopUp':
+      case 'ExistingLedgerFunding.WaitForLedgerUpdate':
+      case 'ExistingLedgerFunding.WaitForPostFundSetup':
+      case 'ExistingLedgerFunding.Success':
+      case 'ExistingLedgerFunding.Failure':
+        return <div>{state.type}</div>;
+      default:
+        return unreachable(state);
+    }
   }
 }
 

--- a/packages/wallet/src/redux/protocols/existing-ledger-funding/container.tsx
+++ b/packages/wallet/src/redux/protocols/existing-ledger-funding/container.tsx
@@ -3,7 +3,9 @@ import { PureComponent } from 'react';
 import React from 'react';
 
 import { connect } from 'react-redux';
-import { unreachable } from 'src/utils/reducer-utils';
+import { unreachable } from '../../../utils/reducer-utils';
+import WaitForPostFundSetup from './components/wait-for-post-fund-setup';
+import WaitForLedgerUpdate from './components/wait-for-ledger-update';
 
 interface Props {
   state: states.ExistingLedgerFundingState;
@@ -14,8 +16,11 @@ class ExistingLedgerFundingContainer extends PureComponent<Props> {
     const { state } = this.props;
     switch (state.type) {
       case 'ExistingLedgerFunding.WaitForLedgerTopUp':
+      // TODO display child container
       case 'ExistingLedgerFunding.WaitForLedgerUpdate':
+        return <WaitForLedgerUpdate channelId={state.channelId} ledgerId={state.ledgerId} />;
       case 'ExistingLedgerFunding.WaitForPostFundSetup':
+        return <WaitForPostFundSetup channelId={state.channelId} />;
       case 'ExistingLedgerFunding.Success':
       case 'ExistingLedgerFunding.Failure':
         return <div>{state.type}</div>;

--- a/packages/wallet/src/redux/protocols/existing-ledger-funding/readme.md
+++ b/packages/wallet/src/redux/protocols/existing-ledger-funding/readme.md
@@ -29,10 +29,12 @@ Currently we assume a Ledger Top-up protocol handles both the cases where a curr
   classDef Success fill:#58ef21;
   classDef Failure fill:#f45941;
   classDef WaitForChildProtocol stroke:#333,stroke-width:4px,color:#ffff,fill:#333;
+  classDef NotAState stroke:#333,stroke-width:4px,fill:#0000;
   class St,L logic;
   class Su Success;
   class F Failure;
   class LT WaitForChildProtocol;
+  class SC0,SP0 NotAState
 ```
 
 ### Player B State Machine
@@ -54,10 +56,12 @@ Currently we assume a Ledger Top-up protocol handles both the cases where a curr
   classDef Success fill:#58ef21;
   classDef Failure fill:#f45941;
   classDef WaitForChildProtocol stroke:#333,stroke-width:4px,color:#ffff,fill:#333;
+  classDef NotAState stroke:#333,stroke-width:4px,fill:#0000;
   class St,L logic;
   class Su Success;
   class F Failure;
   class LT WaitForChildProtocol;
+  class SC1,SP1 NotAState
 ```
 
 ### Scenarios:

--- a/packages/wallet/src/redux/protocols/ledger-top-up/__tests__/stories.tsx
+++ b/packages/wallet/src/redux/protocols/ledger-top-up/__tests__/stories.tsx
@@ -1,0 +1,4 @@
+import { addStoriesFromScenario as addStories } from '../../../../__stories__';
+import * as scenarios from './scenarios';
+
+addStories(scenarios.playerAHappyPath, 'Ledger Top Up / Player A Happy Path');

--- a/packages/wallet/src/redux/protocols/ledger-top-up/container.tsx
+++ b/packages/wallet/src/redux/protocols/ledger-top-up/container.tsx
@@ -1,0 +1,33 @@
+import { PureComponent } from 'react';
+import React from 'react';
+
+import { connect } from 'react-redux';
+import { unreachable } from '../../../utils/reducer-utils';
+import { LedgerTopUpState } from './states';
+import { ConsensusUpdate } from '../consensus-update/container';
+import { DirectFunding } from '../direct-funding/container';
+
+interface Props {
+  state: LedgerTopUpState;
+}
+
+class LedgerTopUpContainer extends PureComponent<Props> {
+  render() {
+    const { state } = this.props;
+    switch (state.type) {
+      case 'LedgerTopUp.SwitchOrderAndAddATopUpUpdate':
+      case 'LedgerTopUp.RestoreOrderAndAddBTopUpUpdate':
+        return <ConsensusUpdate state={state.consensusUpdateState} />;
+      case 'LedgerTopUp.WaitForDirectFundingForA':
+      case 'LedgerTopUp.WaitForDirectFundingForB':
+        return <DirectFunding state={state.directFundingState} />;
+      case 'LedgerTopUp.Success':
+      case 'LedgerTopUp.Failure':
+        return <div>{state.type}</div>;
+      default:
+        return unreachable(state);
+    }
+  }
+}
+
+export const LedgerTopUp = connect(() => ({}))(LedgerTopUpContainer);

--- a/packages/wallet/src/styles/wallet.scss
+++ b/packages/wallet/src/styles/wallet.scss
@@ -62,3 +62,14 @@
 .fa-ul > li {
   padding: 0.7em 1em;
 }
+
+.channel-address {
+  max-width: 100px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.channel-address:hover {
+  overflow: visible;
+}


### PR DESCRIPTION
Add containers and components for `existing-ledger-funding` and it's children (where necessary). 

Many of the screens are only visible for a fraction of a second in the happy path. However, in future we will want to allow for inactivity and challenging, and then they may appear for longer. 

This PR also introduces a way to clip long hex string channel addresses.

![Screenshot 2019-07-01 at 17 57 33](https://user-images.githubusercontent.com/1833419/60453694-ba9db280-9c29-11e9-877e-96848a48c12f.png)

Closes #570 