### PR TITLE
Add Virtual De-Funding to de-funding protocol.

### DIFF
--- a/packages/wallet/src/constants.ts
+++ b/packages/wallet/src/constants.ts
@@ -8,3 +8,5 @@ export const ADJUDICATOR_ADDRESS = getAdjudicatorContractAddress();
 export const CONSENSUS_LIBRARY_ADDRESS = getConsensusContractAddress();
 export const NETWORK_ID = getNetworkId();
 export const USE_STORAGE = process.env.USE_STORAGE === 'TRUE';
+// TODO: Move top ENV variable
+export const HUB_ADDRESS = '0x100063c326b27f78b2cBb7cd036B8ddE4d4FCa7C';

--- a/packages/wallet/src/redux/__tests__/helpers.ts
+++ b/packages/wallet/src/redux/__tests__/helpers.ts
@@ -5,6 +5,7 @@ import { QueuedTransaction, OutboxState, MessageOutbox } from '../outbox/state';
 import { SharedData } from '../state';
 import { ProtocolStateWithSharedData } from '../protocols';
 import { RelayableAction, ProtocolLocator } from 'src/communication';
+import _ from 'lodash';
 
 type SideEffectState =
   | StateWithSideEffects<any>
@@ -287,4 +288,11 @@ export const itRegistersThisChannel = (
     const subscriptionState = state.channelSubscriptions[channelId];
     expect(subscriptionState).toContainEqual({ protocolLocator, processId });
   });
+};
+
+export const mergeSharedData = (
+  firstSharedData: SharedData,
+  secondSharedData: SharedData,
+): SharedData => {
+  return _.merge({}, firstSharedData, secondSharedData);
 };

--- a/packages/wallet/src/redux/channel-store/channel-state/states.ts
+++ b/packages/wallet/src/redux/channel-store/channel-state/states.ts
@@ -9,7 +9,7 @@ export interface ChannelState {
   channelId: string;
   libraryAddress: string;
   ourIndex: number;
-  participants: [string, string];
+  participants: string[];
   channelNonce: number;
   turnNum: number;
   commitments: Commitments;

--- a/packages/wallet/src/redux/protocols/defunding/__tests__/reducer.test.ts
+++ b/packages/wallet/src/redux/protocols/defunding/__tests__/reducer.test.ts
@@ -107,6 +107,12 @@ describe('virtually funded happy path', () => {
     const { state, action, sharedData } = scenario.waitForVirtualDefunding;
     const result = defundingReducer(state, sharedData, action);
 
+    itTransitionsTo(result, 'Defunding.WaitForIndirectDefunding');
+  });
+  describeScenarioStep(scenario.waitForLedgerDefunding, () => {
+    const { state, action, sharedData } = scenario.waitForLedgerDefunding;
+    const result = defundingReducer(state, sharedData, action);
+
     itTransitionsTo(result, 'Defunding.WaitForWithdrawal');
   });
   describeScenarioStep(scenario.waitForWithdrawal, () => {

--- a/packages/wallet/src/redux/protocols/defunding/__tests__/reducer.test.ts
+++ b/packages/wallet/src/redux/protocols/defunding/__tests__/reducer.test.ts
@@ -94,3 +94,26 @@ describe('indirectly funded failure', () => {
     itTransitionsToFailure(result, states.failure({ reason: 'Ledger De-funding Failure' }));
   });
 });
+
+describe('virtually funded happy path', () => {
+  const scenario = scenarios.virtualFundingChannelHappyPath;
+
+  describe('when initializing', () => {
+    const { processId, channelId, sharedData } = scenario.initialize;
+    const result = initialize(processId, channelId, sharedData);
+    itTransitionsTo(result, 'Defunding.WaitForVirtualDefunding');
+  });
+  describeScenarioStep(scenario.waitForVirtualDefunding, () => {
+    const { state, action, sharedData } = scenario.waitForVirtualDefunding;
+    const result = defundingReducer(state, sharedData, action);
+
+    itTransitionsTo(result, 'Defunding.WaitForWithdrawal');
+  });
+  describeScenarioStep(scenario.waitForWithdrawal, () => {
+    const { state, action, sharedData } = scenario.waitForWithdrawal;
+    const result = defundingReducer(state, sharedData, action);
+
+    itTransitionsTo(result, 'Defunding.Success');
+    itSendsThisDisplayEventType(result.sharedData, HIDE_WALLET);
+  });
+});

--- a/packages/wallet/src/redux/protocols/defunding/__tests__/reducer.test.ts
+++ b/packages/wallet/src/redux/protocols/defunding/__tests__/reducer.test.ts
@@ -84,13 +84,31 @@ describe('indirectly funded happy path', () => {
   });
 });
 
-// describe('indirectly funded failure', () => {
-//   const scenario = scenarios.indirectlyFundingFailure;
+describe('virtually funded happy path', () => {
+  const scenario = scenarios.virtualFundingChannelHappyPath;
 
-//   describeScenarioStep(scenario.waitForLedgerDefunding, () => {
-//     const { state, action, sharedData } = scenario.waitForLedgerDefunding;
-//     const result = defundingReducer(state, sharedData, action);
+  describe('when initializing', () => {
+    const { processId, channelId, sharedData } = scenario.initialize;
+    const result = initialize(processId, channelId, sharedData);
+    itTransitionsTo(result, 'Defunding.WaitForVirtualDefunding');
+  });
+  describeScenarioStep(scenario.waitForVirtualDefunding, () => {
+    const { state, action, sharedData } = scenario.waitForVirtualDefunding;
+    const result = defundingReducer(state, sharedData, action);
 
-//     itTransitionsToFailure(result, states.failure({ reason: 'Ledger De-funding Failure' }));
-//   });
-// });
+    itTransitionsTo(result, 'Defunding.WaitForIndirectDefunding');
+  });
+  describeScenarioStep(scenario.waitForLedgerDefunding, () => {
+    const { state, action, sharedData } = scenario.waitForLedgerDefunding;
+    const result = defundingReducer(state, sharedData, action);
+
+    itTransitionsTo(result, 'Defunding.WaitForWithdrawal');
+  });
+  describeScenarioStep(scenario.waitForWithdrawal, () => {
+    const { state, action, sharedData } = scenario.waitForWithdrawal;
+    const result = defundingReducer(state, sharedData, action);
+
+    itTransitionsTo(result, 'Defunding.Success');
+    itSendsThisDisplayEventType(result.sharedData, HIDE_WALLET);
+  });
+});

--- a/packages/wallet/src/redux/protocols/defunding/__tests__/scenarios.ts
+++ b/packages/wallet/src/redux/protocols/defunding/__tests__/scenarios.ts
@@ -5,6 +5,7 @@ import { ChannelState, ChannelStore } from '../../../channel-store';
 import { EMPTY_SHARED_DATA, FundingState } from '../../../state';
 import * as indirectDefunding from '../../indirect-defunding/__tests__';
 import * as virtualDefunding from '../../virtual-defunding/__tests__';
