### PR TITLE
Clean up initializers

### DIFF
--- a/packages/wallet/src/redux/protocols/advance-channel/__tests__/reducer.test.ts
+++ b/packages/wallet/src/redux/protocols/advance-channel/__tests__/reducer.test.ts
@@ -1,7 +1,6 @@
 import * as states from '../states';
 import { initialize, reducer } from '../reducer';
 import * as scenarios from './scenarios';
-import { CommitmentType } from '../../../../domain';
 import {
   itSendsTheseCommitments,
   itStoresThisCommitment,
@@ -24,12 +23,7 @@ describe('sending preFundSetup as A', () => {
 
   describe('when initializing', () => {
     const { sharedData, commitments, args } = scenario.initialize;
-    const { protocolState, sharedData: result } = initialize(
-      processId,
-      sharedData,
-      CommitmentType.PreFundSetup,
-      args,
-    );
+    const { protocolState, sharedData: result } = initialize(sharedData, args);
 
     itTransitionsTo(protocolState, 'AdvanceChannel.CommitmentSent');
     itSendsTheseCommitments(result, commitments);
@@ -63,12 +57,7 @@ describe('sending preFundSetup as B', () => {
 
   describe('when initializing', () => {
     const { sharedData, args } = scenario.initialize;
-    const { protocolState, sharedData: result } = initialize(
-      processId,
-      sharedData,
-      CommitmentType.PreFundSetup,
-      args,
-    );
+    const { protocolState, sharedData: result } = initialize(sharedData, args);
 
     itTransitionsTo(protocolState, 'AdvanceChannel.ChannelUnknown');
     itSendsNoMessage(result);
@@ -100,12 +89,7 @@ describe('sending preFundSetup as Hub', () => {
 
   describe('when initializing', () => {
     const { sharedData, args } = scenario.initialize;
-    const { protocolState, sharedData: result } = initialize(
-      processId,
-      sharedData,
-      CommitmentType.PreFundSetup,
-      args,
-    );
+    const { protocolState, sharedData: result } = initialize(sharedData, args);
 
     itTransitionsTo(protocolState, 'AdvanceChannel.ChannelUnknown');
     itSendsNoMessage(result);
@@ -133,16 +117,10 @@ describe('sending preFundSetup as Hub', () => {
 
 describe('sending postFundSetup as A', () => {
   const scenario = scenarios.existingChannelAsA;
-  const { processId, commitmentType } = scenario;
 
   describe('when initializing', () => {
     const { sharedData, commitments, args } = scenario.initialize;
-    const { protocolState, sharedData: result } = initialize(
-      processId,
-      sharedData,
-      commitmentType,
-      args,
-    );
+    const { protocolState, sharedData: result } = initialize(sharedData, args);
 
     itTransitionsTo(protocolState, 'AdvanceChannel.CommitmentSent');
     itSendsTheseCommitments(result, commitments);
@@ -170,16 +148,10 @@ describe('sending postFundSetup as A', () => {
 
 describe('sending postFundSetup as B', () => {
   const scenario = scenarios.existingChannelAsB;
-  const { processId, commitmentType } = scenario;
 
   describe('when initializing', () => {
     const { sharedData, commitments, args } = scenario.initialize;
-    const { protocolState, sharedData: result } = initialize(
-      processId,
-      sharedData,
-      commitmentType,
-      args,
-    );
+    const { protocolState, sharedData: result } = initialize(sharedData, args);
 
     itTransitionsTo(protocolState, 'AdvanceChannel.NotSafeToSend');
     itSendsNoMessage(result);
@@ -208,16 +180,10 @@ describe('sending postFundSetup as B', () => {
 
 describe('sending postFundSetup as Hub', () => {
   const scenario = scenarios.existingChannelAsHub;
-  const { processId, commitmentType } = scenario;
 
   describe('when initializing', () => {
     const { sharedData, commitments, args } = scenario.initialize;
-    const { protocolState, sharedData: result } = initialize(
-      processId,
-      sharedData,
-      commitmentType,
-      args,
-    );
+    const { protocolState, sharedData: result } = initialize(sharedData, args);
 
     itTransitionsTo(protocolState, 'AdvanceChannel.NotSafeToSend');
     itSendsNoMessage(result);
@@ -237,16 +203,10 @@ describe('sending postFundSetup as Hub', () => {
 
 describe('when not cleared to send', () => {
   const scenario = scenarios.notClearedToSend;
-  const { processId, commitmentType } = scenario;
 
   describe('when initializing', () => {
     const { sharedData, commitments, args } = scenario.initialize;
-    const { protocolState, sharedData: result } = initialize(
-      processId,
-      sharedData,
-      commitmentType,
-      args,
-    );
+    const { protocolState, sharedData: result } = initialize(sharedData, args);
 
     itTransitionsTo(protocolState, 'AdvanceChannel.NotSafeToSend');
     itSendsNoMessage(result);

--- a/packages/wallet/src/redux/protocols/advance-channel/reducer.ts
+++ b/packages/wallet/src/redux/protocols/advance-channel/reducer.ts
@@ -25,11 +25,10 @@ type ReturnVal = ProtocolStateWithSharedData<states.AdvanceChannelState>;
 type Storage = SharedData;
 
 export function initialize(
-  processId: string,
   sharedData: Storage,
-  commitmentType: CommitmentType,
   args: OngoingChannelArgs | NewChannelArgs,
 ): ReturnVal {
+  const { commitmentType, processId } = args;
   if (commitmentType === CommitmentType.PreFundSetup) {
     if (!isNewChannelArgs(args)) {
       throw new Error('Must receive NewChannelArgs');

--- a/packages/wallet/src/redux/protocols/defunding/reducer.ts
+++ b/packages/wallet/src/redux/protocols/defunding/reducer.ts
@@ -36,7 +36,7 @@ export const initialize = (
     }
     const proposedAllocation = getLastCommitment(channel).allocation;
     const proposedDestination = getLastCommitment(channel).destination;
-    const indirectDefundingState = indirectDefundingInitialize(
+    const indirectDefundingState = indirectDefundingInitialize({
       processId,
       channelId,
       ledgerId,
@@ -44,7 +44,7 @@ export const initialize = (
       proposedDestination,
       sharedData,
       action,
-    );
+    });
 
     const protocolState = states.waitForLedgerDefunding({
       processId,

--- a/packages/wallet/src/redux/protocols/dispute/reducer.ts
+++ b/packages/wallet/src/redux/protocols/dispute/reducer.ts
@@ -1,36 +1,12 @@
 import { SharedData } from '../../state';
-import { Commitment } from '../../../domain';
 import { ProtocolStateWithSharedData } from '..';
 import { DisputeState, isTerminal } from './state';
-import { initialize as responderInitialize, responderReducer } from './responder/reducer';
-import { initialize as challengerInitialize, challengerReducer } from './challenger/reducer';
+import { responderReducer } from './responder/reducer';
+import { challengerReducer } from './challenger/reducer';
 import { isNonTerminalResponderState } from './responder/states';
 import { isResponderAction } from './responder/actions';
 import { ProtocolAction } from '../../actions';
 import { isChallengerAction } from './challenger/actions';
-
-export const initializeResponderState = (
-  processId: string,
-  channelId: string,
-  expiryTime: number,
-  sharedData: SharedData,
-  challengeCommitment: Commitment,
-): ProtocolStateWithSharedData<DisputeState> => {
-  return responderInitialize(processId, channelId, expiryTime, sharedData, challengeCommitment);
-};
-
-export const initializeChallengerState = (
-  processId: string,
-  channelId: string,
-  sharedData: SharedData,
-): ProtocolStateWithSharedData<DisputeState> => {
-  const { sharedData: updatedSharedData, state: protocolState } = challengerInitialize(
-    processId,
-    channelId,
-    sharedData,
-  );
-  return { protocolState, sharedData: updatedSharedData };
-};
 
 export const disputeReducer = (
   protocolState: DisputeState,

--- a/packages/wallet/src/redux/protocols/existing-ledger-funding/__tests__/reducer.test.ts
+++ b/packages/wallet/src/redux/protocols/existing-ledger-funding/__tests__/reducer.test.ts
@@ -8,28 +8,9 @@ describe('player A happy path', () => {
   const scenario = scenarios.playerAFullyFundedHappyPath;
 
   describe('when initializing', () => {
-    const {
-      processId,
-      channelId,
-      ledgerId,
-      targetAllocation,
-      targetDestination,
-      protocolLocator,
-      sharedData,
-      reply,
-    } = scenario.initialize;
-
-    const result = initialize(
-      processId,
-      channelId,
-      ledgerId,
-      targetAllocation,
-      targetDestination,
-      protocolLocator,
-      sharedData,
-    );
+    const result = initialize(scenario.initialize);
     itTransitionsTo(result, 'ExistingLedgerFunding.WaitForLedgerUpdate');
-    itSendsTheseCommitments(result, reply);
+    itSendsTheseCommitments(result, scenario.initialize.reply);
   });
 
   describeScenarioStep(scenario.waitForLedgerUpdate, () => {
@@ -43,25 +24,7 @@ describe('player B happy path', () => {
   const scenario = scenarios.playerBFullyFundedHappyPath;
 
   describe('when initializing', () => {
-    const {
-      processId,
-      channelId,
-      ledgerId,
-      targetAllocation,
-      targetDestination,
-      protocolLocator,
-      sharedData,
-    } = scenario.initialize;
-
-    const result = initialize(
-      processId,
-      channelId,
-      ledgerId,
-      targetAllocation,
-      targetDestination,
-      protocolLocator,
-      sharedData,
-    );
+    const result = initialize(scenario.initialize);
     itTransitionsTo(result, 'ExistingLedgerFunding.WaitForLedgerUpdate');
   });
 
@@ -85,25 +48,7 @@ describe('player A invalid ledger commitment', () => {
 describe('player A top up needed', () => {
   const scenario = scenarios.playerATopUpNeeded;
   describe('when initializing', () => {
-    const {
-      processId,
-      channelId,
-      ledgerId,
-      targetAllocation,
-      targetDestination,
-      protocolLocator,
-      sharedData,
-    } = scenario.initialize;
-
-    const result = initialize(
-      processId,
-      channelId,
-      ledgerId,
-      targetAllocation,
-      targetDestination,
-      protocolLocator,
-      sharedData,
-    );
+    const result = initialize(scenario.initialize);
     itTransitionsTo(result, 'ExistingLedgerFunding.WaitForLedgerTopUp');
   });
 });
@@ -120,25 +65,7 @@ describe('player B invalid ledger update commitment', () => {
 describe('player B top up needed', () => {
   const scenario = scenarios.playerATopUpNeeded;
   describe('when initializing', () => {
-    const {
-      processId,
-      channelId,
-      ledgerId,
-      targetAllocation,
-      targetDestination,
-      protocolLocator,
-      sharedData,
-    } = scenario.initialize;
-
-    const result = initialize(
-      processId,
-      channelId,
-      ledgerId,
-      targetAllocation,
-      targetDestination,
-      protocolLocator,
-      sharedData,
-    );
+    const result = initialize(scenario.initialize);
     itTransitionsTo(result, 'ExistingLedgerFunding.WaitForLedgerTopUp');
   });
 });

--- a/packages/wallet/src/redux/protocols/existing-ledger-funding/reducer.ts
+++ b/packages/wallet/src/redux/protocols/existing-ledger-funding/reducer.ts
@@ -34,15 +34,23 @@ import {
 import { LedgerTopUpState } from '../ledger-top-up/states';
 export { EXISTING_LEDGER_FUNDING_PROTOCOL_LOCATOR } from '../../../communication/protocol-locator';
 
-export const initialize = (
-  processId: string,
-  channelId: string,
-  ledgerId: string,
-  targetAllocation: string[],
-  targetDestination: string[],
-  protocolLocator: ProtocolLocator,
-  sharedData: SharedData,
-): ProtocolStateWithSharedData<states.NonTerminalExistingLedgerFundingState | states.Failure> => {
+export const initialize = ({
+  processId,
+  channelId,
+  ledgerId,
+  targetAllocation,
+  targetDestination,
+  protocolLocator,
+  sharedData,
+}: {
+  processId: string;
+  channelId: string;
+  ledgerId: string;
+  targetAllocation: string[];
+  targetDestination: string[];
+  protocolLocator: ProtocolLocator;
+  sharedData: SharedData;
+}): ProtocolStateWithSharedData<states.NonTerminalExistingLedgerFundingState | states.Failure> => {
   const ledgerChannel = selectors.getChannelState(sharedData, ledgerId);
   const theirCommitment = getLastCommitment(ledgerChannel);
 

--- a/packages/wallet/src/redux/protocols/existing-ledger-funding/reducer.ts
+++ b/packages/wallet/src/redux/protocols/existing-ledger-funding/reducer.ts
@@ -68,16 +68,16 @@ export const initialize = ({
 
   if (ledgerChannelNeedsTopUp(theirCommitment, targetAllocation, targetDestination)) {
     let ledgerTopUpState: LedgerTopUpState;
-    ({ protocolState: ledgerTopUpState, sharedData } = initializeLedgerTopUp(
+    ({ protocolState: ledgerTopUpState, sharedData } = initializeLedgerTopUp({
       processId,
       channelId,
       ledgerId,
-      targetAllocation,
-      targetDestination,
-      theirCommitment.allocation,
-      makeLocator(protocolLocator, LEDGER_TOP_UP_PROTOCOL_LOCATOR),
+      proposedAllocation: targetAllocation,
+      proposedDestination: targetDestination,
+      originalAllocation: theirCommitment.allocation,
+      protocolLocator: makeLocator(protocolLocator, LEDGER_TOP_UP_PROTOCOL_LOCATOR),
       sharedData,
-    ));
+    }));
 
     return {
       protocolState: states.waitForLedgerTopUp({

--- a/packages/wallet/src/redux/protocols/funding/player-a/reducer.ts
+++ b/packages/wallet/src/redux/protocols/funding/player-a/reducer.ts
@@ -211,19 +211,14 @@ function strategyApproved(
 
   const { processId, targetChannelId, ourAddress } = state;
   let advanceChannelState: advanceChannelStates.AdvanceChannelState;
-  ({ protocolState: advanceChannelState, sharedData } = initializeAdvanceChannel(
+  ({ protocolState: advanceChannelState, sharedData } = initializeAdvanceChannel(sharedData, {
+    channelId: targetChannelId,
+    ourIndex: TwoPartyPlayerIndex.A,
     processId,
-    sharedData,
-    CommitmentType.PostFundSetup,
-    {
-      channelId: targetChannelId,
-      ourIndex: TwoPartyPlayerIndex.A,
-      processId,
-      commitmentType: CommitmentType.PostFundSetup,
-      clearedToSend: false,
-      protocolLocator: ADVANCE_CHANNEL_PROTOCOL_LOCATOR,
-    },
-  ));
+    commitmentType: CommitmentType.PostFundSetup,
+    clearedToSend: false,
+    protocolLocator: ADVANCE_CHANNEL_PROTOCOL_LOCATOR,
+  }));
 
   switch (action.strategy) {
     case 'IndirectFundingStrategy': {

--- a/packages/wallet/src/redux/protocols/funding/player-a/reducer.ts
+++ b/packages/wallet/src/redux/protocols/funding/player-a/reducer.ts
@@ -228,14 +228,14 @@ function strategyApproved(
   switch (action.strategy) {
     case 'IndirectFundingStrategy': {
       const latestCommitment = getLatestCommitment(state.targetChannelId, sharedData);
-      const { protocolState: fundingState, sharedData: newSharedData } = initializeIndirectFunding(
-        state.processId,
-        state.targetChannelId,
-        latestCommitment.allocation,
-        latestCommitment.destination,
+      const { protocolState: fundingState, sharedData: newSharedData } = initializeIndirectFunding({
+        processId: state.processId,
+        channelId: state.targetChannelId,
+        targetAllocation: latestCommitment.allocation,
+        targetDestination: latestCommitment.destination,
         sharedData,
-        makeLocator(EmbeddedProtocol.IndirectFunding),
-      );
+        protocolLocator: makeLocator(EmbeddedProtocol.IndirectFunding),
+      });
       if (fundingState.type === 'IndirectFunding.Failure') {
         return {
           protocolState: states.failure(fundingState),

--- a/packages/wallet/src/redux/protocols/funding/player-b/reducer.ts
+++ b/packages/wallet/src/redux/protocols/funding/player-b/reducer.ts
@@ -168,14 +168,14 @@ function strategyApproved(
   const message = sendStrategyApproved(opponentAddress, processId, strategy);
   const latestCommitment = getLatestCommitment(targetChannelId, sharedData);
 
-  const { protocolState: fundingState, sharedData: newSharedData } = initializeIndirectFunding(
+  const { protocolState: fundingState, sharedData: newSharedData } = initializeIndirectFunding({
     processId,
-    targetChannelId,
-    latestCommitment.allocation,
-    latestCommitment.destination,
+    channelId: targetChannelId,
+    targetAllocation: latestCommitment.allocation,
+    targetDestination: latestCommitment.destination,
     sharedData,
-    makeLocator(EmbeddedProtocol.IndirectFunding),
-  );
+    protocolLocator: makeLocator(EmbeddedProtocol.IndirectFunding),
+  });
 
   const advanceChannelResult = initializeAdvanceChannel(
     processId,

--- a/packages/wallet/src/redux/protocols/funding/player-b/reducer.ts
+++ b/packages/wallet/src/redux/protocols/funding/player-b/reducer.ts
@@ -177,19 +177,14 @@ function strategyApproved(
     protocolLocator: makeLocator(EmbeddedProtocol.IndirectFunding),
   });
 
-  const advanceChannelResult = initializeAdvanceChannel(
+  const advanceChannelResult = initializeAdvanceChannel(newSharedData, {
+    channelId: targetChannelId,
+    ourIndex: TwoPartyPlayerIndex.B,
     processId,
-    newSharedData,
-    CommitmentType.PostFundSetup,
-    {
-      channelId: targetChannelId,
-      ourIndex: TwoPartyPlayerIndex.B,
-      processId,
-      commitmentType: CommitmentType.PostFundSetup,
-      clearedToSend: false,
-      protocolLocator: makeLocator(ADVANCE_CHANNEL_PROTOCOL_LOCATOR),
-    },
-  );
+    commitmentType: CommitmentType.PostFundSetup,
+    clearedToSend: false,
+    protocolLocator: makeLocator(ADVANCE_CHANNEL_PROTOCOL_LOCATOR),
+  });
   switch (fundingState.type) {
     case 'IndirectFunding.Failure':
       return {

--- a/packages/wallet/src/redux/protocols/indirect-defunding/__tests__/index.ts
+++ b/packages/wallet/src/redux/protocols/indirect-defunding/__tests__/index.ts
@@ -1,5 +1,5 @@
 import * as scenarios from './scenarios';
-export const initialStore = scenarios.playerAHappyPath.initialParams.store;
+export const initialStore = scenarios.playerAHappyPath.initialParams.sharedData;
 export const preSuccessState = scenarios.playerAHappyPath.waitForConclude.state;
 export const successTrigger = scenarios.playerAHappyPath.waitForConclude.action;
 export const preFailureState = scenarios.playerAInvalidCommitment.waitForLedgerUpdate.state;

--- a/packages/wallet/src/redux/protocols/indirect-defunding/__tests__/reducer.test.ts
+++ b/packages/wallet/src/redux/protocols/indirect-defunding/__tests__/reducer.test.ts
@@ -8,25 +8,10 @@ import { itRelaysTheseActions } from '../../../__tests__/helpers';
 
 describe('player A happy path', () => {
   const scenario = scenarios.playerAHappyPath;
-  const {
-    processId,
-    channelId,
-    ledgerId,
-    store,
-    proposedAllocation,
-    proposedDestination,
-    relayActions,
-  } = scenario.initialParams;
+  const { relayActions } = scenario.initialParams;
 
   describe('when initializing', () => {
-    const result = initialize(
-      processId,
-      channelId,
-      ledgerId,
-      proposedAllocation,
-      proposedDestination,
-      store,
-    );
+    const result = initialize(scenario.initialParams);
     itTransitionsTo(result, 'IndirectDefunding.WaitForLedgerUpdate');
     itRelaysTheseActions(result, relayActions);
   });
@@ -56,24 +41,9 @@ describe('player A invalid commitment', () => {
 
 describe('player B happy path', () => {
   const scenario = scenarios.playerBHappyPath;
-  const {
-    processId,
-    channelId,
-    ledgerId,
-    store,
-    proposedAllocation,
-    proposedDestination,
-  } = scenario.initialParams;
 
   describe('when initializing', () => {
-    const result = initialize(
-      processId,
-      channelId,
-      ledgerId,
-      proposedAllocation,
-      proposedDestination,
-      store,
-    );
+    const result = initialize(scenario.initialParams);
     itTransitionsTo(result, 'IndirectDefunding.WaitForLedgerUpdate');
   });
 
@@ -104,23 +74,8 @@ describe('player B invalid commitment', () => {
 
 describe('not defundable', () => {
   const scenario = scenarios.notDefundable;
-  const {
-    processId,
-    channelId,
-    ledgerId,
-    store,
-    proposedAllocation,
-    proposedDestination,
-  } = scenario.initialParams;
   describe('when initializing', () => {
-    const result = initialize(
-      processId,
-      channelId,
-      ledgerId,
-      proposedAllocation,
-      proposedDestination,
-      store,
-    );
+    const result = initialize(scenario.initialParams);
     itTransitionsTo(result, 'IndirectDefunding.Failure');
   });
 });

--- a/packages/wallet/src/redux/protocols/indirect-defunding/__tests__/scenarios.ts
+++ b/packages/wallet/src/redux/protocols/indirect-defunding/__tests__/scenarios.ts
@@ -149,7 +149,7 @@ const invalidLedgerUpdateReceived = globalActions.commitmentReceived({
 // -----------
 export const playerAHappyPath = {
   initialParams: {
-    store: initialStore,
+    sharedData: initialStore,
     ...props,
     relayActions: [
       defundRequested({
@@ -178,7 +178,7 @@ export const playerBInvalidCommitment = {
 
 export const playerBHappyPath = {
   initialParams: {
-    store: initialStore,
+    sharedData: initialStore,
     ...props,
   },
   waitForLedgerUpdate: {
@@ -195,7 +195,7 @@ export const playerBHappyPath = {
 
 export const notDefundable = {
   initialParams: {
-    store: notDefundableInitialStore,
+    sharedData: notDefundableInitialStore,
     ...props,
   },
 };

--- a/packages/wallet/src/redux/protocols/indirect-defunding/reducer.ts
+++ b/packages/wallet/src/redux/protocols/indirect-defunding/reducer.ts
@@ -17,15 +17,23 @@ import { CommitmentReceived } from '../../actions';
 import { messageRelayRequested } from 'magmo-wallet-client';
 import { defundRequested } from '../actions';
 
-export const initialize = (
-  processId: string,
-  channelId: string,
-  ledgerId: string,
-  proposedAllocation: string[],
-  proposedDestination: string[],
-  sharedData: SharedData,
-  action?: CommitmentReceived,
-): ProtocolStateWithSharedData<states.IndirectDefundingState> => {
+export const initialize = ({
+  processId,
+  channelId,
+  ledgerId,
+  proposedAllocation,
+  proposedDestination,
+  sharedData,
+  action,
+}: {
+  processId: string;
+  channelId: string;
+  ledgerId: string;
+  proposedAllocation: string[];
+  proposedDestination: string[];
+  sharedData: SharedData;
+  action?: CommitmentReceived;
+}): ProtocolStateWithSharedData<states.IndirectDefundingState> => {
   if (!helpers.channelIsClosed(channelId, sharedData)) {
     return {
       protocolState: states.failure({ reason: 'Channel Not Closed' }),

--- a/packages/wallet/src/redux/protocols/indirect-funding/__tests__/reducer.test.ts
+++ b/packages/wallet/src/redux/protocols/indirect-funding/__tests__/reducer.test.ts
@@ -7,22 +7,7 @@ describe('existing ledger funding happy path', () => {
   const scenario = scenarios.existingLedgerFundingHappyPath;
 
   describe('when initializing', () => {
-    const {
-      processId,
-      channelId,
-      targetAllocation,
-      targetDestination,
-      sharedData,
-      protocolLocator,
-    } = scenario.initialize;
-    const result = initialize(
-      processId,
-      channelId,
-      targetAllocation,
-      targetDestination,
-      sharedData,
-      protocolLocator,
-    );
+    const result = initialize(scenario.initialize);
     itTransitionsTo(result.protocolState, 'IndirectFunding.WaitForExistingLedgerFunding');
   });
 });
@@ -31,22 +16,7 @@ describe('new ledger funding happy path', () => {
   const scenario = scenarios.newLedgerChannelHappyPath;
 
   describe('when initializing', () => {
-    const {
-      processId,
-      channelId,
-      targetAllocation,
-      targetDestination,
-      sharedData,
-      protocolLocator,
-    } = scenario.initialize;
-    const result = initialize(
-      processId,
-      channelId,
-      targetAllocation,
-      targetDestination,
-      sharedData,
-      protocolLocator,
-    );
+    const result = initialize(scenario.initialize);
     itTransitionsTo(result.protocolState, 'IndirectFunding.WaitForNewLedgerChannel');
   });
 

--- a/packages/wallet/src/redux/protocols/indirect-funding/reducer.ts
+++ b/packages/wallet/src/redux/protocols/indirect-funding/reducer.ts
@@ -189,15 +189,15 @@ function fundWithExistingLedgerChannel({
   const {
     protocolState: existingLedgerFundingState,
     sharedData: newSharedData,
-  } = initializeExistingLedgerFunding(
+  } = initializeExistingLedgerFunding({
     processId,
     channelId,
     ledgerId,
     targetAllocation,
     targetDestination,
-    makeLocator(protocolLocator, EXISTING_LEDGER_FUNDING_PROTOCOL_LOCATOR),
+    protocolLocator: makeLocator(protocolLocator, EXISTING_LEDGER_FUNDING_PROTOCOL_LOCATOR),
     sharedData,
-  );
+  });
 
   switch (existingLedgerFundingState.type) {
     case 'ExistingLedgerFunding.Failure':

--- a/packages/wallet/src/redux/protocols/indirect-funding/reducer.ts
+++ b/packages/wallet/src/redux/protocols/indirect-funding/reducer.ts
@@ -20,14 +20,21 @@ import { EXISTING_LEDGER_FUNDING_PROTOCOL_LOCATOR } from '../existing-ledger-fun
 
 export const INDIRECT_FUNDING_PROTOCOL_LOCATOR = makeLocator(EmbeddedProtocol.IndirectFunding);
 
-export function initialize(
-  processId: string,
-  channelId: string,
-  targetAllocation: string[],
-  targetDestination: string[],
-  sharedData: SharedData,
-  protocolLocator: ProtocolLocator,
-): ProtocolStateWithSharedData<states.NonTerminalIndirectFundingState | states.Failure> {
+export function initialize({
+  processId,
+  channelId,
+  targetAllocation,
+  targetDestination,
+  sharedData,
+  protocolLocator,
+}: {
+  processId: string;
+  channelId: string;
+  targetAllocation: string[];
+  targetDestination: string[];
+  sharedData: SharedData;
+  protocolLocator: ProtocolLocator;
+}): ProtocolStateWithSharedData<states.NonTerminalIndirectFundingState | states.Failure> {
   const existingLedgerChannel = selectors.getFundedLedgerChannelForParticipants(
     sharedData,
     helpers.getOurAddress(channelId, sharedData),

--- a/packages/wallet/src/redux/protocols/ledger-top-up/__tests__/reducer.test.ts
+++ b/packages/wallet/src/redux/protocols/ledger-top-up/__tests__/reducer.test.ts
@@ -10,26 +10,7 @@ describe('player A happy path', () => {
   const scenario = scenarios.playerAHappyPath;
 
   describe('when initializing', () => {
-    const {
-      channelId,
-      sharedData,
-      processId,
-      ledgerId,
-      proposedAllocation,
-      proposedDestination,
-      originalAllocation,
-      protocolLocator,
-    } = scenario.initialize;
-    const initialState = initialize(
-      processId,
-      channelId,
-      ledgerId,
-      proposedAllocation,
-      proposedDestination,
-      originalAllocation,
-      protocolLocator,
-      sharedData,
-    );
+    const initialState = initialize(scenario.initialize);
     it('requests the correct allocation/destination updates', () => {
       const consensusUpdate = getProposedConsensus(initialState.protocolState);
       expect(consensusUpdate.proposedAllocation).toEqual(['0x03', '0x04']);
@@ -75,26 +56,7 @@ describe('player A happy path', () => {
 describe('player B happy path', () => {
   const scenario = scenarios.playerBHappyPath;
   describe('when initializing', () => {
-    const {
-      channelId,
-      sharedData,
-      processId,
-      ledgerId,
-      proposedAllocation,
-      proposedDestination,
-      originalAllocation,
-      protocolLocator,
-    } = scenario.initialize;
-    const initialState = initialize(
-      processId,
-      channelId,
-      ledgerId,
-      proposedAllocation,
-      proposedDestination,
-      originalAllocation,
-      protocolLocator,
-      sharedData,
-    );
+    const initialState = initialize(scenario.initialize);
 
     itTransitionsTo(initialState, 'LedgerTopUp.SwitchOrderAndAddATopUpUpdate');
     it('requests the correct allocation/destination updates', () => {
@@ -144,26 +106,7 @@ describe('player B happy path', () => {
 describe('player A one user needs top up', () => {
   const scenario = scenarios.playerAOneUserNeedsTopUp;
   describe('when initializing', () => {
-    const {
-      channelId,
-      sharedData,
-      processId,
-      ledgerId,
-      proposedAllocation,
-      proposedDestination,
-      originalAllocation,
-      protocolLocator,
-    } = scenario.initialize;
-    const initialState = initialize(
-      processId,
-      channelId,
-      ledgerId,
-      proposedAllocation,
-      proposedDestination,
-      originalAllocation,
-      protocolLocator,
-      sharedData,
-    );
+    const initialState = initialize(scenario.initialize);
 
     itTransitionsTo(initialState, 'LedgerTopUp.SwitchOrderAndAddATopUpUpdate');
     it('requests the correct allocation/destination updates', () => {
@@ -202,26 +145,7 @@ describe('player A one user needs top up', () => {
 describe('player B one user needs top up', () => {
   const scenario = scenarios.playerBOneUserNeedsTopUp;
   describe('when initializing', () => {
-    const {
-      channelId,
-      sharedData,
-      processId,
-      ledgerId,
-      proposedAllocation,
-      proposedDestination,
-      originalAllocation,
-      protocolLocator,
-    } = scenario.initialize;
-    const initialState = initialize(
-      processId,
-      channelId,
-      ledgerId,
-      proposedAllocation,
-      proposedDestination,
-      originalAllocation,
-      protocolLocator,
-      sharedData,
-    );
+    const initialState = initialize(scenario.initialize);
 
     itTransitionsTo(initialState, 'LedgerTopUp.SwitchOrderAndAddATopUpUpdate');
     it('requests the correct allocation/destination updates', () => {

--- a/packages/wallet/src/redux/protocols/ledger-top-up/reducer.ts
+++ b/packages/wallet/src/redux/protocols/ledger-top-up/reducer.ts
@@ -23,16 +23,25 @@ import { CONSENSUS_UPDATE_PROTOCOL_LOCATOR } from '../consensus-update/reducer';
 import { DirectFundingState } from '../direct-funding/states';
 import { clearedToSend } from '../consensus-update/actions';
 export { LEDGER_TOP_UP_PROTOCOL_LOCATOR } from '../../../communication/protocol-locator';
-export function initialize(
-  processId: string,
-  channelId: string,
-  ledgerId: string,
-  proposedAllocation: string[],
-  proposedDestination: string[],
-  originalAllocation: string[],
-  protocolLocator: ProtocolLocator,
-  sharedData: SharedData,
-): ProtocolStateWithSharedData<states.LedgerTopUpState> {
+export function initialize({
+  processId,
+  channelId,
+  ledgerId,
+  proposedAllocation,
+  proposedDestination,
+  originalAllocation,
+  protocolLocator,
+  sharedData,
+}: {
+  processId: string;
+  channelId: string;
+  ledgerId: string;
+  proposedAllocation: string[];
+  proposedDestination: string[];
+  originalAllocation: string[];
+  protocolLocator: ProtocolLocator;
+  sharedData: SharedData;
+}): ProtocolStateWithSharedData<states.LedgerTopUpState> {
   sharedData = registerChannelToMonitor(sharedData, processId, ledgerId);
   const { consensusUpdateState, sharedData: newSharedData } = initializeConsensusState(
     TwoPartyPlayerIndex.A,

--- a/packages/wallet/src/redux/protocols/ledger-top-up/reducer.ts
+++ b/packages/wallet/src/redux/protocols/ledger-top-up/reducer.ts
@@ -51,7 +51,6 @@ export function initialize({
     proposedDestination,
     originalAllocation,
     protocolLocator,
-    true,
     sharedData,
   );
   const newProtocolState = states.switchOrderAndAddATopUpUpdate({
@@ -163,7 +162,6 @@ const switchOrderAndAddATopUpUpdateReducer: ProtocolReducer<states.LedgerTopUpSt
       proposedDestination,
       lastCommitment.allocation,
       protocolState.protocolLocator,
-      playerAFunded,
       sharedData,
     ));
     if (playerAFunded) {
@@ -356,7 +354,6 @@ function initializeConsensusState(
   proposedDestination: string[],
   currentAllocation: string[],
   protocolLocator: ProtocolLocator,
-  canSend: boolean,
   sharedData: SharedData,
 ) {
   let newAllocation;

--- a/packages/wallet/src/redux/protocols/new-ledger-channel/reducer.ts
+++ b/packages/wallet/src/redux/protocols/new-ledger-channel/reducer.ts
@@ -54,15 +54,10 @@ export function initialize(
     participants: channel.participants,
   };
 
-  const advanceChannelResult = initializeAdvanceChannel(
-    processId,
-    sharedData,
-    CommitmentType.PreFundSetup,
-    {
-      ...initializationArgs,
-      ...channelSpecificArgs(allocation, destination),
-    },
-  );
+  const advanceChannelResult = initializeAdvanceChannel(sharedData, {
+    ...initializationArgs,
+    ...channelSpecificArgs(allocation, destination),
+  });
   sharedData = advanceChannelResult.sharedData;
 
   const protocolState = states.waitForPreFundSetup({
@@ -181,22 +176,17 @@ function handleWaitForPreFundSetup(
       const directFundingState = initializeDirectFunding(directFundingAction, sharedData);
       sharedData = directFundingState.sharedData;
 
-      const advanceChannelResult = initializeAdvanceChannel(
-        protocolState.processId,
-        directFundingState.sharedData,
-        CommitmentType.PostFundSetup,
-        {
-          channelId: ledgerId,
-          ourIndex,
-          processId: protocolState.processId,
-          commitmentType: CommitmentType.PostFundSetup,
-          clearedToSend: false,
-          protocolLocator: makeLocator(
-            protocolState.protocolLocator,
-            ADVANCE_CHANNEL_PROTOCOL_LOCATOR,
-          ),
-        },
-      );
+      const advanceChannelResult = initializeAdvanceChannel(directFundingState.sharedData, {
+        channelId: ledgerId,
+        ourIndex,
+        processId: protocolState.processId,
+        commitmentType: CommitmentType.PostFundSetup,
+        clearedToSend: false,
+        protocolLocator: makeLocator(
+          protocolState.protocolLocator,
+          ADVANCE_CHANNEL_PROTOCOL_LOCATOR,
+        ),
+      });
       sharedData = advanceChannelResult.sharedData;
       const newProtocolState = states.waitForDirectFunding({
         ...protocolState,

--- a/packages/wallet/src/redux/protocols/virtual-funding/reducer.ts
+++ b/packages/wallet/src/redux/protocols/virtual-funding/reducer.ts
@@ -51,15 +51,10 @@ export function initialize(
 
   const jointAllocation = [...startingAllocation, startingAllocation.reduce(addHex)];
   const jointDestination = [...startingDestination, hubAddress];
-  const jointChannelInitialized = advanceChannel.initializeAdvanceChannel(
-    processId,
-    sharedData,
-    CommitmentType.PreFundSetup,
-    {
-      ...initializationArgs,
-      ...channelSpecificArgs(jointAllocation, jointDestination),
-    },
-  );
+  const jointChannelInitialized = advanceChannel.initializeAdvanceChannel(sharedData, {
+    ...initializationArgs,
+    ...channelSpecificArgs(jointAllocation, jointDestination),
+  });
 
   return {
     protocolState: states.waitForJointChannel({
@@ -112,19 +107,14 @@ function waitForJointChannelReducer(
       const { channelId: jointChannelId } = result.protocolState;
       switch (result.protocolState.commitmentType) {
         case CommitmentType.PreFundSetup:
-          const jointChannelResult = advanceChannel.initializeAdvanceChannel(
+          const jointChannelResult = advanceChannel.initializeAdvanceChannel(result.sharedData, {
+            clearedToSend: true,
+            commitmentType: CommitmentType.PostFundSetup,
             processId,
-            result.sharedData,
-            CommitmentType.PostFundSetup,
-            {
-              clearedToSend: true,
-              commitmentType: CommitmentType.PostFundSetup,
-              processId,
-              protocolLocator: ADVANCE_CHANNEL_PROTOCOL_LOCATOR,
-              channelId: jointChannelId,
-              ourIndex,
-            },
-          );
+            protocolLocator: ADVANCE_CHANNEL_PROTOCOL_LOCATOR,
+            channelId: jointChannelId,
+            ourIndex,
+          });
 
           return {
             protocolState: {
@@ -140,9 +130,7 @@ function waitForJointChannelReducer(
           const channelType = CONSENSUS_LIBRARY_ADDRESS;
           const destination = [targetChannelId, ourAddress, hubAddress];
           const guarantorChannelResult = advanceChannel.initializeAdvanceChannel(
-            processId,
             result.sharedData,
-            CommitmentType.PreFundSetup,
             {
               clearedToSend: true,
               commitmentType: CommitmentType.PreFundSetup,
@@ -199,9 +187,7 @@ function waitForGuarantorChannelReducer(
       switch (result.protocolState.commitmentType) {
         case CommitmentType.PreFundSetup:
           const guarantorChannelResult = advanceChannel.initializeAdvanceChannel(
-            processId,
             result.sharedData,
-            CommitmentType.PostFundSetup,
             {
               clearedToSend: true,
               commitmentType: CommitmentType.PostFundSetup,

--- a/packages/wallet/src/redux/protocols/virtual-funding/reducer.ts
+++ b/packages/wallet/src/redux/protocols/virtual-funding/reducer.ts
@@ -221,14 +221,17 @@ function waitForGuarantorChannelReducer(
 
         case CommitmentType.PostFundSetup:
           const latestCommitment = getLatestCommitment(guarantorChannelId, sharedData);
-          const indirectFundingResult = indirectFunding.initializeIndirectFunding(
+          const indirectFundingResult = indirectFunding.initializeIndirectFunding({
             processId,
-            result.protocolState.channelId,
-            latestCommitment.allocation,
-            latestCommitment.destination,
-            result.sharedData,
-            makeLocator(protocolState.protocolLocator, EmbeddedProtocol.IndirectFunding),
-          );
+            channelId: result.protocolState.channelId,
+            targetAllocation: latestCommitment.allocation,
+            targetDestination: latestCommitment.destination,
+            sharedData: result.sharedData,
+            protocolLocator: makeLocator(
+              protocolState.protocolLocator,
+              EmbeddedProtocol.IndirectFunding,
+            ),
+          });
           switch (indirectFundingResult.protocolState.type) {
             case 'IndirectFunding.Failure':
               return {


### PR DESCRIPTION
Many initializers are better off using destructured objects as their arguments. This is less bug-prone -- consider the case where `proposedAllocation` and `proposedDestination` are passed in the wrong order -- and leads to cleaner tests.

Along the way, I removed some extra cruft.