### PR TITLE
Fix Invalid Transition

### DIFF
--- a/packages/wallet/src/redux/protocols/new-ledger-channel/reducer.ts
+++ b/packages/wallet/src/redux/protocols/new-ledger-channel/reducer.ts
@@ -290,8 +290,8 @@ function channelSpecificArgs(
     allocation,
     destination,
     appAttributes: bytesFromAppAttributes({
-      proposedAllocation: allocation,
-      proposedDestination: destination,
+      proposedAllocation: [],
+      proposedDestination: [],
       furtherVotesRequired: 0,
     }),
   };


### PR DESCRIPTION
When creating the initial prefund setup for the ledger channel we were setting `proposedAllocation` and `proposedDestination` however according to the consensus rules these must be empty for a consensus (which is the state we start in)