### PR TITLE
Correctly set funding state in New Ledger Channel protocol

### DIFF
--- a/packages/wallet/src/redux/protocols/indirect-funding/__tests__/scenarios.ts
+++ b/packages/wallet/src/redux/protocols/indirect-funding/__tests__/scenarios.ts
@@ -15,6 +15,7 @@ import { preSuccess as existingLedgerPreSuccess } from '../../existing-ledger-fu
 import {
   preSuccessState as newLedgerPreSuccess,
   successTrigger as NewLedgerChannelSuccessTrigger,
+  successState as newLedgerSuccess,
 } from '../../new-ledger-channel/__tests__';
 import { INDIRECT_FUNDING_PROTOCOL_LOCATOR } from '../reducer';
 
@@ -36,7 +37,7 @@ const ledger4 = ledgerCommitment({ turnNum: 4, balances: oneThree });
 const ledger5 = ledgerCommitment({ turnNum: 5, balances: oneThree });
 const app0 = appCommitment({ turnNum: 0, balances: oneThree });
 const app1 = appCommitment({ turnNum: 1, balances: oneThree });
-const existingLedgerFundingSharedData = setChannels(existingLedgerPreSuccess.sharedData, [
+const existingLedgerFundingSharedData = setChannels(newLedgerSuccess.store, [
   channelFromCommitments([ledger4, ledger5], asAddress, asPrivateKey),
   channelFromCommitments([app0, app1], asAddress, asPrivateKey),
 ]);

--- a/packages/wallet/src/redux/protocols/new-ledger-channel/__tests__/reducer.test.ts
+++ b/packages/wallet/src/redux/protocols/new-ledger-channel/__tests__/reducer.test.ts
@@ -44,6 +44,16 @@ describe('happy-path scenario', () => {
     const updatedState = NewLedgerChannelReducer(state, sharedData, action);
 
     itTransitionsTo(updatedState, 'NewLedgerChannel.Success');
+    it('correctly sets the funding state', () => {
+      expect(updatedState.sharedData.fundingState[state.channelId]).toMatchObject({
+        directlyFunded: false,
+        fundingChannel: state.ledgerId,
+      });
+
+      expect(updatedState.sharedData.fundingState[state.ledgerId]).toMatchObject({
+        directlyFunded: true,
+      });
+    });
   });
 });
 

--- a/packages/wallet/src/redux/protocols/new-ledger-channel/__tests__/scenarios.ts
+++ b/packages/wallet/src/redux/protocols/new-ledger-channel/__tests__/scenarios.ts
@@ -1,7 +1,7 @@
 import { bigNumberify } from 'ethers/utils';
 import * as states from '../states';
 import { channelFromCommitments } from '../../../channel-store/channel-state/__tests__';
-import { EMPTY_SHARED_DATA, setChannels } from '../../../state';
+import { EMPTY_SHARED_DATA, setChannels, SharedData } from '../../../state';
 
 import {
   preFailure as DFPreFailure,
@@ -39,6 +39,16 @@ const app3 = appCommitment({ turnNum: 3, balances: twoThree });
 const ledger4 = ledgerCommitment({ turnNum: 4, balances: twoThree, proposedBalances: fiveToApp });
 const ledger5 = ledgerCommitment({ turnNum: 5, balances: fiveToApp });
 
+const setFundingState = (sharedData: SharedData): SharedData => {
+  return {
+    ...sharedData,
+    fundingState: {
+      [channelId]: { directlyFunded: false, fundingChannel: ledgerId },
+      [ledgerId]: { directlyFunded: true },
+    },
+  };
+};
+
 // Channels
 
 const protocolLocator = NEW_LEDGER_FUNDING_PROTOCOL_LOCATOR;
@@ -72,10 +82,12 @@ const waitForPreFundSetupSharedData = _.merge(
 const waitForPostFundSharedData = _.merge(ACPreSuccess.sharedData);
 export const successState = {
   state: success({}),
-  store: setChannels(EMPTY_SHARED_DATA, [
-    channelFromCommitments([app2, app3], asAddress, asPrivateKey),
-    channelFromCommitments([ledger4, ledger5], asAddress, asPrivateKey),
-  ]),
+  store: setFundingState(
+    setChannels(EMPTY_SHARED_DATA, [
+      channelFromCommitments([app2, app3], asAddress, asPrivateKey),
+      channelFromCommitments([ledger4, ledger5], asAddress, asPrivateKey),
+    ]),
+  ),
 };
 
 const waitForDirectFundingFailure = states.waitForDirectFunding({

--- a/packages/wallet/src/redux/protocols/new-ledger-channel/reducer.ts
+++ b/packages/wallet/src/redux/protocols/new-ledger-channel/reducer.ts
@@ -309,7 +309,6 @@ function channelSpecificArgs(
 }
 
 function updateFundingState(sharedData: SharedData, appChannelId: string, ledgerId: string) {
-  // update fundingState
   const channelFundingState: ChannelFundingState = {
     directlyFunded: false,
     fundingChannel: ledgerId,


### PR DESCRIPTION
Funding state was not being set correctly so existing ledger channels were not being found when trying to fund the game with an existing ledger channel.

Fixes #622 