### PR TITLE
add Cleared To Send support to Consensus Update Protocol

### DIFF
--- a/packages/wallet/src/redux/protocols/concluding/instigator/reducer.ts
+++ b/packages/wallet/src/redux/protocols/concluding/instigator/reducer.ts
@@ -123,6 +123,7 @@ function keepLedgerChannelApproved(protocolState: CState, sharedData: Storage) {
       } = consensusUpdateInitialize(
         protocolState.processId,
         ledgerId,
+        true, // TODO: Make use of cleared to send in concluding protocol
         latestCommitment.allocation,
         latestCommitment.destination,
         sharedData,
@@ -254,6 +255,7 @@ function keepOpenChosen(protocolState: NonTerminalCState, sharedData: Storage): 
     } = consensusUpdateInitialize(
       protocolState.processId,
       ledgerId,
+      true, // TODO: Make use of cleared to send in concluding protocol
       latestCommitment.allocation,
       latestCommitment.destination,
       sharedData,

--- a/packages/wallet/src/redux/protocols/concluding/responder/reducer.ts
+++ b/packages/wallet/src/redux/protocols/concluding/responder/reducer.ts
@@ -184,6 +184,7 @@ function keepOpenChosen(protocolState: NonTerminalCState, sharedData: Storage): 
     } = initializeConsensusUpdate(
       protocolState.processId,
       ledgerId,
+      true, // TODO: Use cleared to send in concluding protocol
       latestCommitment.allocation,
       latestCommitment.destination,
       sharedData,
@@ -247,6 +248,7 @@ function keepLedgerChannelApproved(protocolState: CState, sharedData: Storage) {
       } = initializeConsensusUpdate(
         protocolState.processId,
         ledgerId,
+        true, // TODO: Use cleared to send in concluding protocol
         latestCommitment.allocation,
         latestCommitment.destination,
         sharedData,

--- a/packages/wallet/src/redux/protocols/consensus-update/__tests__/scenarios.ts
+++ b/packages/wallet/src/redux/protocols/consensus-update/__tests__/scenarios.ts
@@ -16,6 +16,7 @@ import * as states from '../states';
 import { CONSENSUS_UPDATE_PROTOCOL_LOCATOR } from '../reducer';
 import { commitmentsReceived } from '../../../../communication';
 import { ThreePartyPlayerIndex } from '../../../types';
+import { clearedToSend } from '../actions';
 
 const twoThree = [
   { address: asAddress, wei: bigNumberify(2).toHexString() },
@@ -122,19 +123,27 @@ const processId = 'process-id.123';
 // ------
 // States
 // ------
-const twoPlayerWaitForUpdate = states.waitForUpdate({
-  channelId: ledgerId,
-  processId,
-  proposedAllocation,
-  proposedDestination,
-});
+const twoPlayerWaitForUpdate = (clearedToSend, updateSent) => {
+  return states.waitForUpdate({
+    channelId: ledgerId,
+    processId,
+    proposedAllocation,
+    proposedDestination,
+    clearedToSend,
+    updateSent,
+  });
+};
 
-const threePlayerWaitForUpdate = states.waitForUpdate({
-  channelId: threeWayLedgerId,
-  processId,
-  proposedAllocation: threePlayerProposedAllocation,
-  proposedDestination: threePlayerProposedDestination,
-});
+const threePlayerWaitForUpdate = (clearedToSend, updateSent) => {
+  return states.waitForUpdate({
+    channelId: threeWayLedgerId,
+    processId,
+    proposedAllocation: threePlayerProposedAllocation,
+    proposedDestination: threePlayerProposedDestination,
+    clearedToSend,
+    updateSent,
+  });
+};
 
 // ------
 // Actions
@@ -144,7 +153,7 @@ const twoPlayerUpdate0Received = commitmentsReceived({
   signedCommitments: [ledger6],
   protocolLocator: CONSENSUS_UPDATE_PROTOCOL_LOCATOR,
 });
-const twoPLayerUpdate1Received = commitmentsReceived({
+const twoPlayerUpdate1Received = commitmentsReceived({
   processId,
   signedCommitments: [ledger6, ledger7],
   protocolLocator: CONSENSUS_UPDATE_PROTOCOL_LOCATOR,
@@ -171,7 +180,10 @@ const threePlayerUpdate2Received = commitmentsReceived({
   signedCommitments: [threePlayerLedger9, threePlayerLedger10, threePlayerLedger11],
   protocolLocator: CONSENSUS_UPDATE_PROTOCOL_LOCATOR,
 });
-
+const clearedToSendAction = clearedToSend({
+  processId,
+  protocolLocator: CONSENSUS_UPDATE_PROTOCOL_LOCATOR,
+});
 export const twoPlayerAHappyPath = {
   initialize: {
     channelId: ledgerId,
@@ -180,11 +192,12 @@ export const twoPlayerAHappyPath = {
     processId,
     sharedData: twoPlayerAInitialSharedData,
     reply: [ledger5, ledger6],
+    clearedToSend: true,
   },
   waitForUpdate: {
-    state: twoPlayerWaitForUpdate,
+    state: twoPlayerWaitForUpdate(true, true),
     sharedData: twoPlayerAUpdate0ReceivedSharedData,
-    action: twoPLayerUpdate1Received,
+    action: twoPlayerUpdate1Received,
   },
 };
 
@@ -194,10 +207,11 @@ export const twoPlayerBHappyPath = {
     channelId: ledgerId,
     proposedAllocation,
     proposedDestination,
+    clearedToSend: true,
     sharedData: twoPlayerBInitialSharedData,
   },
   waitForUpdate: {
-    state: twoPlayerWaitForUpdate,
+    state: twoPlayerWaitForUpdate(true, false),
     sharedData: twoPlayerBInitialSharedData,
     action: twoPlayerUpdate0Received,
     reply: [ledger6, ledger7],
@@ -206,7 +220,7 @@ export const twoPlayerBHappyPath = {
 
 export const twoPlayerACommitmentRejected = {
   waitForUpdate: {
-    state: twoPlayerWaitForUpdate,
+    state: twoPlayerWaitForUpdate(true, true),
     sharedData: twoPlayerAUpdate0ReceivedSharedData,
     action: twoPlayerInvalidUpdateReceived,
   },
@@ -214,7 +228,7 @@ export const twoPlayerACommitmentRejected = {
 
 export const twoPlayerBCommitmentRejected = {
   waitForUpdate: {
-    state: twoPlayerWaitForUpdate,
+    state: twoPlayerWaitForUpdate(true, false),
     sharedData: twoPlayerBInitialSharedData,
     action: twoPlayerInvalidUpdateReceived,
   },
@@ -226,16 +240,17 @@ export const threePlayerAHappyPath = {
     processId,
     proposedAllocation: threePlayerProposedAllocation,
     proposedDestination: threePlayerProposedDestination,
+    clearedToSend: true,
     sharedData: threePlayerInitialSharedData(ThreePartyPlayerIndex.A),
     reply: [threePlayerLedger7, threePlayerLedger8, threePlayerLedger9],
   },
   waitForPlayerBUpdate: {
-    state: threePlayerWaitForUpdate,
+    state: threePlayerWaitForUpdate(true, true),
     sharedData: threePlayerFirstUpdateSharedData(ThreePartyPlayerIndex.A),
     action: threePlayerUpdate1Received,
   },
   waitForHubUpdate: {
-    state: threePlayerWaitForUpdate,
+    state: threePlayerWaitForUpdate(true, true),
     sharedData: threePlayerSecondUpdateSharedData(ThreePartyPlayerIndex.A),
     action: threePlayerUpdate2Received,
   },
@@ -247,16 +262,17 @@ export const threePlayerBHappyPath = {
     processId,
     proposedAllocation: threePlayerProposedAllocation,
     proposedDestination: threePlayerProposedDestination,
+    clearedToSend: true,
     sharedData: threePlayerInitialSharedData(ThreePartyPlayerIndex.B),
   },
   waitForPlayerAUpdate: {
-    state: threePlayerWaitForUpdate,
+    state: threePlayerWaitForUpdate(true, false),
     sharedData: threePlayerInitialSharedData(ThreePartyPlayerIndex.B),
     action: threePlayerUpdate0Received,
     reply: [threePlayerLedger8, threePlayerLedger9, threePlayerLedger10],
   },
   waitForHubUpdate: {
-    state: threePlayerWaitForUpdate,
+    state: threePlayerWaitForUpdate(true, true),
     sharedData: threePlayerSecondUpdateSharedData(ThreePartyPlayerIndex.B),
     action: threePlayerUpdate2Received,
   },
@@ -268,17 +284,84 @@ export const threePlayerHubHappyPath = {
     processId,
     proposedAllocation: threePlayerProposedAllocation,
     proposedDestination: threePlayerProposedDestination,
+    clearedToSend: true,
     sharedData: threePlayerInitialSharedData(ThreePartyPlayerIndex.Hub),
   },
   waitForPlayerAUpdate: {
-    state: threePlayerWaitForUpdate,
+    state: threePlayerWaitForUpdate(true, false),
     sharedData: threePlayerInitialSharedData(ThreePartyPlayerIndex.Hub),
     action: threePlayerUpdate0Received,
   },
   waitForPlayerBUpdate: {
-    state: threePlayerWaitForUpdate,
+    state: threePlayerWaitForUpdate(true, false),
     sharedData: threePlayerFirstUpdateSharedData(ThreePartyPlayerIndex.Hub),
     action: threePlayerUpdate1Received,
+    reply: [threePlayerLedger9, threePlayerLedger10, threePlayerLedger11],
+  },
+};
+
+export const threePlayerANotClearedToSend = {
+  initialize: {
+    channelId: threeWayLedgerId,
+    processId,
+    proposedAllocation: threePlayerProposedAllocation,
+    proposedDestination: threePlayerProposedDestination,
+    clearedToSend: false,
+    sharedData: threePlayerInitialSharedData(ThreePartyPlayerIndex.A),
+  },
+  waitForUpdateAndClearedToSend: {
+    state: threePlayerWaitForUpdate(false, false),
+    sharedData: threePlayerInitialSharedData(ThreePartyPlayerIndex.A),
+    action: clearedToSendAction,
+    reply: [threePlayerLedger7, threePlayerLedger8, threePlayerLedger9],
+  },
+};
+
+export const threePlayerBNotClearedToSend = {
+  initialize: {
+    channelId: threeWayLedgerId,
+    processId,
+    proposedAllocation: threePlayerProposedAllocation,
+    proposedDestination: threePlayerProposedDestination,
+    clearedToSend: false,
+    sharedData: threePlayerInitialSharedData(ThreePartyPlayerIndex.B),
+  },
+  waitForUpdateAndClearedToSend: {
+    state: threePlayerWaitForUpdate(false, false),
+    sharedData: threePlayerInitialSharedData(ThreePartyPlayerIndex.B),
+    action: clearedToSendAction,
+  },
+  waitForPlayerAUpdate: {
+    state: threePlayerWaitForUpdate(true, false),
+    sharedData: threePlayerInitialSharedData(ThreePartyPlayerIndex.B),
+    action: threePlayerUpdate0Received,
+    reply: [threePlayerLedger8, threePlayerLedger9, threePlayerLedger10],
+  },
+};
+
+export const threePlayerHubNotClearedToSend = {
+  initialize: {
+    channelId: threeWayLedgerId,
+    processId,
+    proposedAllocation: threePlayerProposedAllocation,
+    proposedDestination: threePlayerProposedDestination,
+    clearedToSend: false,
+    sharedData: threePlayerInitialSharedData(ThreePartyPlayerIndex.Hub),
+  },
+  waitForPlayerAUpdate: {
+    state: threePlayerWaitForUpdate(false, false),
+    sharedData: threePlayerInitialSharedData(ThreePartyPlayerIndex.Hub),
+    action: threePlayerUpdate0Received,
+  },
+  waitForPlayerBUpdate: {
+    state: threePlayerWaitForUpdate(false, false),
+    sharedData: threePlayerFirstUpdateSharedData(ThreePartyPlayerIndex.Hub),
+    action: threePlayerUpdate1Received,
+  },
+  waitForClearedToSend: {
+    state: threePlayerWaitForUpdate(false, false),
+    action: clearedToSendAction,
+    sharedData: threePlayerSecondUpdateSharedData(ThreePartyPlayerIndex.Hub),
     reply: [threePlayerLedger9, threePlayerLedger10, threePlayerLedger11],
   },
 };

--- a/packages/wallet/src/redux/protocols/consensus-update/__tests__/scenarios.ts
+++ b/packages/wallet/src/redux/protocols/consensus-update/__tests__/scenarios.ts
@@ -123,7 +123,8 @@ const processId = 'process-id.123';
 // ------
 // States
 // ------
-const twoPlayerWaitForUpdate = (clearedToSend, updateSent) => {
+// tslint:disable-next-line: no-shadowed-variable
+const twoPlayerWaitForUpdate = (clearedToSend: boolean, updateSent: boolean) => {
   return states.waitForUpdate({
     channelId: ledgerId,
     processId,
@@ -134,6 +135,7 @@ const twoPlayerWaitForUpdate = (clearedToSend, updateSent) => {
   });
 };
 
+// tslint:disable-next-line: no-shadowed-variable
 const threePlayerWaitForUpdate = (clearedToSend, updateSent) => {
   return states.waitForUpdate({
     channelId: threeWayLedgerId,

--- a/packages/wallet/src/redux/protocols/consensus-update/actions.ts
+++ b/packages/wallet/src/redux/protocols/consensus-update/actions.ts
@@ -1,12 +1,26 @@
 import { WalletAction } from '../../actions';
 import { CONSENSUS_UPDATE_PROTOCOL_LOCATOR } from './reducer';
-import { CommitmentsReceived } from '../../../communication';
+import { CommitmentsReceived, BaseProcessAction } from '../../../communication';
+import { ActionConstructor } from '../../utils';
 
-export type ConsensusUpdateAction = CommitmentsReceived;
+export interface ClearedToSend extends BaseProcessAction {
+  type: 'WALLET.CONSENSUS_UPDATE.CLEARED_TO_SEND';
+  protocolLocator: string;
+}
+
+export const clearedToSend: ActionConstructor<ClearedToSend> = p => {
+  return {
+    ...p,
+    type: 'WALLET.CONSENSUS_UPDATE.CLEARED_TO_SEND',
+  };
+};
+
+export type ConsensusUpdateAction = CommitmentsReceived | ClearedToSend;
 
 export const isConsensusUpdateAction = (action: WalletAction): action is ConsensusUpdateAction => {
   return (
-    action.type === 'WALLET.COMMON.COMMITMENTS_RECEIVED' &&
-    action.protocolLocator.indexOf(CONSENSUS_UPDATE_PROTOCOL_LOCATOR) >= 0
+    (action.type === 'WALLET.COMMON.COMMITMENTS_RECEIVED' &&
+      action.protocolLocator.indexOf(CONSENSUS_UPDATE_PROTOCOL_LOCATOR) >= 0) ||
+    action.type === 'WALLET.CONSENSUS_UPDATE.CLEARED_TO_SEND'
   );
 };

--- a/packages/wallet/src/redux/protocols/consensus-update/states.ts
+++ b/packages/wallet/src/redux/protocols/consensus-update/states.ts
@@ -10,6 +10,8 @@ export interface WaitForUpdate {
   proposedDestination: string[];
   channelId: string;
   processId: string;
+  clearedToSend: boolean;
+  updateSent: boolean;
 }
 
 export interface Failure {

--- a/packages/wallet/src/redux/protocols/ledger-top-up/reducer.ts
+++ b/packages/wallet/src/redux/protocols/ledger-top-up/reducer.ts
@@ -370,6 +370,13 @@ function initializeConsensusState(
   const {
     protocolState: consensusUpdateState,
     sharedData: newSharedData,
-  } = initializeConsensusUpdate(processId, ledgerId, newAllocation, newDestination, sharedData);
+  } = initializeConsensusUpdate(
+    processId,
+    ledgerId,
+    true,
+    newAllocation,
+    newDestination,
+    sharedData,
+  );
   return { consensusUpdateState, sharedData: newSharedData };
 }

--- a/packages/wallet/src/redux/protocols/virtual-funding/reducer.ts
+++ b/packages/wallet/src/redux/protocols/virtual-funding/reducer.ts
@@ -275,6 +275,7 @@ function waitForGuarantorFundingReducer(
           const applicationFundingResult = consensusUpdate.initializeConsensusUpdate(
             processId,
             jointChannelId,
+            true,
             proposedAllocation,
             proposedDestination,
             result.sharedData,


### PR DESCRIPTION
As part of the refactor to exchange post fund setups in the `funding`/`newLedgerFunding` protocol I ran into an issue  where ledger updates were coming in early.

To address this I've added `clearedToSend` so the Consensus Update protocol can be started before the commitment arrives and be handled properly.

Related to #593.