### PR TITLE
Fix Ledger Top Up

### DIFF
--- a/packages/wallet/src/redux/protocols/consensus-update/__tests__/index.ts
+++ b/packages/wallet/src/redux/protocols/consensus-update/__tests__/index.ts
@@ -8,6 +8,8 @@ import {
 
 export const twoPlayerPreSuccessA = twoPlayerAHappyPath.waitForUpdate;
 export const twoPlayerPreSuccessB = twoPlayerBHappyPath.waitForUpdate;
+export const twoPlayerReplyA = twoPlayerAHappyPath.initialize.reply;
+export const twoPlayerReplyB = twoPlayerBHappyPath.waitForUpdate.reply;
 
 export const threePlayerPreSuccessA = threePlayerAHappyPath.waitForHubUpdate;
 export const threePlayerPreSuccessB = threePlayerBHappyPath.waitForHubUpdate;

--- a/packages/wallet/src/redux/protocols/consensus-update/states.ts
+++ b/packages/wallet/src/redux/protocols/consensus-update/states.ts
@@ -2,7 +2,8 @@ import { StateConstructor } from '../../utils';
 import { ProtocolState } from '..';
 import { ProtocolLocator } from '../../../communication';
 
-export type ConsensusUpdateState = WaitForUpdate | Failure | Success;
+export type ConsensusUpdateState = WaitForUpdate | TerminalConsensusUpdateState;
+export type TerminalConsensusUpdateState = Failure | Success;
 export type ConsensusUpdateStateType = ConsensusUpdateState['type'];
 
 export interface WaitForUpdate {

--- a/packages/wallet/src/redux/protocols/existing-ledger-funding/__tests__/reducer.test.ts
+++ b/packages/wallet/src/redux/protocols/existing-ledger-funding/__tests__/reducer.test.ts
@@ -146,20 +146,3 @@ function itTransitionsTo(state: ReturnVal, type: states.ExistingLedgerFundingSta
     expect(state.protocolState.type).toEqual(type);
   });
 }
-
-// function itSendsMessage(state: ReturnVal, message: SignedCommitment) {
-//   it('sends a message', () => {
-//     const lastMessage = getLastMessage(state.sharedData);
-//     if (lastMessage && 'messagePayload' in lastMessage) {
-//       const dataPayload = lastMessage.messagePayload;
-//       // This is yuk. The data in a message is currently of 'any' type..
-//       if (!('signedCommitment' in dataPayload)) {
-//         fail('No signedCommitment in the last message.');
-//       }
-//       const { commitment, signature } = dataPayload.signedCommitment;
-//       expect({ commitment, signature }).toEqual(message);
-//     } else {
-//       fail('No messages in the outbox.');
-//     }
-//   });
-// }

--- a/packages/wallet/src/redux/protocols/existing-ledger-funding/__tests__/reducer.test.ts
+++ b/packages/wallet/src/redux/protocols/existing-ledger-funding/__tests__/reducer.test.ts
@@ -2,8 +2,8 @@ import * as scenarios from './scenarios';
 import { initialize, existingLedgerFundingReducer } from '../reducer';
 import * as states from '../states';
 import { ProtocolStateWithSharedData } from '../..';
-import { getLastMessage } from '../../../state';
-import { SignedCommitment } from '../../../../domain';
+// import { getLastMessage } from '../../../state';
+// import { SignedCommitment } from '../../../../domain';
 import { describeScenarioStep } from '../../../__tests__/helpers';
 
 describe('player A happy path', () => {
@@ -30,7 +30,6 @@ describe('player A happy path', () => {
       sharedData,
     );
     itTransitionsTo(result, 'ExistingLedgerFunding.WaitForLedgerUpdate');
-    itSendsMessage(result, scenario.initialize.reply);
   });
 
   describeScenarioStep(scenario.waitForLedgerUpdate, () => {
@@ -67,10 +66,9 @@ describe('player B happy path', () => {
   });
 
   describeScenarioStep(scenario.waitForLedgerUpdate, () => {
-    const { state, action, sharedData, reply } = scenario.waitForLedgerUpdate;
+    const { state, action, sharedData } = scenario.waitForLedgerUpdate;
     const updatedState = existingLedgerFundingReducer(state, sharedData, action);
     itTransitionsTo(updatedState, 'ExistingLedgerFunding.Success');
-    itSendsMessage(updatedState, reply);
   });
 });
 
@@ -151,19 +149,19 @@ function itTransitionsTo(state: ReturnVal, type: states.ExistingLedgerFundingSta
   });
 }
 
-function itSendsMessage(state: ReturnVal, message: SignedCommitment) {
-  it('sends a message', () => {
-    const lastMessage = getLastMessage(state.sharedData);
-    if (lastMessage && 'messagePayload' in lastMessage) {
-      const dataPayload = lastMessage.messagePayload;
-      // This is yuk. The data in a message is currently of 'any' type..
-      if (!('signedCommitment' in dataPayload)) {
-        fail('No signedCommitment in the last message.');
-      }
-      const { commitment, signature } = dataPayload.signedCommitment;
-      expect({ commitment, signature }).toEqual(message);
-    } else {
-      fail('No messages in the outbox.');
-    }
-  });
-}
+// function itSendsMessage(state: ReturnVal, message: SignedCommitment) {
+//   it('sends a message', () => {
+//     const lastMessage = getLastMessage(state.sharedData);
+//     if (lastMessage && 'messagePayload' in lastMessage) {
+//       const dataPayload = lastMessage.messagePayload;
+//       // This is yuk. The data in a message is currently of 'any' type..
+//       if (!('signedCommitment' in dataPayload)) {
+//         fail('No signedCommitment in the last message.');
+//       }
+//       const { commitment, signature } = dataPayload.signedCommitment;
+//       expect({ commitment, signature }).toEqual(message);
+//     } else {
+//       fail('No messages in the outbox.');
+//     }
+//   });
+// }

--- a/packages/wallet/src/redux/protocols/existing-ledger-funding/__tests__/reducer.test.ts
+++ b/packages/wallet/src/redux/protocols/existing-ledger-funding/__tests__/reducer.test.ts
@@ -2,7 +2,7 @@ import * as scenarios from './scenarios';
 import { initialize, existingLedgerFundingReducer } from '../reducer';
 import * as states from '../states';
 import { ProtocolStateWithSharedData } from '../..';
