### PR TITLE
TSLint fails on build/start

### DIFF
--- a/packages/wallet/tslint.json
+++ b/packages/wallet/tslint.json
@@ -22,6 +22,7 @@
     "ordered-imports": false,
     "jsx-no-lambda": false,
     "interface-name": false,
+    "prefer-for-of": false,
     "trailing-comma": [
       true,
       {


### PR DESCRIPTION
TS-lint was failing and outputting an error on build/start. This disables the rule that was causing the failure.
```The 'prefer-for-of' rule threw an error in '/Users/alexgap/code/apps/packages/wallet/src/utils/hex-utils.ts':
TypeError: Cannot read property 'uses' of undefined
    at visitForStatement (/Users/alexgap/code/apps/node_modules/tslint/lib/rules/preferForOfRule.js:66:59)
    at cb (/Users/alexgap/code/apps/node_modules/tslint/lib/rules/preferForOfRule.js:53:13)
    at visitNodes (/Users/alexgap/code/apps/node_modules/typescript/lib/typescript.js:16514:30)
    at Object.forEachChild (/Users/alexgap/code/apps/node_modules/typescript/lib/typescript.js:16740:24)
    at cb (/Users/alexgap/code/apps/node_modules/tslint/lib/rules/preferForOfRule.js:55:19)
    at visitNode (/Users/alexgap/code/apps/node_modules/typescript/lib/typescript.js:16505:24)
    at Object.forEachChild (/Users/alexgap/code/apps/node_modules/typescript/lib/typescript.js:16635:21)
    at cb (/Users/alexgap/code/apps/node_modules/tslint/lib/rules/preferForOfRule.js:55:19)
    at visitNodes (/Users/alexgap/code/apps/node_modules/typescript/lib/typescript.js:16514:30)
    at Object.forEachChild (/Users/alexgap/code/apps/node_modules/typescript/lib/typescript.js:16742:24)
The 'prefer-for-of' rule threw an error in '/Users/alexgap/code/apps/packages/wallet/src/redux/protocols/existing-ledger-funding/reducer.ts':
TypeError: Cannot read property 'uses' of undefined
    at visitForStatement (/Users/alexgap/code/apps/node_modules/tslint/lib/rules/preferForOfRule.js:66:59)
    at cb (/Users/alexgap/code/apps/node_modules/tslint/lib/rules/preferForOfRule.js:53:13)
    at visitNodes (/Users/alexgap/code/apps/node_modules/typescript/lib/typescript.js:16514:30)
    at Object.forEachChild (/Users/alexgap/code/apps/node_modules/typescript/lib/typescript.js:16740:24)
    at cb (/Users/alexgap/code/apps/node_modules/tslint/lib/rules/preferForOfRule.js:55:19)
    at visitNode (/Users/alexgap/code/apps/node_modules/typescript/lib/typescript.js:16505:24)
    at Object.forEachChild (/Users/alexgap/code/apps/node_modules/typescript/lib/typescript.js:16635:21)
    at cb (/Users/alexgap/code/apps/node_modules/tslint/lib/rules/preferForOfRule.js:55:19)
    at visitNodes (/Users/alexgap/code/apps/node_modules/typescript/lib/typescript.js:16514:30)
    at Object.forEachChild (/Users/alexgap/code/apps/node_modules/typescript/lib/typescript.js:16742:24)```

