### PR TITLE
Introduce an InitializeArgs interface

### DIFF
--- a/packages/wallet/src/redux/protocols/new-ledger-channel/__tests__/reducer.test.ts
+++ b/packages/wallet/src/redux/protocols/new-ledger-channel/__tests__/reducer.test.ts
@@ -16,10 +16,13 @@ Object.defineProperty(selectors, 'getNextNonce', {
 describe('happy-path scenario', () => {
   const scenario = scenarios.happyPath;
   describe('when initializing', () => {
-    const { channelId, store, processId } = scenario.initialParams;
-    const initialState = initialize(processId, channelId, store, [
-      EmbeddedProtocol.NewLedgerChannel,
-    ]);
+    const { channelId, store: sharedData, processId } = scenario.initialParams;
+    const initialState = initialize({
+      processId,
+      channelId,
+      sharedData,
+      protocolLocator: [EmbeddedProtocol.NewLedgerChannel],
+    });
 
     itTransitionsTo(initialState, 'NewLedgerChannel.WaitForPreFundSetup');
     itSendsAMessage(initialState);


### PR DESCRIPTION
This draft PR sketches out an approach where we give an explicit name for the type of the intialize function parameter object.

Since the properties are often passed through to other functions also accepting objects with identically-named properties, the spread operator (i.e. `...args` pattern) can be used to clean things up a bit.

So far only a couple of files touched. Will wait for feedback before rolling out to other files. 