-import { describeScenarioStep } from '../../../__tests__/helpers';
+import { describeScenarioStep, itSendsTheseCommitments } from '../../../__tests__/helpers';
 
 describe('player A happy path', () => {
   const scenario = scenarios.playerAFullyFundedHappyPath;
@@ -16,6 +16,7 @@ describe('player A happy path', () => {
       targetDestination,
       protocolLocator,
       sharedData,
+      reply,
     } = scenario.initialize;
 
     const result = initialize(
@@ -28,6 +29,7 @@ describe('player A happy path', () => {
       sharedData,
     );
     itTransitionsTo(result, 'ExistingLedgerFunding.WaitForLedgerUpdate');
+    itSendsTheseCommitments(result, reply);
   });
 
   describeScenarioStep(scenario.waitForLedgerUpdate, () => {
@@ -64,8 +66,9 @@ describe('player B happy path', () => {
   });
 
   describeScenarioStep(scenario.waitForLedgerUpdate, () => {
-    const { state, action, sharedData } = scenario.waitForLedgerUpdate;
+    const { state, action, sharedData, reply } = scenario.waitForLedgerUpdate;
     const updatedState = existingLedgerFundingReducer(state, sharedData, action);
+    itSendsTheseCommitments(updatedState, reply);
     itTransitionsTo(updatedState, 'ExistingLedgerFunding.Success');
   });
 });

--- a/packages/wallet/src/redux/protocols/existing-ledger-funding/__tests__/reducer.test.ts
+++ b/packages/wallet/src/redux/protocols/existing-ledger-funding/__tests__/reducer.test.ts
@@ -2,8 +2,6 @@ import * as scenarios from './scenarios';
 import { initialize, existingLedgerFundingReducer } from '../reducer';
 import * as states from '../states';
 import { ProtocolStateWithSharedData } from '../..';
-// import { getLastMessage } from '../../../state';
-// import { SignedCommitment } from '../../../../domain';
 import { describeScenarioStep } from '../../../__tests__/helpers';
 
 describe('player A happy path', () => {

--- a/packages/wallet/src/redux/protocols/existing-ledger-funding/__tests__/scenarios.ts
+++ b/packages/wallet/src/redux/protocols/existing-ledger-funding/__tests__/scenarios.ts
@@ -12,10 +12,16 @@ import { bigNumberify } from 'ethers/utils/bignumber';
 import { SharedData, EMPTY_SHARED_DATA, setChannels } from '../../../state';
 import { channelFromCommitments } from '../../../channel-store/channel-state/__tests__';
 import * as states from '../states';
-import * as globalActions from '../../../actions';
+
 import { EXISTING_LEDGER_FUNDING_PROTOCOL_LOCATOR } from '../reducer';
 import { playerAHappyPath } from '../../ledger-top-up/__tests__/scenarios';
-
+import {
+  twoPlayerPreSuccessA as consensusUpdatePreSuccessA,
+  twoPlayerPreSuccessB as consensusUpdatePreSuccessB,
+} from '../../consensus-update/__tests__/';
+import { makeLocator, prependToLocator } from '../..';
+import { CONSENSUS_UPDATE_PROTOCOL_LOCATOR } from '../../consensus-update/reducer';
+import { commitmentsReceived } from '../../../../communication';
 const processId = 'processId';
 const oneThree = [
   { address: asAddress, wei: bigNumberify(1).toHexString() },
@@ -37,6 +43,16 @@ const props = {
   protocolLocator: EXISTING_LEDGER_FUNDING_PROTOCOL_LOCATOR,
 };
 
+const propsA = {
+  ...props,
+  consensusUpdateState: consensusUpdatePreSuccessA.state,
+};
+
+const propsB = {
+  ...props,
+  consensusUpdateState: consensusUpdatePreSuccessB.state,
+};
+
 const setFundingState = (sharedData: SharedData): SharedData => {
   return {
     ...sharedData,
@@ -53,13 +69,11 @@ const setFundingState = (sharedData: SharedData): SharedData => {
 const ledger4 = ledgerCommitment({ turnNum: 4, balances: oneThree });
 const ledger5 = ledgerCommitment({ turnNum: 5, balances: oneThree });
 const ledger6 = ledgerCommitment({ turnNum: 6, balances: oneThree, proposedBalances: fourToApp });
-const ledger7 = ledgerCommitment({ turnNum: 7, balances: fourToApp });
 const topUpLedger4 = ledgerCommitment({ turnNum: 4, balances: oneOne });
 const topUpLedger5 = ledgerCommitment({ turnNum: 5, balances: oneOne });
 
 const app0 = appCommitment({ turnNum: 0, balances: oneThree });
 const app1 = appCommitment({ turnNum: 1, balances: oneThree });
-const app3 = appCommitment({ turnNum: 3, balances: oneThree });
 // -----------
 // Shared Data
 // -----------
@@ -102,38 +116,30 @@ const initialPlayerBTopUpNeededSharedData = setFundingState(
 // -----------
 // States
 // -----------
-const waitForLedgerUpdate = states.waitForLedgerUpdate(props);
-// -----------
-// Actions
-// -----------
-const ledgerUpdate0Received = globalActions.commitmentReceived({
-  processId,
-  signedCommitment: ledger6,
-  protocolLocator: EXISTING_LEDGER_FUNDING_PROTOCOL_LOCATOR,
-});
-const ledgerUpdate1Received = globalActions.commitmentReceived({
-  processId,
-  signedCommitment: ledger7,
-  protocolLocator: EXISTING_LEDGER_FUNDING_PROTOCOL_LOCATOR,
-});
+const waitForLedgerUpdateForA = states.waitForLedgerUpdate(propsA);
+const waitForLedgerUpdateForB = states.waitForLedgerUpdate(propsB);
 
-const invalidLedgerUpdateReceived = globalActions.commitmentReceived({
+const invalidLedgerUpdateReceived = commitmentsReceived({
   processId,
-  signedCommitment: ledger5,
-  protocolLocator: EXISTING_LEDGER_FUNDING_PROTOCOL_LOCATOR,
+  signedCommitments: [ledger5],
+  protocolLocator: makeLocator(
+    EXISTING_LEDGER_FUNDING_PROTOCOL_LOCATOR,
+    CONSENSUS_UPDATE_PROTOCOL_LOCATOR,
+  ),
 });
 
 export const playerAFullyFundedHappyPath = {
   initialize: {
     sharedData: initialPlayerALedgerSharedData,
     ...props,
-    reply: ledger6,
   },
   waitForLedgerUpdate: {
-    state: waitForLedgerUpdate,
-    sharedData: playerAFirstCommitmentReceived,
-    action: ledgerUpdate1Received,
-    reply: app3,
+    state: waitForLedgerUpdateForA,
+    sharedData: consensusUpdatePreSuccessA.sharedData,
+    action: prependToLocator(
+      consensusUpdatePreSuccessA.action,
+      EXISTING_LEDGER_FUNDING_PROTOCOL_LOCATOR,
+    ),
   },
 };
 
@@ -143,16 +149,18 @@ export const playerBFullyFundedHappyPath = {
     ...props,
   },
   waitForLedgerUpdate: {
-    state: waitForLedgerUpdate,
-    sharedData: initialPlayerBLedgerSharedData,
-    action: ledgerUpdate0Received,
-    reply: ledger7,
+    state: waitForLedgerUpdateForB,
+    sharedData: consensusUpdatePreSuccessB.sharedData,
+    action: prependToLocator(
+      consensusUpdatePreSuccessB.action,
+      EXISTING_LEDGER_FUNDING_PROTOCOL_LOCATOR,
+    ),
   },
 };
 
 export const playerAInvalidUpdateCommitment = {
   waitForLedgerUpdate: {
-    state: waitForLedgerUpdate,
+    state: waitForLedgerUpdateForA,
     sharedData: playerAFirstCommitmentReceived,
     action: invalidLedgerUpdateReceived,
   },
@@ -160,7 +168,7 @@ export const playerAInvalidUpdateCommitment = {
 
 export const playerBInvalidUpdateCommitment = {
   waitForLedgerUpdate: {
-    state: waitForLedgerUpdate,
+    state: waitForLedgerUpdateForB,
     sharedData: initialPlayerBLedgerSharedData,
     action: invalidLedgerUpdateReceived,
   },
@@ -175,6 +183,7 @@ export const playerATopUpNeeded = {
     state: states.waitForLedgerTopUp({
       ...props,
       ledgerTopUpState: playerAHappyPath.switchOrderAndAddATopUpUpdate.state,
+      consensusUpdateState: consensusUpdatePreSuccessA.state,
     }),
   },
 };

--- a/packages/wallet/src/redux/protocols/existing-ledger-funding/__tests__/scenarios.ts
+++ b/packages/wallet/src/redux/protocols/existing-ledger-funding/__tests__/scenarios.ts
@@ -18,6 +18,7 @@ import { playerAHappyPath } from '../../ledger-top-up/__tests__/scenarios';
 import {
   twoPlayerPreSuccessA as consensusUpdatePreSuccessA,
   twoPlayerPreSuccessB as consensusUpdatePreSuccessB,
+  twoPlayerReplyB,
 } from '../../consensus-update/__tests__/';
 import { makeLocator, prependToLocator } from '../..';
 import { CONSENSUS_UPDATE_PROTOCOL_LOCATOR } from '../../consensus-update/reducer';
@@ -132,6 +133,7 @@ export const playerAFullyFundedHappyPath = {
   initialize: {
     sharedData: initialPlayerALedgerSharedData,
     ...props,
+    reply: [ledger5, ledger6],
   },
   waitForLedgerUpdate: {
     state: waitForLedgerUpdateForA,
@@ -155,6 +157,7 @@ export const playerBFullyFundedHappyPath = {
       consensusUpdatePreSuccessB.action,
       EXISTING_LEDGER_FUNDING_PROTOCOL_LOCATOR,
     ),
+    reply: twoPlayerReplyB,
   },
 };
 

--- a/packages/wallet/src/redux/protocols/existing-ledger-funding/reducer.ts
+++ b/packages/wallet/src/redux/protocols/existing-ledger-funding/reducer.ts
@@ -21,7 +21,11 @@ import {
   CONSENSUS_UPDATE_PROTOCOL_LOCATOR,
   consensusUpdateReducer,
 } from '../consensus-update/reducer';
-import { clearedToSend, routesToConsensusUpdate } from '../consensus-update/actions';
+import {
+  clearedToSend,
+  routesToConsensusUpdate,
+  isConsensusUpdateAction,
+} from '../consensus-update/actions';
 import {
   TerminalConsensusUpdateState,
   isTerminal,
@@ -197,7 +201,7 @@ const waitForLedgerUpdateReducer = (
   sharedData: SharedData,
   action: ExistingLedgerFundingAction,
 ) => {
-  if (!routesToConsensusUpdate(action, protocolState.protocolLocator)) {
+  if (!isConsensusUpdateAction(action)) {
     console.warn(`Expected Consensus Update action received ${action.type} instead`);
     return { protocolState, sharedData };
   }

--- a/packages/wallet/src/redux/protocols/existing-ledger-funding/reducer.ts
+++ b/packages/wallet/src/redux/protocols/existing-ledger-funding/reducer.ts
@@ -1,29 +1,33 @@
-import {
-  SharedData,
-  signAndStore,
-  queueMessage,
-  checkAndStore,
-  ChannelFundingState,
-  setFundingState,
-} from '../../state';
+import { SharedData, ChannelFundingState, setFundingState } from '../../state';
 import * as states from './states';
 import { ProtocolStateWithSharedData, makeLocator } from '..';
 import { ExistingLedgerFundingAction } from './actions';
 import * as helpers from '../reducer-helpers';
 import * as selectors from '../../selectors';
-import { proposeNewConsensus, acceptConsensus } from '../../../domain/consensus-app';
-import { theirAddress, getLastCommitment } from '../../channel-store';
+import { getLastCommitment } from '../../channel-store';
 import { Commitment } from '../../../domain';
 import { bigNumberify } from 'ethers/utils';
-import { sendCommitmentReceived, EmbeddedProtocol, ProtocolLocator } from '../../../communication';
+import { EmbeddedProtocol, ProtocolLocator } from '../../../communication';
 import { CommitmentType } from 'fmg-core';
 import {
   initialize as initializeLedgerTopUp,
   ledgerTopUpReducer,
   LEDGER_TOP_UP_PROTOCOL_LOCATOR,
 } from '../ledger-top-up/reducer';
-import { isLedgerTopUpAction } from '../ledger-top-up/actions';
+import { routesToLedgerTopUp } from '../ledger-top-up/actions';
 import { addHex } from '../../../utils/hex-utils';
+import { initializeConsensusUpdate } from '../consensus-update';
+import {
+  CONSENSUS_UPDATE_PROTOCOL_LOCATOR,
+  consensusUpdateReducer,
+} from '../consensus-update/reducer';
+import { clearedToSend, routesToConsensusUpdate } from '../consensus-update/actions';
+import {
+  TerminalConsensusUpdateState,
+  isTerminal,
+  ConsensusUpdateState,
+} from '../consensus-update/states';
+import { LedgerTopUpState } from '../ledger-top-up/states';
 export const EXISTING_LEDGER_FUNDING_PROTOCOL_LOCATOR = makeLocator(
   EmbeddedProtocol.ExistingLedgerFunding,
 );
@@ -40,8 +44,21 @@ export const initialize = (
   const ledgerChannel = selectors.getChannelState(sharedData, ledgerId);
   const theirCommitment = getLastCommitment(ledgerChannel);
 
+  const appFunding = craftAppFunding(sharedData, channelId);
+  let consensusUpdateState: ConsensusUpdateState;
+  ({ sharedData, protocolState: consensusUpdateState } = initializeConsensusUpdate(
+    processId,
+    ledgerId,
+    false,
+    appFunding.proposedAllocation,
+    appFunding.proposedDestination,
+    makeLocator(protocolLocator, CONSENSUS_UPDATE_PROTOCOL_LOCATOR),
+    sharedData,
+  ));
+
   if (ledgerChannelNeedsTopUp(theirCommitment, targetAllocation, targetDestination)) {
-    const { protocolState: ledgerTopUpState, sharedData: newSharedData } = initializeLedgerTopUp(
+    let ledgerTopUpState: LedgerTopUpState;
+    ({ protocolState: ledgerTopUpState, sharedData } = initializeLedgerTopUp(
       processId,
       channelId,
       ledgerId,
@@ -50,7 +67,8 @@ export const initialize = (
       theirCommitment.allocation,
       makeLocator(protocolLocator, LEDGER_TOP_UP_PROTOCOL_LOCATOR),
       sharedData,
-    );
+    ));
+
     return {
       protocolState: states.waitForLedgerTopUp({
         ledgerTopUpState,
@@ -60,47 +78,32 @@ export const initialize = (
         targetAllocation,
         targetDestination,
         protocolLocator,
+        consensusUpdateState,
       }),
-      sharedData: newSharedData,
+      sharedData,
     };
   }
-
-  if (helpers.isFirstPlayer(ledgerId, sharedData)) {
-    const appFunding = craftAppFunding(sharedData, channelId);
-    const ourCommitment = proposeNewConsensus(
-      theirCommitment,
-      appFunding.proposedAllocation,
-      appFunding.proposedDestination,
-    );
-    const signResult = signAndStore(sharedData, ourCommitment);
-    if (!signResult.isSuccess) {
-      return {
-        protocolState: states.failure({ reason: 'ReceivedInvalidCommitment' }),
-        sharedData,
-      };
-    }
-    sharedData = signResult.store;
-
-    const messageRelay = sendCommitmentReceived(
-      theirAddress(ledgerChannel),
+  // If the ledger channel does not need a top up we can start exchanging consensus commitments
+  ({ sharedData, protocolState: consensusUpdateState } = consensusUpdateReducer(
+    consensusUpdateState,
+    sharedData,
+    clearedToSend({
+      protocolLocator: makeLocator(protocolLocator, CONSENSUS_UPDATE_PROTOCOL_LOCATOR),
       processId,
-      signResult.signedCommitment.commitment,
-      signResult.signedCommitment.signature,
-      makeLocator(protocolLocator, EXISTING_LEDGER_FUNDING_PROTOCOL_LOCATOR),
-    );
-    sharedData = queueMessage(sharedData, messageRelay);
-  }
-
-  const protocolState = states.waitForLedgerUpdate({
-    processId,
-    ledgerId,
-    channelId,
-    targetAllocation,
-    targetDestination,
-    protocolLocator,
-  });
-
-  return { protocolState, sharedData };
+    }),
+  ));
+  return {
+    protocolState: states.waitForLedgerUpdate({
+      processId,
+      ledgerId,
+      channelId,
+      targetAllocation,
+      targetDestination,
+      consensusUpdateState,
+      protocolLocator,
+    }),
+    sharedData,
+  };
 };
 
 export const existingLedgerFundingReducer = (
@@ -122,61 +125,68 @@ const waitForLedgerTopUpReducer = (
   sharedData: SharedData,
   action: ExistingLedgerFundingAction,
 ): ProtocolStateWithSharedData<states.ExistingLedgerFundingState> => {
-  if (!isLedgerTopUpAction(action)) {
-    console.warn(`Expected a ledger top up action.`);
-  }
-  const { protocolState: ledgerTopUpState, sharedData: newSharedData } = ledgerTopUpReducer(
-    protocolState.ledgerTopUpState,
-    sharedData,
-    action,
-  );
-  sharedData = newSharedData;
-
-  if (ledgerTopUpState.type === 'LedgerTopUp.Failure') {
-    return {
-      protocolState: states.failure({ reason: 'LedgerTopUpFailure' }),
+  if (routesToConsensusUpdate(action, protocolState.protocolLocator)) {
+    const consensusUpdateResult = consensusUpdateReducer(
+      protocolState.consensusUpdateState,
       sharedData,
+      action,
+    );
+    return {
+      protocolState: {
+        ...protocolState,
+        consensusUpdateState: consensusUpdateResult.protocolState,
+      },
+      sharedData: consensusUpdateResult.sharedData,
     };
-  } else if (ledgerTopUpState.type === 'LedgerTopUp.Success') {
-    const { ledgerId, processId } = protocolState;
-    const ledgerChannel = selectors.getChannelState(sharedData, ledgerId);
-    const theirCommitment = getLastCommitment(ledgerChannel);
+  } else if (routesToLedgerTopUp(action, protocolState.protocolLocator)) {
+    const { protocolState: ledgerTopUpState, sharedData: newSharedData } = ledgerTopUpReducer(
+      protocolState.ledgerTopUpState,
+      sharedData,
+      action,
+    );
+    sharedData = newSharedData;
 
-    if (helpers.isFirstPlayer(ledgerId, sharedData)) {
-      const appFunding = craftAppFunding(sharedData, protocolState.channelId);
-      const ourCommitment = proposeNewConsensus(
-        theirCommitment,
-        appFunding.proposedAllocation,
-        appFunding.proposedDestination,
+    if (ledgerTopUpState.type === 'LedgerTopUp.Failure') {
+      return {
+        protocolState: states.failure({ reason: 'LedgerTopUpFailure' }),
+        sharedData,
+      };
+    } else if (ledgerTopUpState.type === 'LedgerTopUp.Success') {
+      const { protocolLocator, processId } = protocolState;
+      const consensusUpdateResult = consensusUpdateReducer(
+        protocolState.consensusUpdateState,
+        sharedData,
+        clearedToSend({
+          protocolLocator: makeLocator(protocolLocator, CONSENSUS_UPDATE_PROTOCOL_LOCATOR),
+          processId,
+        }),
       );
-      const signResult = signAndStore(sharedData, ourCommitment);
-      if (!signResult.isSuccess) {
+      sharedData = consensusUpdateResult.sharedData;
+      if (isTerminal(consensusUpdateResult.protocolState)) {
+        return handleTerminalConsensusUpdate(
+          protocolState.channelId,
+          protocolState.ledgerId,
+          consensusUpdateResult.protocolState,
+          sharedData,
+        );
+      } else {
         return {
-          protocolState: states.failure({
-            reason: 'ReceivedInvalidCommitment',
+          protocolState: states.waitForLedgerUpdate({
+            ...protocolState,
+            consensusUpdateState: consensusUpdateResult.protocolState,
           }),
           sharedData,
         };
       }
-      sharedData = signResult.store;
-
-      const messageRelay = sendCommitmentReceived(
-        theirAddress(ledgerChannel),
-        processId,
-        signResult.signedCommitment.commitment,
-        signResult.signedCommitment.signature,
-        makeLocator(protocolState.protocolLocator, EmbeddedProtocol.ExistingLedgerFunding),
-      );
-      sharedData = queueMessage(sharedData, messageRelay);
+    } else {
+      return {
+        protocolState: states.waitForLedgerTopUp({ ...protocolState, ledgerTopUpState }),
+        sharedData,
+      };
     }
-
-    return {
-      protocolState: states.waitForLedgerUpdate(protocolState),
-      sharedData,
-    };
   } else {
     return {
-      protocolState: states.waitForLedgerTopUp({ ...protocolState, ledgerTopUpState }),
+      protocolState,
       sharedData,
     };
   }
@@ -187,50 +197,32 @@ const waitForLedgerUpdateReducer = (
   sharedData: SharedData,
   action: ExistingLedgerFundingAction,
 ) => {
-  if (action.type !== 'WALLET.COMMON.COMMITMENT_RECEIVED') {
+  if (!routesToConsensusUpdate(action, protocolState.protocolLocator)) {
+    console.warn(`Expected Consensus Update action received ${action.type} instead`);
     return { protocolState, sharedData };
   }
-  const { ledgerId, processId } = protocolState;
-  let newSharedData = { ...sharedData };
-  const ledgerChannel = selectors.getChannelState(sharedData, ledgerId);
-  const theirCommitment = action.signedCommitment.commitment;
-
-  const checkResult = checkAndStore(newSharedData, action.signedCommitment);
-  if (!checkResult.isSuccess) {
+  const consensusUpdateResult = consensusUpdateReducer(
+    protocolState.consensusUpdateState,
+    sharedData,
+    action,
+  );
+  sharedData = consensusUpdateResult.sharedData;
+  if (isTerminal(consensusUpdateResult.protocolState)) {
+    return handleTerminalConsensusUpdate(
+      protocolState.channelId,
+      protocolState.ledgerId,
+      consensusUpdateResult.protocolState,
+      sharedData,
+    );
+  } else {
     return {
-      protocolState: states.failure({ reason: 'ReceivedInvalidCommitment' }),
+      protocolState: {
+        ...protocolState,
+        consensusUpdateState: consensusUpdateResult.protocolState,
+      },
       sharedData,
     };
   }
-  newSharedData = checkResult.store;
-  if (!helpers.isFirstPlayer(protocolState.ledgerId, newSharedData)) {
-    const ourCommitment = acceptConsensus(theirCommitment);
-    const signResult = signAndStore(newSharedData, ourCommitment);
-    if (!signResult.isSuccess) {
-      return {
-        protocolState: states.failure({ reason: 'ReceivedInvalidCommitment' }),
-        sharedData,
-      };
-    }
-    newSharedData = signResult.store;
-
-    const messageRelay = sendCommitmentReceived(
-      theirAddress(ledgerChannel),
-      processId,
-      signResult.signedCommitment.commitment,
-      signResult.signedCommitment.signature,
-      makeLocator(protocolState.protocolLocator, EXISTING_LEDGER_FUNDING_PROTOCOL_LOCATOR),
-    );
-    newSharedData = queueMessage(newSharedData, messageRelay);
-  }
-  const fundingState: ChannelFundingState = {
-    directlyFunded: false,
-    fundingChannel: protocolState.ledgerId,
-  };
-
-  newSharedData = setFundingState(newSharedData, protocolState.channelId, fundingState);
-
-  return { protocolState: states.success({}), sharedData: newSharedData };
 };
 
 function ledgerChannelNeedsTopUp(
@@ -258,6 +250,7 @@ function ledgerChannelNeedsTopUp(
   }
   return false;
 }
+
 function craftAppFunding(
   sharedData: SharedData,
   appChannelId: string,
@@ -268,4 +261,29 @@ function craftAppFunding(
     proposedAllocation: [total],
     proposedDestination: [appChannelId],
   };
+}
+
+function handleTerminalConsensusUpdate(
+  channelId: string,
+  ledgerId: string,
+  consensusUpdateState: TerminalConsensusUpdateState,
+  sharedData: SharedData,
+) {
+  if (consensusUpdateState.type === 'ConsensusUpdate.Failure') {
+    return {
+      protocolState: states.failure({ reason: 'LedgerTopUpFailure' }),
+      sharedData,
+    };
+  } else {
+    const fundingState: ChannelFundingState = {
+      directlyFunded: false,
+      fundingChannel: ledgerId,
+    };
+
+    sharedData = setFundingState(sharedData, channelId, fundingState);
+    return {
+      protocolState: states.success({}),
+      sharedData,
+    };
+  }
 }

--- a/packages/wallet/src/redux/protocols/existing-ledger-funding/states.ts
+++ b/packages/wallet/src/redux/protocols/existing-ledger-funding/states.ts
@@ -1,6 +1,7 @@
 import { StateConstructor } from '../../utils';
 import { ProtocolState } from '..';
 import { ProtocolLocator } from '../../../communication';
+import { ConsensusUpdateState } from '../consensus-update';
 
 export type FailureReason =
   | 'ReceivedInvalidCommitment'
@@ -17,6 +18,7 @@ export interface WaitForLedgerTopUp {
   targetAllocation: string[];
   targetDestination: string[];
   protocolLocator: ProtocolLocator;
+  consensusUpdateState: ConsensusUpdateState;
 }
 
 export interface WaitForLedgerUpdate {
@@ -27,6 +29,7 @@ export interface WaitForLedgerUpdate {
   targetAllocation: string[];
   targetDestination: string[];
   protocolLocator: ProtocolLocator;
+  consensusUpdateState: ConsensusUpdateState;
 }
 
 export interface Failure {

--- a/packages/wallet/src/redux/protocols/indirect-funding/reducer.ts
+++ b/packages/wallet/src/redux/protocols/indirect-funding/reducer.ts
@@ -4,11 +4,12 @@ import * as selectors from '../../selectors';
 import * as helpers from '../reducer-helpers';
 import { getLastCommitment, ChannelState } from '../../channel-store/channel-state';
 import { CommitmentType } from 'fmg-core';
+import { isExistingLedgerFundingAction } from '../existing-ledger-funding';
+// TODO: Why does importing the reducer from the index result in test failures in grand parent protocols?
 import {
-  initializeExistingLedgerFunding,
-  isExistingLedgerFundingAction,
+  initialize as initializeExistingLedgerFunding,
   existingLedgerFundingReducer,
-} from '../existing-ledger-funding';
+} from '../existing-ledger-funding/reducer';
 import * as states from './states';
 import { isNewLedgerChannelAction, NewLedgerChannelReducer } from '../new-ledger-channel';
 import { unreachable } from '../../../utils/reducer-utils';

--- a/packages/wallet/src/redux/protocols/ledger-top-up/__tests__/reducer.test.ts
+++ b/packages/wallet/src/redux/protocols/ledger-top-up/__tests__/reducer.test.ts
@@ -49,11 +49,6 @@ describe('player A happy path', () => {
     const { action, sharedData, state } = scenario.waitForDirectFundingForA;
     const updatedState = ledgerTopUpReducer(state, sharedData, action);
     itTransitionsTo(updatedState, 'LedgerTopUp.RestoreOrderAndAddBTopUpUpdate');
-    it('requests the correct allocation/destination updates', () => {
-      const consensusUpdate = getProposedConsensus(updatedState.protocolState);
-      expect(consensusUpdate.proposedAllocation).toEqual(['0x04', '0x05']);
-      expect(consensusUpdate.proposedDestination).toEqual([asAddress, bsAddress]);
-    });
   });
   describeScenarioStep(scenario.restoreOrderAndAddBTopUpUpdate, () => {
     const { action, sharedData, state } = scenario.restoreOrderAndAddBTopUpUpdate;
@@ -115,11 +110,6 @@ describe('player B happy path', () => {
     const { action, sharedData, state } = scenario.waitForDirectFundingForA;
     const updatedState = ledgerTopUpReducer(state, sharedData, action);
     itTransitionsTo(updatedState, 'LedgerTopUp.RestoreOrderAndAddBTopUpUpdate');
-    it('requests the correct allocation/destination updates', () => {
-      const consensusUpdate = getProposedConsensus(updatedState.protocolState);
-      expect(consensusUpdate.proposedAllocation).toEqual(['0x04', '0x05']);
-      expect(consensusUpdate.proposedDestination).toEqual([asAddress, bsAddress]);
-    });
   });
   describeScenarioStep(scenario.restoreOrderAndAddBTopUpUpdate, () => {
     const { action, sharedData, state } = scenario.restoreOrderAndAddBTopUpUpdate;
@@ -181,11 +171,6 @@ describe('player A one user needs top up', () => {
     const { action, sharedData, state } = scenario.waitForDirectFundingForA;
     const updatedState = ledgerTopUpReducer(state, sharedData, action);
     itTransitionsTo(updatedState, 'LedgerTopUp.RestoreOrderAndAddBTopUpUpdate');
-    it('requests the correct allocation/destination updates', () => {
-      const consensusUpdate = getProposedConsensus(updatedState.protocolState);
-      expect(consensusUpdate.proposedAllocation).toEqual(['0x04', '0x03']);
-      expect(consensusUpdate.proposedDestination).toEqual([asAddress, bsAddress]);
-    });
   });
   describeScenarioStep(scenario.restoreOrderAndAddBTopUpUpdate, () => {
     const { action, sharedData, state } = scenario.restoreOrderAndAddBTopUpUpdate;
@@ -238,11 +223,6 @@ describe('player B one user needs top up', () => {
     const { action, sharedData, state } = scenario.waitForDirectFundingForA;
     const updatedState = ledgerTopUpReducer(state, sharedData, action);
     itTransitionsTo(updatedState, 'LedgerTopUp.RestoreOrderAndAddBTopUpUpdate');
-    it('requests the correct allocation/destination updates', () => {
-      const consensusUpdate = getProposedConsensus(updatedState.protocolState);
-      expect(consensusUpdate.proposedAllocation).toEqual(['0x04', '0x03']);
-      expect(consensusUpdate.proposedDestination).toEqual([asAddress, bsAddress]);
-    });
   });
   describeScenarioStep(scenario.restoreOrderAndAddBTopUpUpdate, () => {
     const { action, sharedData, state } = scenario.restoreOrderAndAddBTopUpUpdate;

--- a/packages/wallet/src/redux/protocols/ledger-top-up/__tests__/scenarios.ts
+++ b/packages/wallet/src/redux/protocols/ledger-top-up/__tests__/scenarios.ts
@@ -76,6 +76,7 @@ const waitForDirectFundingForA = props =>
   states.waitForDirectFundingForA({
     ...props,
     directFundingState: preSuccessA.state,
+    consensusUpdateState: twoPlayerPreSuccessA.state,
   });
 const restoreOrderAndAddBTopUpUpdate = props =>
   states.restoreOrderAndAddBTopUpUpdate({

--- a/packages/wallet/src/redux/protocols/ledger-top-up/reducer.ts
+++ b/packages/wallet/src/redux/protocols/ledger-top-up/reducer.ts
@@ -14,11 +14,14 @@ import {
   initializeConsensusUpdate,
   isConsensusUpdateAction,
   consensusUpdateReducer,
+  ConsensusUpdateState,
 } from '../consensus-update';
 import { bigNumberify } from 'ethers/utils';
 import { PlayerIndex } from 'magmo-wallet-client/lib/wallet-instructions';
 import { ProtocolLocator, EmbeddedProtocol } from '../../../communication';
 import { CONSENSUS_UPDATE_PROTOCOL_LOCATOR } from '../consensus-update/reducer';
+import { DirectFundingState } from '../direct-funding/states';
+import { clearedToSend } from '../consensus-update/actions';
 export const LEDGER_TOP_UP_PROTOCOL_LOCATOR = makeLocator(EmbeddedProtocol.LedgerTopUp);
 export function initialize(
   processId: string,
@@ -39,6 +42,7 @@ export function initialize(
     proposedDestination,
     originalAllocation,
     protocolLocator,
+    true,
     sharedData,
   );
   const newProtocolState = states.switchOrderAndAddATopUpUpdate({
@@ -115,11 +119,13 @@ const switchOrderAndAddATopUpUpdateReducer: ProtocolReducer<states.LedgerTopUpSt
     console.warn(`Received non consensus update action in ${protocolState.type} state.`);
     return { protocolState, sharedData };
   }
-  const {
-    protocolState: consensusUpdateState,
-    sharedData: consensusUpdateSharedData,
-  } = consensusUpdateReducer(protocolState.consensusUpdateState, sharedData, action);
-  sharedData = consensusUpdateSharedData;
+
+  let consensusUpdateState: ConsensusUpdateState;
+  ({ protocolState: consensusUpdateState, sharedData } = consensusUpdateReducer(
+    protocolState.consensusUpdateState,
+    sharedData,
+    action,
+  ));
 
   const {
     processId,
@@ -133,53 +139,50 @@ const switchOrderAndAddATopUpUpdateReducer: ProtocolReducer<states.LedgerTopUpSt
   if (consensusUpdateState.type === 'ConsensusUpdate.Failure') {
     return {
       protocolState: states.failure({ reason: 'ConsensusUpdateFailure' }),
-      sharedData: consensusUpdateSharedData,
+      sharedData,
     };
   } else if (consensusUpdateState.type === 'ConsensusUpdate.Success') {
-    // If player A already has enough funds we skip straight to the next ledger update step
-    if (
-      bigNumberify(originalAllocation[TwoPartyPlayerIndex.A]).gte(
-        proposedAllocation[TwoPartyPlayerIndex.A],
-      )
-    ) {
-      const {
-        consensusUpdateState: consensusUpdateStateForB,
-        sharedData: newSharedData,
-      } = initializeConsensusState(
-        TwoPartyPlayerIndex.B,
-        processId,
-        ledgerId,
-        proposedAllocation,
-        proposedDestination,
-        lastCommitment.allocation,
-        protocolState.protocolLocator,
-        consensusUpdateSharedData,
-      );
+    const playerAFunded = bigNumberify(originalAllocation[TwoPartyPlayerIndex.A]).gte(
+      proposedAllocation[TwoPartyPlayerIndex.A],
+    );
 
+    ({ consensusUpdateState, sharedData } = initializeConsensusState(
+      TwoPartyPlayerIndex.B,
+      processId,
+      ledgerId,
+      proposedAllocation,
+      proposedDestination,
+      lastCommitment.allocation,
+      protocolState.protocolLocator,
+      playerAFunded,
+      sharedData,
+    ));
+    if (playerAFunded) {
       return {
         protocolState: states.restoreOrderAndAddBTopUpUpdate({
           ...protocolState,
-          consensusUpdateState: consensusUpdateStateForB,
+          consensusUpdateState,
         }),
-        sharedData: newSharedData,
+        sharedData,
       };
     }
-
-    const {
-      directFundingState,
-      sharedData: directFundingSharedData,
-    } = initializeDirectFundingState(
+    let directFundingState: DirectFundingState;
+    ({ directFundingState, sharedData } = initializeDirectFundingState(
       TwoPartyPlayerIndex.A,
       processId,
       ledgerId,
       proposedAllocation,
       originalAllocation,
       sharedData,
-    );
+    ));
 
     return {
-      protocolState: states.waitForDirectFundingForA({ ...protocolState, directFundingState }),
-      sharedData: directFundingSharedData,
+      protocolState: states.waitForDirectFundingForA({
+        ...protocolState,
+        directFundingState,
+        consensusUpdateState,
+      }),
+      sharedData,
     };
   } else {
     return {
@@ -196,45 +199,47 @@ const waitForDirectFundingForAReducer: ProtocolReducer<states.LedgerTopUpState> 
   sharedData: SharedData,
   action: LedgerTopUpAction,
 ): ProtocolStateWithSharedData<states.LedgerTopUpState> => {
-  if (!isDirectFundingAction(action)) {
-    console.warn(`Received non direct funding action in ${protocolState.type} state.`);
-    return { protocolState, sharedData };
-  }
-
-  const {
-    protocolState: directFundingState,
-    sharedData: directFundingSharedData,
-  } = directFundingStateReducer(protocolState.directFundingState, sharedData, action);
-
-  sharedData = directFundingSharedData;
-
-  const lastCommitment = helpers.getLatestCommitment(protocolState.ledgerId, sharedData);
-  const { ledgerId, processId, proposedAllocation, proposedDestination } = protocolState;
-
-  if (directFundingState.type === 'DirectFunding.FundingFailure') {
-    return { protocolState: states.failure({ reason: 'DirectFundingFailure' }), sharedData };
-  } else if (directFundingState.type === 'DirectFunding.FundingSuccess') {
-    const { consensusUpdateState, sharedData: newSharedData } = initializeConsensusState(
-      TwoPartyPlayerIndex.B,
-      processId,
-      ledgerId,
-      proposedAllocation,
-      proposedDestination,
-      lastCommitment.allocation,
-      protocolState.protocolLocator,
+  if (isDirectFundingAction(action)) {
+    let directFundingState: DirectFundingState;
+    ({ protocolState: directFundingState, sharedData } = directFundingStateReducer(
+      protocolState.directFundingState,
       sharedData,
-    );
+      action,
+    ));
 
-    const newProtocolState = states.restoreOrderAndAddBTopUpUpdate({
-      ...protocolState,
-      consensusUpdateState,
-    });
-    return {
-      protocolState: newProtocolState,
-      sharedData: newSharedData,
-    };
+    const { protocolLocator, processId } = protocolState;
+    if (directFundingState.type === 'DirectFunding.FundingFailure') {
+      return { protocolState: states.failure({ reason: 'DirectFundingFailure' }), sharedData };
+    } else if (directFundingState.type === 'DirectFunding.FundingSuccess') {
+      let consensusUpdateState: ConsensusUpdateState;
+      ({ protocolState: consensusUpdateState, sharedData } = consensusUpdateReducer(
+        protocolState.consensusUpdateState,
+        sharedData,
+        clearedToSend({
+          protocolLocator: makeLocator(protocolLocator, CONSENSUS_UPDATE_PROTOCOL_LOCATOR),
+          processId,
+        }),
+      ));
+      return {
+        protocolState: states.restoreOrderAndAddBTopUpUpdate({
+          ...protocolState,
+          consensusUpdateState,
+        }),
+        sharedData,
+      };
+    } else {
+      return { protocolState: { ...protocolState, directFundingState }, sharedData };
+    }
+  } else if (isConsensusUpdateAction(action)) {
+    let consensusUpdateState: ConsensusUpdateState;
+    ({ protocolState: consensusUpdateState, sharedData } = consensusUpdateReducer(
+      protocolState.consensusUpdateState,
+      sharedData,
+      action,
+    ));
+    return { protocolState: { ...protocolState, consensusUpdateState }, sharedData };
   } else {
-    return { protocolState: { ...protocolState, directFundingState }, sharedData };
+    return { protocolState, sharedData };
   }
 };
 
@@ -341,6 +346,7 @@ function initializeConsensusState(
   proposedDestination: string[],
   currentAllocation: string[],
   protocolLocator: ProtocolLocator,
+  canSend: boolean,
   sharedData: SharedData,
 ) {
   let newAllocation;
@@ -378,7 +384,7 @@ function initializeConsensusState(
   } = initializeConsensusUpdate(
     processId,
     ledgerId,
-    true,
+    canSend,
     newAllocation,
     newDestination,
     makeLocator(protocolLocator, CONSENSUS_UPDATE_PROTOCOL_LOCATOR),

--- a/packages/wallet/src/redux/protocols/ledger-top-up/reducer.ts
+++ b/packages/wallet/src/redux/protocols/ledger-top-up/reducer.ts
@@ -18,6 +18,7 @@ import {
 import { bigNumberify } from 'ethers/utils';
 import { PlayerIndex } from 'magmo-wallet-client/lib/wallet-instructions';
 import { ProtocolLocator, EmbeddedProtocol } from '../../../communication';
+import { CONSENSUS_UPDATE_PROTOCOL_LOCATOR } from '../consensus-update/reducer';
 export const LEDGER_TOP_UP_PROTOCOL_LOCATOR = makeLocator(EmbeddedProtocol.LedgerTopUp);
 export function initialize(
   processId: string,
@@ -380,7 +381,7 @@ function initializeConsensusState(
     true,
     newAllocation,
     newDestination,
-    makeLocator(protocolLocator, EmbeddedProtocol.LedgerTopUp),
+    makeLocator(protocolLocator, CONSENSUS_UPDATE_PROTOCOL_LOCATOR),
     sharedData,
   );
   return { consensusUpdateState, sharedData: newSharedData };

--- a/packages/wallet/src/redux/protocols/ledger-top-up/reducer.ts
+++ b/packages/wallet/src/redux/protocols/ledger-top-up/reducer.ts
@@ -208,27 +208,28 @@ const waitForDirectFundingForAReducer: ProtocolReducer<states.LedgerTopUpState> 
     ));
 
     const { protocolLocator, processId } = protocolState;
-    if (directFundingState.type === 'DirectFunding.FundingFailure') {
-      return { protocolState: states.failure({ reason: 'DirectFundingFailure' }), sharedData };
-    } else if (directFundingState.type === 'DirectFunding.FundingSuccess') {
-      let consensusUpdateState: ConsensusUpdateState;
-      ({ protocolState: consensusUpdateState, sharedData } = consensusUpdateReducer(
-        protocolState.consensusUpdateState,
-        sharedData,
-        clearedToSend({
-          protocolLocator: makeLocator(protocolLocator, CONSENSUS_UPDATE_PROTOCOL_LOCATOR),
-          processId,
-        }),
-      ));
-      return {
-        protocolState: states.restoreOrderAndAddBTopUpUpdate({
-          ...protocolState,
-          consensusUpdateState,
-        }),
-        sharedData,
-      };
-    } else {
-      return { protocolState: { ...protocolState, directFundingState }, sharedData };
+    switch (directFundingState.type) {
+      case 'DirectFunding.FundingFailure':
+        return { protocolState: states.failure({ reason: 'DirectFundingFailure' }), sharedData };
+      case 'DirectFunding.FundingSuccess':
+        let consensusUpdateState: ConsensusUpdateState;
+        ({ protocolState: consensusUpdateState, sharedData } = consensusUpdateReducer(
+          protocolState.consensusUpdateState,
+          sharedData,
+          clearedToSend({
+            protocolLocator: makeLocator(protocolLocator, CONSENSUS_UPDATE_PROTOCOL_LOCATOR),
+            processId,
+          }),
+        ));
+        return {
+          protocolState: states.restoreOrderAndAddBTopUpUpdate({
+            ...protocolState,
+            consensusUpdateState,
+          }),
+          sharedData,
+        };
+      default:
+        return { protocolState: { ...protocolState, directFundingState }, sharedData };
     }
   } else if (isConsensusUpdateAction(action)) {
     let consensusUpdateState: ConsensusUpdateState;

--- a/packages/wallet/src/redux/protocols/ledger-top-up/states.ts
+++ b/packages/wallet/src/redux/protocols/ledger-top-up/states.ts
@@ -13,6 +13,7 @@ export interface WaitForDirectFundingForA {
   originalAllocation: string[];
   protocolLocator: ProtocolLocator;
   directFundingState: DirectFundingState;
+  consensusUpdateState: ConsensusUpdateState;
 }
 
 export interface WaitForDirectFundingForB {

--- a/packages/wallet/src/redux/protocols/virtual-funding/__tests__/reducer.test.ts
+++ b/packages/wallet/src/redux/protocols/virtual-funding/__tests__/reducer.test.ts
@@ -8,7 +8,6 @@ import {
 } from '../../../__tests__/helpers';
 import { preFund, postFund } from '../../advance-channel/__tests__';
 import { CONSENSUS_LIBRARY_ADDRESS } from '../../../../constants';
-import { bytesFromAppAttributes } from 'fmg-nitro-adjudicator/lib/consensus-app';
 import { bigNumberify } from 'ethers/utils';
 
 const itTransitionsTo = (
@@ -124,8 +123,8 @@ describe('happyPath', () => {
   });
 
   describe(scenarioStepDescription(scenario.fundG), () => {
-    const { state, sharedData, action, appChannelId } = scenario.fundG;
-    const { protocolState, sharedData: result } = reducer(state, sharedData, action);
+    const { state, sharedData, action } = scenario.fundG;
+    const { protocolState } = reducer(state, sharedData, action);
 
     itTransitionsTo(protocolState, 'VirtualFunding.WaitForApplicationFunding');
     itTransitionsSubstateTo(
@@ -133,21 +132,9 @@ describe('happyPath', () => {
       'indirectApplicationFunding',
       'ConsensusUpdate.WaitForUpdate',
     );
-    itSendsTheseCommitments(result, [
-      { commitment: { turnNum: 7 } },
-      {
-        commitment: {
-          turnNum: 8,
-          destination: [appChannelId],
-          allocation: [bigNumberify(4).toHexString()],
-          appAttributes: bytesFromAppAttributes({
-            proposedAllocation: [bigNumberify(5).toHexString()],
-            proposedDestination: [appChannelId],
-            furtherVotesRequired: 1,
-          }),
-        },
-      },
-    ]);
+    // TODO: Now that existing ledger funding is using consensus update
+    // We can't test directly for the commitments since we get back
+    // consensus update pre-success
   });
 
   describe(scenarioStepDescription(scenario.fundApp), () => {

--- a/packages/wallet/src/redux/protocols/virtual-funding/__tests__/reducer.test.ts
+++ b/packages/wallet/src/redux/protocols/virtual-funding/__tests__/reducer.test.ts
@@ -132,9 +132,6 @@ describe('happyPath', () => {
       'indirectApplicationFunding',
       'ConsensusUpdate.WaitForUpdate',
     );
-    // TODO: Now that existing ledger funding is using consensus update
-    // We can't test directly for the commitments since we get back
-    // consensus update pre-success
   });
 
   describe(scenarioStepDescription(scenario.fundApp), () => {


### PR DESCRIPTION
Two main changes in this PR:
- Refactor Existing Ledger Funding to use Consensus Update
- Start Consensus Update protocol early in Ledger Top Up to handle commitments that might come in before we get a `FUNDING_RECEIVED` event.

Fixes #625 