+import _ from 'lodash';
 const processId = 'process-id.123';
 
 const {
@@ -23,7 +24,7 @@ const concludeCommitment2 = testScenarios.appCommitment({ turnNum: 52, isFinal: 
 const channelStatus: ChannelState = {
   address,
   privateKey,
-  channelId,
+  channelId: virtualDefunding.initial.targetChannelId,
   libraryAddress,
   ourIndex: 0,
   participants,
@@ -143,7 +144,15 @@ export const virtualFundingChannelHappyPath = {
   waitForVirtualDefunding: {
     state: waitForVirtualDefunding,
     action: virtualDefunding.preSuccess.action,
-    sharedData: virtualDefunding.preSuccess.sharedData,
+    sharedData: _.merge(
+      virtualDefunding.preSuccess.sharedData,
+      indirectDefunding.preSuccessState.store,
+    ),
+  },
+  waitForLedgerDefunding: {
+    state: waitForLedgerDefunding,
+    action: indirectDefunding.successTrigger,
+    sharedData: indirectDefunding.preSuccessState.store,
   },
   waitForWithdrawal: {
     state: waitForWithdrawal,

--- a/packages/wallet/src/redux/protocols/defunding/__tests__/scenarios.ts
+++ b/packages/wallet/src/redux/protocols/defunding/__tests__/scenarios.ts
@@ -76,6 +76,7 @@ const waitForVirtualDefunding = states.waitForVirtualDefunding({
   processId,
   channelId,
   virtualDefunding: virtualDefunding.preSuccess.state,
+  indirectDefundingState: indirectDefunding.preSuccessState.state,
 });
 
 // const waitForLedgerFailure = states.waitForLedgerDefunding({

--- a/packages/wallet/src/redux/protocols/defunding/__tests__/scenarios.ts
+++ b/packages/wallet/src/redux/protocols/defunding/__tests__/scenarios.ts
@@ -4,6 +4,7 @@ import * as testScenarios from '../../../../domain/commitments/__tests__';
 import { ChannelState, ChannelStore } from '../../../channel-store';
 import { EMPTY_SHARED_DATA, FundingState } from '../../../state';
 import * as indirectDefunding from '../../indirect-defunding/__tests__';
+import * as virtualDefunding from '../../virtual-defunding/__tests__';
 const processId = 'process-id.123';
 
 const {
@@ -75,6 +76,12 @@ const waitForLedgerDefunding = states.waitForLedgerDefunding({
   indirectDefundingState: indirectDefunding.preSuccessState.state,
 });
 
+const waitForVirtualDefunding = states.waitForVirtualDefunding({
+  processId,
+  channelId,
+  virtualDefunding: virtualDefunding.preSuccess.state,
+});
+
 const waitForLedgerFailure = states.waitForLedgerDefunding({
   processId,
   channelId,
@@ -114,6 +121,29 @@ export const indirectlyFundingChannelHappyPath = {
     state: waitForLedgerDefunding,
     action: indirectDefunding.successTrigger,
     sharedData: indirectDefunding.preSuccessState.store,
+  },
+  waitForWithdrawal: {
+    state: waitForWithdrawal,
+    action: withdrawalScenarios.happyPath.waitForAcknowledgement.action,
+    sharedData: {
+      ...EMPTY_SHARED_DATA,
+      fundingState: directlyFundedFundingState,
+      channelStore,
+    },
+  },
+};
+
+export const virtualFundingChannelHappyPath = {
+  initialize: {
+    processId,
+    channelId: virtualDefunding.initial.targetChannelId,
+    sharedData: virtualDefunding.initial.sharedData,
+  },
+  // States
+  waitForVirtualDefunding: {
+    state: waitForVirtualDefunding,
+    action: virtualDefunding.preSuccess.action,
+    sharedData: virtualDefunding.preSuccess.sharedData,
   },
   waitForWithdrawal: {
     state: waitForWithdrawal,

--- a/packages/wallet/src/redux/protocols/defunding/__tests__/scenarios.ts
+++ b/packages/wallet/src/redux/protocols/defunding/__tests__/scenarios.ts
@@ -10,6 +10,7 @@ import * as virtualDefunding from '../../virtual-defunding/__tests__';
 import _ from 'lodash';
 import { prependToLocator } from '../..';
 import { EmbeddedProtocol } from '../../../../communication';
+import { mergeSharedData } from '../../../__tests__/helpers';
 const processId = 'process-id.123';
 
 const { asAddress, bsAddress, asPrivateKey, channelId } = testScenarios;
@@ -171,13 +172,16 @@ export const virtualFundingChannelHappyPath = {
   initialize: {
     processId,
     channelId: virtualDefunding.initial.targetChannelId,
-    sharedData: virtualDefunding.initial.sharedData,
+    sharedData: mergeSharedData(
+      virtualDefunding.preSuccess.sharedData,
+      indirectDefunding.preSuccessState.sharedData,
+    ),
   },
   // States
   waitForVirtualDefunding: {
     state: waitForVirtualDefunding,
     action: prependToLocator(virtualDefunding.preSuccess.action, EmbeddedProtocol.VirtualDefunding),
-    sharedData: _.merge(
+    sharedData: mergeSharedData(
       virtualDefunding.preSuccess.sharedData,
       indirectDefunding.preSuccessState.sharedData,
     ),
@@ -185,7 +189,7 @@ export const virtualFundingChannelHappyPath = {
   waitForLedgerDefunding: {
     state: waitForLedgerDefunding,
     action: prependToLocator(indirectDefunding.successTrigger, EmbeddedProtocol.IndirectDefunding),
-    sharedData: _.merge(
+    sharedData: mergeSharedData(
       indirectDefunding.preSuccessState.sharedData,
       virtualDefunding.preSuccess.sharedData,
     ),

--- a/packages/wallet/src/redux/protocols/defunding/actions.ts
+++ b/packages/wallet/src/redux/protocols/defunding/actions.ts
@@ -1,6 +1,7 @@
 import { WalletAction } from '../../actions';
 import { WithdrawalAction, isWithdrawalAction } from '../withdrawing/actions';
 import { IndirectDefundingAction, isIndirectDefundingAction } from '../indirect-defunding/actions';
+import { VirtualDefundingAction } from '../virtual-defunding';
 
 // -------
 // Actions
@@ -15,7 +16,7 @@ import { IndirectDefundingAction, isIndirectDefundingAction } from '../indirect-
 // -------
 
 // TODO: Replace once ledger defunding actions are defined
-export type DefundingAction = WithdrawalAction | IndirectDefundingAction;
+export type DefundingAction = WithdrawalAction | IndirectDefundingAction | VirtualDefundingAction;
 
 export const isDefundingAction = (action: WalletAction): action is DefundingAction => {
   return isWithdrawalAction(action) || isIndirectDefundingAction(action);

--- a/packages/wallet/src/redux/protocols/defunding/actions.ts
+++ b/packages/wallet/src/redux/protocols/defunding/actions.ts
@@ -1,7 +1,7 @@
 import { WalletAction } from '../../actions';
 import { WithdrawalAction, isWithdrawalAction } from '../withdrawing/actions';
 import { IndirectDefundingAction, isIndirectDefundingAction } from '../indirect-defunding/actions';
-import { VirtualDefundingAction } from '../virtual-defunding';
+import { VirtualDefundingAction, isVirtualDefundingAction } from '../virtual-defunding';
 
 // -------
 // Actions
@@ -19,5 +19,9 @@ import { VirtualDefundingAction } from '../virtual-defunding';
 export type DefundingAction = WithdrawalAction | IndirectDefundingAction | VirtualDefundingAction;
 
 export const isDefundingAction = (action: WalletAction): action is DefundingAction => {
-  return isWithdrawalAction(action) || isIndirectDefundingAction(action);
+  return (
+    isWithdrawalAction(action) ||
+    isIndirectDefundingAction(action) ||
+    isVirtualDefundingAction(action)
+  );
 };

--- a/packages/wallet/src/redux/protocols/defunding/container.tsx
+++ b/packages/wallet/src/redux/protocols/defunding/container.tsx
@@ -28,7 +28,7 @@ class DefundingContainer extends PureComponent<Props> {
       case 'Defunding.WaitForVirtualDefunding':
         return <VirtualDefunding state={state.virtualDefunding} />;
       default:
-        unreachable(state);
+        return unreachable(state);
     }
   }
 }

--- a/packages/wallet/src/redux/protocols/defunding/container.tsx
+++ b/packages/wallet/src/redux/protocols/defunding/container.tsx
@@ -6,6 +6,8 @@ import Failure from '../shared-components/failure';
 import Success from '../shared-components/success';
 import { connect } from 'react-redux';
 import { IndirectDefunding } from '../indirect-defunding/container';
+import { unreachable } from '../../../utils/reducer-utils';
+import { VirtualDefunding } from '../virtual-defunding/container';
 
 interface Props {
   state: states.DefundingState;
@@ -23,6 +25,10 @@ class DefundingContainer extends PureComponent<Props> {
         return <Failure name="de-funding" reason={state.reason} />;
       case 'Defunding.Success':
         return <Success name="de-funding" />;
+      case 'Defunding.WaitForVirtualDefunding':
+        return <VirtualDefunding state={state.virtualDefunding} />;
+      default:
+        unreachable(state);
     }
   }
 }

--- a/packages/wallet/src/redux/protocols/defunding/readme.md
+++ b/packages/wallet/src/redux/protocols/defunding/readme.md
@@ -15,9 +15,12 @@ graph TD
 linkStyle default interpolate basis
   S((start))-->ICC{Is Channel Closed}
   ICC-->|No|F((failure))
-  ICC-->|Yes|ID{Is Direct Channel}
-  ID-->|Yes|WP(Wait for Withdrawal)
-  ID -->|No|LDP(Wait for Indirect De-funding)
+  ICC-->|Yes|ID{Get Funding Type}
+  ID-->|Directly Funded|WP(Wait for Withdrawal)
+  ID -->|Ledger Funding|LDP(Wait for Indirect De-funding)
+  ID -->|Virtual Funding|VD(Wait for Virtual De-funding)
+  VD -->|Virtual Defunding Action|VD
+  VD -->|Virtual Defunding Success|WP(Wait for Withdrawal)
   LDP-->|Indirect de-funding protocol success|WP(Wait for Withdrawal)
   WP-->|Withdrawal protocol success|Su((Success))
   WP-->|Withdrawal protocol failure|F((Failure))
@@ -30,7 +33,7 @@ linkStyle default interpolate basis
   class S,ICC,ID logic;
   class Su Success;
   class F Failure;
-  class WP,LDP WaitForChildProtocol;
+  class WP,LDP,VD WaitForChildProtocol;
 ```
 
 ## Notes

--- a/packages/wallet/src/redux/protocols/defunding/readme.md
+++ b/packages/wallet/src/redux/protocols/defunding/readme.md
@@ -20,7 +20,7 @@ linkStyle default interpolate basis
   ID -->|Ledger Funding|LDP(Wait for Indirect De-funding)
   ID -->|Virtual Funding|VD(Wait for Virtual De-funding)
   VD -->|Virtual Defunding Action|VD
-  VD -->|Virtual Defunding Success|WP(Wait for Withdrawal)
+  VD -->|Virtual Defunding Success|LDP
   LDP-->|Indirect de-funding protocol success|WP(Wait for Withdrawal)
   WP-->|Withdrawal protocol success|Su((Success))
   WP-->|Withdrawal protocol failure|F((Failure))

--- a/packages/wallet/src/redux/protocols/defunding/reducer.ts
+++ b/packages/wallet/src/redux/protocols/defunding/reducer.ts
@@ -1,5 +1,5 @@
 import { SharedData, getChannel } from '../../state';
-import { ProtocolStateWithSharedData } from '..';
+import { ProtocolStateWithSharedData, makeLocator } from '..';
 import * as states from './states';
 import * as helpers from '../reducer-helpers';
 import { withdrawalReducer, initialize as withdrawalInitialize } from './../withdrawing/reducer';
@@ -13,9 +13,12 @@ import {
 } from '../indirect-defunding/reducer';
 import { isIndirectDefundingAction } from '../indirect-defunding/actions';
 import * as indirectDefundingStates from '../indirect-defunding/states';
-import { CommitmentReceived } from '../../../communication';
+import { CommitmentReceived, EmbeddedProtocol } from '../../../communication';
 import { getLastCommitment } from '../../channel-store';
 import { ProtocolAction } from '../../../redux/actions';
+import { VirtualDefundingState } from '../virtual-defunding/states';
+import { initializeVirtualDefunding, virtualDefundingReducer } from '../virtual-defunding';
+import { routesToConsensusUpdate } from '../consensus-update/actions';
 
 export const initialize = (
   processId: string,
@@ -26,33 +29,49 @@ export const initialize = (
   if (!helpers.channelIsClosed(channelId, sharedData)) {
     return { protocolState: states.failure({ reason: 'Channel Not Closed' }), sharedData };
   }
-  if (helpers.isChannelDirectlyFunded(channelId, sharedData)) {
-    return createWaitForWithdrawal(sharedData, processId, channelId);
-  } else {
-    const ledgerId = helpers.getFundingChannelId(channelId, sharedData);
-    const channel = getChannel(sharedData, channelId);
-    if (!channel) {
-      throw new Error(`Channel does not exist with id ${channelId}`);
-    }
-    const proposedAllocation = getLastCommitment(channel).allocation;
-    const proposedDestination = getLastCommitment(channel).destination;
-    const indirectDefundingState = indirectDefundingInitialize({
-      processId,
-      channelId,
-      ledgerId,
-      proposedAllocation,
-      proposedDestination,
-      sharedData,
-      action,
-    });
+  const fundingType = helpers.getChannelFundingType(channelId, sharedData);
+  switch (fundingType) {
+    case helpers.FundingType.Direct:
+      return createWaitForWithdrawal(sharedData, processId, channelId);
+    case helpers.FundingType.Ledger:
+      const ledgerId = helpers.getFundingChannelId(channelId, sharedData);
+      const channel = getChannel(sharedData, channelId);
+      if (!channel) {
+        throw new Error(`Channel does not exist with id ${channelId}`);
+      }
+      const proposedAllocation = getLastCommitment(channel).allocation;
+      const proposedDestination = getLastCommitment(channel).destination;
+      const indirectDefundingState = indirectDefundingInitialize({
+        processId,
+        channelId,
+        ledgerId,
+        proposedAllocation,
+        proposedDestination,
+        sharedData,
+        action,
+      });
 
-    const protocolState = states.waitForLedgerDefunding({
-      processId,
-      channelId,
-      indirectDefundingState: indirectDefundingState.protocolState,
-    });
+      const protocolState = states.waitForLedgerDefunding({
+        processId,
+        channelId,
+        indirectDefundingState: indirectDefundingState.protocolState,
+      });
 
-    return { protocolState, sharedData: indirectDefundingState.sharedData };
+      return { protocolState, sharedData: indirectDefundingState.sharedData };
+
+    case helpers.FundingType.Virtual:
+      let virtualDefunding: VirtualDefundingState;
+      ({ protocolState: virtualDefunding, sharedData } = initializeVirtualDefunding({
+        processId,
+        targetChannelId: channelId,
+
+        protocolLocator: makeLocator(EmbeddedProtocol.VirtualDefunding),
+        sharedData,
+      }));
+      return {
+        protocolState: states.waitForVirtualDefunding({ processId, channelId, virtualDefunding }),
+        sharedData,
+      };
   }
 };
 
@@ -70,13 +89,50 @@ export const defundingReducer = (
       return waitForWithdrawalReducer(protocolState, sharedData, action);
     case 'Defunding.WaitForIndirectDefunding':
       return waitForIndirectDefundingReducer(protocolState, sharedData, action);
+    case 'Defunding.WaitForVirtualDefunding':
+      return waitForVirtualDefundingReducer(protocolState, sharedData, action);
     case 'Defunding.Failure':
     case 'Defunding.Success':
       return { protocolState, sharedData };
     default:
       return unreachable(protocolState);
   }
-  return { protocolState, sharedData };
+};
+
+const waitForVirtualDefundingReducer = (
+  protocolState: states.WaitForVirtualDefunding,
+  sharedData: SharedData,
+  action: actions.DefundingAction,
+): ProtocolStateWithSharedData<states.DefundingState> => {
+  if (!routesToConsensusUpdate(action, makeLocator(EmbeddedProtocol.ConsensusUpdate))) {
+    console.warn(`Expected virtual defunding action but received ${action.type}`);
+    return { protocolState, sharedData };
+  }
+  let virtualDefunding: VirtualDefundingState;
+  ({ protocolState: virtualDefunding, sharedData } = virtualDefundingReducer(
+    protocolState.virtualDefunding,
+    sharedData,
+    action,
+  ));
+
+  switch (virtualDefunding.type) {
+    case 'VirtualDefunding.Failure':
+      return {
+        protocolState: states.failure({ reason: 'Virtual De-Funding Failure' }),
+        sharedData,
+      };
+    case 'VirtualDefunding.Success':
+      const fundingChannelId = helpers.getDirectlyFundedChannel(
+        protocolState.channelId,
+        sharedData,
+      );
+      return createWaitForWithdrawal(sharedData, protocolState.processId, fundingChannelId);
+    default:
+      return {
+        protocolState: states.waitForVirtualDefunding({ ...protocolState, virtualDefunding }),
+        sharedData,
+      };
+  }
 };
 
 const waitForIndirectDefundingReducer = (

--- a/packages/wallet/src/redux/protocols/defunding/reducer.ts
+++ b/packages/wallet/src/redux/protocols/defunding/reducer.ts
@@ -18,7 +18,7 @@ import { getLastCommitment } from '../../channel-store';
 import { ProtocolAction } from '../../../redux/actions';
 import { VirtualDefundingState } from '../virtual-defunding/states';
 import { initializeVirtualDefunding, virtualDefundingReducer } from '../virtual-defunding';
-import { routesToConsensusUpdate } from '../consensus-update/actions';
+import { routesToVirtualDefunding } from '../virtual-defunding/actions';
 
 export const initialize = (
   processId: string,
@@ -80,7 +80,7 @@ const waitForVirtualDefundingReducer = (
   sharedData: SharedData,
   action: actions.DefundingAction,
 ): ProtocolStateWithSharedData<states.DefundingState> => {
-  if (!routesToConsensusUpdate(action, [])) {
+  if (!routesToVirtualDefunding(action, [])) {
     console.warn(`Expected virtual defunding action but received ${action.type}`);
     return { protocolState, sharedData };
   }

--- a/packages/wallet/src/redux/protocols/defunding/reducer.ts
+++ b/packages/wallet/src/redux/protocols/defunding/reducer.ts
@@ -231,7 +231,7 @@ const createIndirectDefundingState = (
   clearedToSend: boolean,
   sharedData: SharedData,
 ) => {
-  const ledgerId = helpers.getFundingChannelId(channelId, sharedData);
+  const ledgerId = helpers.getChannelWithFunds(channelId, sharedData);
   const channel = getChannel(sharedData, channelId);
   if (!channel) {
     throw new Error(`Channel does not exist with id ${channelId}`);
@@ -245,7 +245,7 @@ const createIndirectDefundingState = (
     proposedAllocation,
     proposedDestination,
     sharedData,
-    clearedToSend: true,
+    clearedToSend,
     protocolLocator: makeLocator([], EmbeddedProtocol.IndirectDefunding),
   });
 

--- a/packages/wallet/src/redux/protocols/defunding/reducer.ts
+++ b/packages/wallet/src/redux/protocols/defunding/reducer.ts
@@ -104,7 +104,7 @@ const waitForVirtualDefundingReducer = (
   sharedData: SharedData,
   action: actions.DefundingAction,
 ): ProtocolStateWithSharedData<states.DefundingState> => {
-  if (!routesToConsensusUpdate(action, makeLocator(EmbeddedProtocol.ConsensusUpdate))) {
+  if (!routesToConsensusUpdate(action, [])) {
     console.warn(`Expected virtual defunding action but received ${action.type}`);
     return { protocolState, sharedData };
   }

--- a/packages/wallet/src/redux/protocols/defunding/reducer.ts
+++ b/packages/wallet/src/redux/protocols/defunding/reducer.ts
@@ -41,10 +41,12 @@ export const initialize = (
         true,
         sharedData,
       ));
+
       return {
         protocolState: states.waitForLedgerDefunding({
           processId,
           channelId,
+          ledgerId: helpers.getChannelWithFunds(channelId, sharedData),
           indirectDefundingState,
         }),
         sharedData,
@@ -70,6 +72,7 @@ export const initialize = (
         protocolState: states.waitForVirtualDefunding({
           processId,
           channelId,
+          ledgerId: helpers.getChannelWithFunds(channelId, sharedData),
           virtualDefunding,
           indirectDefundingState,
         }),
@@ -137,7 +140,7 @@ const waitForVirtualDefundingReducer = (
     case 'VirtualDefunding.Success':
       const { processId } = protocolState;
       return handleIndirectDefundingAction(
-        protocolState,
+        states.waitForLedgerDefunding(protocolState),
         sharedData,
         indirectDefundingActions.clearedToSend({
           processId,
@@ -216,7 +219,7 @@ const handleIndirectDefundingAction = (
         sharedData,
       };
     case 'IndirectDefunding.Success':
-      return createWaitForWithdrawal(sharedData, protocolState.processId, protocolState.channelId);
+      return createWaitForWithdrawal(sharedData, protocolState.processId, protocolState.ledgerId);
     default:
       return { protocolState: { ...protocolState, indirectDefundingState }, sharedData };
   }

--- a/packages/wallet/src/redux/protocols/defunding/reducer.ts
+++ b/packages/wallet/src/redux/protocols/defunding/reducer.ts
@@ -46,7 +46,7 @@ export const initialize = (
         protocolState: states.waitForLedgerDefunding({
           processId,
           channelId,
-          ledgerId: helpers.getChannelWithFunds(channelId, sharedData),
+          ledgerId: helpers.getFundingChannelId(channelId, sharedData),
           indirectDefundingState,
         }),
         sharedData,
@@ -72,7 +72,7 @@ export const initialize = (
         protocolState: states.waitForVirtualDefunding({
           processId,
           channelId,
-          ledgerId: helpers.getChannelWithFunds(channelId, sharedData),
+          ledgerId: helpers.getFundingChannelId(channelId, sharedData),
           virtualDefunding,
           indirectDefundingState,
         }),
@@ -231,7 +231,7 @@ const createIndirectDefundingState = (
   clearedToSend: boolean,
   sharedData: SharedData,
 ) => {
-  const ledgerId = helpers.getChannelWithFunds(channelId, sharedData);
+  const ledgerId = helpers.getFundingChannelId(channelId, sharedData);
   const channel = getChannel(sharedData, channelId);
   if (!channel) {
     throw new Error(`Channel does not exist with id ${channelId}`);

--- a/packages/wallet/src/redux/protocols/defunding/states.ts
+++ b/packages/wallet/src/redux/protocols/defunding/states.ts
@@ -31,6 +31,7 @@ export interface WaitForVirtualDefunding {
   type: 'Defunding.WaitForVirtualDefunding';
   processId: string;
   virtualDefunding: NonTerminalVirtualDefundingState;
+  indirectDefundingState: IndirectDefundingState;
   channelId: string;
 }
 

--- a/packages/wallet/src/redux/protocols/defunding/states.ts
+++ b/packages/wallet/src/redux/protocols/defunding/states.ts
@@ -2,7 +2,10 @@ import { WithdrawalState } from '../withdrawing/states';
 import { StateConstructor } from '../../utils';
 import { IndirectDefundingState } from '../indirect-defunding/states';
 import { ProtocolState } from '..';
-import { VirtualDefundingState } from '../virtual-defunding/states';
+import {
+  VirtualDefundingState,
+  NonTerminalVirtualDefundingState,
+} from '../virtual-defunding/states';
 
 // -------
 // States
@@ -30,7 +33,7 @@ export interface WaitForIndirectDefunding {
 export interface WaitForVirtualDefunding {
   type: 'Defunding.WaitForVirtualDefunding';
   processId: string;
-  virtualDefunding: VirtualDefundingState;
+  virtualDefunding: NonTerminalVirtualDefundingState;
   channelId: string;
 }
 

--- a/packages/wallet/src/redux/protocols/defunding/states.ts
+++ b/packages/wallet/src/redux/protocols/defunding/states.ts
@@ -25,6 +25,7 @@ export interface WaitForIndirectDefunding {
   processId: string;
   indirectDefundingState: IndirectDefundingState;
   channelId;
+  ledgerId: string;
 }
 
 export interface WaitForVirtualDefunding {
@@ -33,6 +34,7 @@ export interface WaitForVirtualDefunding {
   virtualDefunding: NonTerminalVirtualDefundingState;
   indirectDefundingState: IndirectDefundingState;
   channelId: string;
+  ledgerId: string;
 }
 
 export interface Failure {

--- a/packages/wallet/src/redux/protocols/defunding/states.ts
+++ b/packages/wallet/src/redux/protocols/defunding/states.ts
@@ -2,10 +2,7 @@ import { WithdrawalState } from '../withdrawing/states';
 import { StateConstructor } from '../../utils';
 import { IndirectDefundingState } from '../indirect-defunding/states';
 import { ProtocolState } from '..';
-import {
-  VirtualDefundingState,
-  NonTerminalVirtualDefundingState,
-} from '../virtual-defunding/states';
+import { NonTerminalVirtualDefundingState } from '../virtual-defunding/states';
 
 // -------
 // States

--- a/packages/wallet/src/redux/protocols/defunding/states.ts
+++ b/packages/wallet/src/redux/protocols/defunding/states.ts
@@ -2,6 +2,7 @@ import { WithdrawalState } from '../withdrawing/states';
 import { StateConstructor } from '../../utils';
 import { IndirectDefundingState } from '../indirect-defunding/states';
 import { ProtocolState } from '..';
+import { VirtualDefundingState } from '../virtual-defunding/states';
 
 // -------
 // States
@@ -26,6 +27,13 @@ export interface WaitForIndirectDefunding {
   channelId;
 }
 
+export interface WaitForVirtualDefunding {
+  type: 'Defunding.WaitForVirtualDefunding';
+  processId: string;
+  virtualDefunding: VirtualDefundingState;
+  channelId: string;
+}
+
 export interface Failure {
   type: 'Defunding.Failure';
   reason: string;
@@ -47,6 +55,9 @@ export const waitForLedgerDefunding: StateConstructor<WaitForIndirectDefunding> 
   return { ...p, type: 'Defunding.WaitForIndirectDefunding' };
 };
 
+export const waitForVirtualDefunding: StateConstructor<WaitForVirtualDefunding> = p => {
+  return { ...p, type: 'Defunding.WaitForVirtualDefunding' };
+};
 export const success: StateConstructor<Success> = p => {
   return { ...p, type: 'Defunding.Success' };
 };
@@ -59,8 +70,11 @@ export const failure: StateConstructor<Failure> = p => {
 // Unions and Guards
 // -------
 
-export type NonTerminalDefundingState = WaitForWithdrawal | WaitForIndirectDefunding;
-export type DefundingState = WaitForWithdrawal | WaitForIndirectDefunding | Failure | Success;
+export type NonTerminalDefundingState =
+  | WaitForWithdrawal
+  | WaitForIndirectDefunding
+  | WaitForVirtualDefunding;
+export type DefundingState = NonTerminalDefundingState | Failure | Success;
 export type DefundingStateType = DefundingState['type'];
 
 export function isTerminal(state: DefundingState): state is Failure | Success {

--- a/packages/wallet/src/redux/protocols/defunding/states.ts
+++ b/packages/wallet/src/redux/protocols/defunding/states.ts
@@ -85,6 +85,7 @@ export function isDefundingState(state: ProtocolState): state is DefundingState 
   return (
     state.type === 'Defunding.WaitForWithdrawal' ||
     state.type === 'Defunding.WaitForIndirectDefunding' ||
+    state.type === 'Defunding.WaitForVirtualDefunding' ||
     state.type === 'Defunding.Failure' ||
     state.type === 'Defunding.Success'
   );

--- a/packages/wallet/src/redux/protocols/direct-funding/__tests__/scenarios.ts
+++ b/packages/wallet/src/redux/protocols/direct-funding/__tests__/scenarios.ts
@@ -60,7 +60,7 @@ const adjudicatorStateSharedData: SharedData = {
   adjudicatorState: { [channelId]: { channelId, balance: '0x5', finalized: false } },
 };
 export const aHappyPath = {
-  initialize: { sharedData: sharedData(), ...defaultsForA },
+  initialize: { ...defaultsForA, sharedData: sharedData() },
   waitForDepositTransaction: {
     state: states.waitForDepositTransaction({
       ...defaultsForA,
@@ -123,7 +123,7 @@ export const transactionFails = {
 };
 
 export const fundsReceivedArrivesEarly = {
-  initialize: { sharedData: sharedData(), ...defaultsForA },
+  initialize: { ...defaultsForA, sharedData: sharedData() },
   waitForDepositTransaction: {
     state: states.waitForDepositTransaction({
       ...defaultsForA,

--- a/packages/wallet/src/redux/protocols/indirect-defunding/actions.ts
+++ b/packages/wallet/src/redux/protocols/indirect-defunding/actions.ts
@@ -40,6 +40,6 @@ export function isIndirectDefundingAction(action: WalletAction): action is Indir
   );
 }
 export const routesToIndirectDefunding = routerFactory(
-  isConsensusUpdateAction,
+  isIndirectDefundingAction,
   EmbeddedProtocol.IndirectDefunding,
 );

--- a/packages/wallet/src/redux/protocols/indirect-defunding/reducer.ts
+++ b/packages/wallet/src/redux/protocols/indirect-defunding/reducer.ts
@@ -47,7 +47,7 @@ export const initialize = ({
     proposedDestination,
     channelId: ledgerId,
     clearedToSend,
-    protocolLocator,
+    protocolLocator: makeLocator(protocolLocator, EmbeddedProtocol.ConsensusUpdate),
     sharedData,
   }));
 

--- a/packages/wallet/src/redux/protocols/reducer-helpers.ts
+++ b/packages/wallet/src/redux/protocols/reducer-helpers.ts
@@ -208,17 +208,6 @@ export const getChannelFundingType = (channelId: string, sharedData: SharedData)
   return channelState.participants.length === 3 ? FundingType.Virtual : FundingType.Ledger;
 };
 
-export const getFundingChannelId = (channelId: string, sharedData: SharedData): string => {
-  const channelFundingState = selectors.getChannelFundingState(sharedData, channelId);
-  if (!channelFundingState) {
-    throw new Error(`No funding state for ${channelId}. Cannot determine funding type.`);
-  }
-
-  if (!channelFundingState.fundingChannel) {
-    throw new Error('No funding channel id defined.');
-  }
-  return channelFundingState.fundingChannel;
-};
 export const getTwoPlayerIndex = (
   channelId: string,
   sharedData: SharedData,
@@ -293,7 +282,7 @@ export function ourTurn(sharedData: SharedData, channelId: string) {
   return ourTurnOnChannel(channel);
 }
 
-export function getChannelWithFunds(channelId: string, sharedData: SharedData): string {
+export function getFundingChannelId(channelId: string, sharedData: SharedData): string {
   const fundingState = selectors.getChannelFundingState(sharedData, channelId);
   if (!fundingState) {
     throw new Error(`No funding state found for ${channelId}`);
@@ -310,6 +299,6 @@ export function getChannelWithFunds(channelId: string, sharedData: SharedData): 
       );
     }
 
-    return getChannelWithFunds(channelIdToCheck, sharedData);
+    return getFundingChannelId(channelIdToCheck, sharedData);
   }
 }

--- a/packages/wallet/src/redux/protocols/virtual-defunding/__tests__/index.ts
+++ b/packages/wallet/src/redux/protocols/virtual-defunding/__tests__/index.ts
@@ -1,3 +1,4 @@
 import { happyPath } from './scenarios';
 
 export const preSuccess = happyPath.waitForLedgerChannel;
+export const initial = happyPath.initialize;

--- a/packages/wallet/src/redux/protocols/virtual-defunding/__tests__/reducer.test.ts
+++ b/packages/wallet/src/redux/protocols/virtual-defunding/__tests__/reducer.test.ts
@@ -4,7 +4,8 @@ import * as states from '../states';
 import { scenarioStepDescription, itSendsTheseCommitments } from '../../../__tests__/helpers';
 import { bigNumberify } from 'ethers/utils';
 import { bytesFromAppAttributes } from 'fmg-nitro-adjudicator/lib/consensus-app';
-import { asAddress, bsAddress, hubAddress } from '../../../../domain/commitments/__tests__';
+import { asAddress, bsAddress } from '../../../../domain/commitments/__tests__';
+import { HUB_ADDRESS } from '../../../../constants';
 const itTransitionsTo = (
   result: states.VirtualDefundingState,
   type: states.VirtualDefundingStateType,
@@ -28,7 +29,7 @@ describe('happyPath', () => {
         bigNumberify(3).toHexString(),
         bigNumberify(4).toHexString(),
       ],
-      proposedDestination: [asAddress, bsAddress, hubAddress],
+      proposedDestination: [asAddress, bsAddress, HUB_ADDRESS],
       furtherVotesRequired: 2,
     });
 
@@ -59,7 +60,7 @@ describe('happyPath', () => {
 
     const appAttributes = bytesFromAppAttributes({
       proposedAllocation: [bigNumberify(1).toHexString(), bigNumberify(3).toHexString()],
-      proposedDestination: [asAddress, hubAddress],
+      proposedDestination: [asAddress, HUB_ADDRESS],
       furtherVotesRequired: 1,
     });
 

--- a/packages/wallet/src/redux/protocols/virtual-defunding/__tests__/scenarios.ts
+++ b/packages/wallet/src/redux/protocols/virtual-defunding/__tests__/scenarios.ts
@@ -36,7 +36,7 @@ const guarantorChannelId = '0x01';
 const startingAllocation = app0.commitment.allocation;
 const startingDestination = app0.commitment.destination;
 const props = {
-  appChannelId,
+  targetChannelId: appChannelId,
   processId,
   startingAllocation,
   startingDestination,

--- a/packages/wallet/src/redux/protocols/virtual-defunding/__tests__/scenarios.ts
+++ b/packages/wallet/src/redux/protocols/virtual-defunding/__tests__/scenarios.ts
@@ -10,14 +10,15 @@ import { bsAddress } from '../../../../communication/__tests__/commitments';
 import { commitmentsReceived, EmbeddedProtocol } from '../../../../communication';
 import { makeLocator } from '../..';
 import * as consensusStates from '../../consensus-update/states';
+import { HUB_ADDRESS } from '../../../../constants';
 
 // ---------
 // Test data
 // ---------
 const processId = 'Process.123';
 
-const { asAddress, asPrivateKey, threeParticipants: destination } = scenarios;
-const hubAddress = destination[2];
+const { asAddress, asPrivateKey } = scenarios;
+const hubAddress = HUB_ADDRESS;
 const twoTwo = [
   { address: asAddress, wei: bigNumberify(2).toHexString() },
   { address: hubAddress, wei: bigNumberify(2).toHexString() },

--- a/packages/wallet/src/redux/protocols/virtual-defunding/__tests__/scenarios.ts
+++ b/packages/wallet/src/redux/protocols/virtual-defunding/__tests__/scenarios.ts
@@ -135,21 +135,25 @@ const waitForLedgerChannelUpdate = states.waitForLedgerChannelUpdate({
 const createFundingState = sharedData => {
   return setFundingState(
     setFundingState(
-      setFundingState(sharedData, appChannelId, {
-        fundingChannel: jointChannelId,
-        directlyFunded: false,
-      }),
-      jointChannelId,
+      setFundingState(
+        setFundingState(sharedData, appChannelId, {
+          fundingChannel: jointChannelId,
+          directlyFunded: false,
+        }),
+        jointChannelId,
+        {
+          guarantorChannel: guarantorChannelId,
+          directlyFunded: false,
+        },
+      ),
+      guarantorChannelId,
       {
-        guarantorChannel: guarantorChannelId,
+        fundingChannel: ledgerId,
         directlyFunded: false,
       },
     ),
-    guarantorChannelId,
-    {
-      fundingChannel: ledgerId,
-      directlyFunded: false,
-    },
+    ledgerId,
+    { directlyFunded: true },
   );
 };
 

--- a/packages/wallet/src/redux/protocols/virtual-defunding/__tests__/scenarios.ts
+++ b/packages/wallet/src/redux/protocols/virtual-defunding/__tests__/scenarios.ts
@@ -100,6 +100,7 @@ const props = {
   protocolLocator: [],
   ourAddress: asAddress,
   jointChannelId,
+  ledgerChannelId: ledgerId,
 };
 
 // ----

--- a/packages/wallet/src/redux/protocols/virtual-defunding/container.tsx
+++ b/packages/wallet/src/redux/protocols/virtual-defunding/container.tsx
@@ -1,0 +1,40 @@
+import * as states from './states';
+import { PureComponent } from 'react';
+import React from 'react';
+
+import { connect } from 'react-redux';
+import { unreachable } from '../../../utils/reducer-utils';
+import WaitForOtherPlayer from '../shared-components/wait-for-other-player';
+
+interface Props {
+  state: states.NonTerminalVirtualDefundingState;
+}
+
+class VirtualDefundingContainer extends PureComponent<Props> {
+  render() {
+    const { state } = this.props;
+    switch (state.type) {
+      case 'VirtualDefunding.WaitForJointChannelUpdate':
+        return (
+          <WaitForOtherPlayer
+            actionDescriptor={'joint channel update'}
+            channelId={state.jointChannelId}
+          />
+        );
+      case 'VirtualDefunding.WaitForLedgerChannelUpdate':
+        return (
+          <WaitForOtherPlayer
+            actionDescriptor={'ledger channel update'}
+            channelId={state.ledgerChannelId}
+          />
+        );
+
+      default:
+        return unreachable(state);
+    }
+  }
+}
+export const VirtualDefunding = connect(
+  () => ({}),
+  () => ({}),
+)(VirtualDefundingContainer);

--- a/packages/wallet/src/redux/protocols/virtual-defunding/index.ts
+++ b/packages/wallet/src/redux/protocols/virtual-defunding/index.ts
@@ -1,0 +1,6 @@
+export { VirtualDefundingState, NonTerminalVirtualDefundingState, isTerminal } from './states';
+export { VirtualDefundingAction, isVirtualDefundingAction } from './actions';
+export {
+  initialize as initializeVirtualDefunding,
+  reducer as virtualDefundingReducer,
+} from './reducer';

--- a/packages/wallet/src/redux/protocols/virtual-defunding/reducer.ts
+++ b/packages/wallet/src/redux/protocols/virtual-defunding/reducer.ts
@@ -8,11 +8,7 @@ import {
   consensusUpdateReducer,
 } from '../consensus-update/reducer';
 import { getChannelFundingState } from '../../selectors';
-import {
-  getLatestCommitment,
-  getTwoPlayerIndex,
-  getChannelWithFunds,
-} from '../reducer-helpers';
+import { getLatestCommitment, getTwoPlayerIndex, getChannelWithFunds } from '../reducer-helpers';
 import { addHex } from '../../../utils/hex-utils';
 import { VirtualDefundingAction } from './actions';
 import { routesToConsensusUpdate } from '../consensus-update/actions';

--- a/packages/wallet/src/redux/protocols/virtual-defunding/reducer.ts
+++ b/packages/wallet/src/redux/protocols/virtual-defunding/reducer.ts
@@ -37,7 +37,7 @@ export function initialize({
 
   const proposedDestination = [...latestAppCommitment.destination, hubAddress];
   const proposedAllocation = [
-    latestAppCommitment.allocation.reduce(addHex),
+    ...latestAppCommitment.allocation,
     latestAppCommitment.allocation.reduce(addHex),
   ];
   let jointChannel: ConsensusUpdateState;
@@ -109,7 +109,7 @@ function waitForJointChannelUpdateReducer(
 
         const proposedAllocation = [
           latestAppCommitment.allocation[ourIndex],
-          latestAppCommitment.allocation.reduce(addHex),
+          latestAppCommitment.allocation[1 - ourIndex],
         ];
         const proposedDestination = [latestAppCommitment.destination[ourIndex], hubAddress];
         let ledgerChannel: ConsensusUpdateState;

--- a/packages/wallet/src/redux/protocols/virtual-defunding/reducer.ts
+++ b/packages/wallet/src/redux/protocols/virtual-defunding/reducer.ts
@@ -15,25 +15,25 @@ import { routesToConsensusUpdate } from '../consensus-update/actions';
 
 export function initialize({
   processId,
-  appChannelId,
+  targetChannelId,
   ourIndex,
   hubAddress,
   protocolLocator,
   sharedData,
 }: {
   processId: string;
-  appChannelId: string;
+  targetChannelId: string;
   ourIndex: number;
   hubAddress: string;
   protocolLocator: ProtocolLocator;
   sharedData: SharedData;
 }): ProtocolStateWithSharedData<states.NonTerminalVirtualDefundingState> {
-  const fundingState = getChannelFundingState(sharedData, appChannelId);
+  const fundingState = getChannelFundingState(sharedData, targetChannelId);
   if (!fundingState || !fundingState.fundingChannel) {
-    throw new Error(`Attempting to virtually defund a directly funded channel ${appChannelId}`);
+    throw new Error(`Attempting to virtually defund a directly funded channel ${targetChannelId}`);
   }
   const jointChannelId = fundingState.fundingChannel;
-  const latestAppCommitment = getLatestCommitment(appChannelId, sharedData);
+  const latestAppCommitment = getLatestCommitment(targetChannelId, sharedData);
 
   const proposedDestination = [...latestAppCommitment.destination, hubAddress];
   const proposedAllocation = [
@@ -58,7 +58,7 @@ export function initialize({
       hubAddress,
       jointChannel,
       jointChannelId,
-      appChannelId: appChannelId,
+      targetChannelId: targetChannelId,
       protocolLocator,
     }),
     sharedData,
@@ -96,7 +96,13 @@ function waitForJointChannelUpdateReducer(
       case 'ConsensusUpdate.Failure':
         return { protocolState: states.failure({}), sharedData };
       case 'ConsensusUpdate.Success':
-        const { hubAddress, jointChannelId, appChannelId, ourIndex, processId } = protocolState;
+        const {
+          hubAddress,
+          jointChannelId,
+          targetChannelId: appChannelId,
+          ourIndex,
+          processId,
+        } = protocolState;
         // TODO: We probably need to start this earlier to deal with commitments coming in early
         const ledgerChannelId = getLedgerChannelId(jointChannelId, sharedData);
         const latestAppCommitment = getLatestCommitment(appChannelId, sharedData);

--- a/packages/wallet/src/redux/protocols/virtual-defunding/reducer.ts
+++ b/packages/wallet/src/redux/protocols/virtual-defunding/reducer.ts
@@ -8,7 +8,11 @@ import {
   consensusUpdateReducer,
 } from '../consensus-update/reducer';
 import { getChannelFundingState } from '../../selectors';
-import { getLatestCommitment, getTwoPlayerIndex } from '../reducer-helpers';
+import {
+  getLatestCommitment,
+  getTwoPlayerIndex,
+  getDirectlyFundedChannel,
+} from '../reducer-helpers';
 import { addHex } from '../../../utils/hex-utils';
 import { VirtualDefundingAction } from './actions';
 import { routesToConsensusUpdate } from '../consensus-update/actions';
@@ -50,7 +54,7 @@ export function initialize({
     proposedDestination,
     sharedData,
   }));
-  const ledgerChannelId = getLedgerChannelId(jointChannelId, sharedData);
+  const ledgerChannelId = getDirectlyFundedChannel(targetChannelId, sharedData);
   return {
     protocolState: states.waitForJointChannelUpdate({
       processId,
@@ -166,23 +170,4 @@ function waitForLedgerChannelUpdateReducer(
     }
   }
   return { protocolState, sharedData };
-}
-
-function getLedgerChannelId(jointChannelId: string, sharedData: SharedData): string {
-  const guarantorFundingState = getChannelFundingState(sharedData, jointChannelId);
-  if (!guarantorFundingState || !guarantorFundingState.guarantorChannel) {
-    throw new Error(`No guarantor for joint channel ${jointChannelId}`);
-  }
-  const ledgerFundingState = getChannelFundingState(
-    sharedData,
-    guarantorFundingState.guarantorChannel,
-  );
-  if (!ledgerFundingState || !ledgerFundingState.fundingChannel) {
-    throw new Error(
-      `No ledger funding channel found for guarantor channel ${
-        guarantorFundingState.guarantorChannel
-      }`,
-    );
-  }
-  return ledgerFundingState.fundingChannel;
 }

--- a/packages/wallet/src/redux/protocols/virtual-defunding/reducer.ts
+++ b/packages/wallet/src/redux/protocols/virtual-defunding/reducer.ts
@@ -11,7 +11,7 @@ import { getChannelFundingState } from '../../selectors';
 import {
   getLatestCommitment,
   getTwoPlayerIndex,
-  getDirectlyFundedChannel,
+  getChannelWithFunds,
 } from '../reducer-helpers';
 import { addHex } from '../../../utils/hex-utils';
 import { VirtualDefundingAction } from './actions';
@@ -54,7 +54,7 @@ export function initialize({
     proposedDestination,
     sharedData,
   }));
-  const ledgerChannelId = getDirectlyFundedChannel(targetChannelId, sharedData);
+  const ledgerChannelId = getChannelWithFunds(targetChannelId, sharedData);
   return {
     protocolState: states.waitForJointChannelUpdate({
       processId,

--- a/packages/wallet/src/redux/protocols/virtual-defunding/reducer.ts
+++ b/packages/wallet/src/redux/protocols/virtual-defunding/reducer.ts
@@ -8,7 +8,7 @@ import {
   consensusUpdateReducer,
 } from '../consensus-update/reducer';
 import { getChannelFundingState } from '../../selectors';
-import { getLatestCommitment, getTwoPlayerIndex, getChannelWithFunds } from '../reducer-helpers';
+import { getLatestCommitment, getTwoPlayerIndex, getFundingChannelId } from '../reducer-helpers';
 import { addHex } from '../../../utils/hex-utils';
 import { VirtualDefundingAction } from './actions';
 import { routesToConsensusUpdate } from '../consensus-update/actions';
@@ -48,7 +48,7 @@ export function initialize({
     proposedDestination,
     sharedData,
   }));
-  const ledgerChannelId = getChannelWithFunds(targetChannelId, sharedData);
+  const ledgerChannelId = getFundingChannelId(targetChannelId, sharedData);
   return {
     protocolState: states.waitForJointChannelUpdate({
       processId,

--- a/packages/wallet/src/redux/protocols/virtual-defunding/reducer.ts
+++ b/packages/wallet/src/redux/protocols/virtual-defunding/reducer.ts
@@ -58,7 +58,7 @@ export function initialize({
       hubAddress,
       jointChannel,
       jointChannelId,
-      targetChannelId: targetChannelId,
+      targetChannelId,
       protocolLocator,
     }),
     sharedData,

--- a/packages/wallet/src/redux/protocols/virtual-defunding/states.ts
+++ b/packages/wallet/src/redux/protocols/virtual-defunding/states.ts
@@ -9,7 +9,7 @@ interface Base {
   hubAddress: string;
   protocolLocator: ProtocolLocator;
   jointChannelId: string;
-  appChannelId: string;
+  targetChannelId: string;
 }
 
 export interface WaitForJointChannelUpdate extends Base {

--- a/packages/wallet/src/redux/protocols/virtual-defunding/states.ts
+++ b/packages/wallet/src/redux/protocols/virtual-defunding/states.ts
@@ -10,6 +10,7 @@ interface Base {
   protocolLocator: ProtocolLocator;
   jointChannelId: string;
   targetChannelId: string;
+  ledgerChannelId: string;
 }
 
 export interface WaitForJointChannelUpdate extends Base {

--- a/packages/wallet/src/redux/protocols/virtual-funding/__tests__/scenarios.ts
+++ b/packages/wallet/src/redux/protocols/virtual-funding/__tests__/scenarios.ts
@@ -56,6 +56,7 @@ const initializeArgs = {
 const props = {
   targetChannelId,
   processId,
+  jointChannelId,
   startingAllocation,
   startingDestination,
   hubAddress,

--- a/packages/wallet/src/redux/protocols/virtual-funding/reducer.ts
+++ b/packages/wallet/src/redux/protocols/virtual-funding/reducer.ts
@@ -360,6 +360,10 @@ function waitForApplicationFundingReducer(
     if (consensusUpdate.isTerminal(result.protocolState)) {
       switch (result.protocolState.type) {
         case 'ConsensusUpdate.Success':
+          result.sharedData = setFundingState(result.sharedData, protocolState.targetChannelId, {
+            directlyFunded: false,
+            fundingChannel: protocolState.jointChannelId,
+          });
           return {
             protocolState: states.success(protocolState),
             sharedData: result.sharedData,

--- a/packages/wallet/src/redux/protocols/virtual-funding/states.ts
+++ b/packages/wallet/src/redux/protocols/virtual-funding/states.ts
@@ -41,6 +41,7 @@ export interface WaitForGuarantorFunding extends Base {
 export interface WaitForApplicationFunding extends Base {
   type: 'VirtualFunding.WaitForApplicationFunding';
   indirectApplicationFunding: ConsensusUpdateState;
+  jointChannelId: string;
 }
 
 export interface Success {


### PR DESCRIPTION
This gets virtual de-funding integrated into the parent defunding protocol.
It allows for the defunding/withdrawal from a game that has been virtually funded.

This is dependent on #655 #661, #660 and #659 and should only be merged after those.