### PR TITLE
Refactor Indirect-Defunding to use AdvanceChannel and ConsensusUpdate

### DIFF
--- a/packages/wallet/src/redux/protocols/concluding/responder/__tests__/scenarios.ts
+++ b/packages/wallet/src/redux/protocols/concluding/responder/__tests__/scenarios.ts
@@ -6,16 +6,8 @@ import { channelFromCommitments } from '../../../../channel-store/channel-state/
 import { appCommitment, ledgerId } from '../../../../../domain/commitments/__tests__';
 import { bigNumberify } from 'ethers/utils';
 import { bsPrivateKey } from '../../../../../communication/__tests__/commitments';
-import {
-  ledgerUpdate0Received,
-  ledger4,
-  ledger5,
-  ledger7,
-  app10,
-  app11,
-  setFundingState as setFundingStateAlt,
-} from '../../../indirect-defunding/__tests__/scenarios';
 import { twoPlayerPreSuccessA, twoPlayerPreSuccessB } from '../../../consensus-update/__tests__';
+import { commitmentReceived } from '../../../../../communication/actions';
 
 // -----------------
 // Channel Scenarios
@@ -26,7 +18,25 @@ const twoThree = [
   { address: asAddress, wei: bigNumberify(2).toHexString() },
   { address: bsAddress, wei: bigNumberify(3).toHexString() },
 ];
+const fiveToApp = [{ address: channelId, wei: bigNumberify(5).toHexString() }];
 
+const app10 = appCommitment({ turnNum: 10, balances: twoThree, isFinal: true });
+const app11 = appCommitment({ turnNum: 11, balances: twoThree, isFinal: true });
+
+const ledger4 = testScenarios.ledgerCommitment({
+  turnNum: 4,
+  balances: twoThree,
+  proposedBalances: fiveToApp,
+});
+const ledger5 = testScenarios.ledgerCommitment({ turnNum: 5, balances: fiveToApp });
+const ledger6 = testScenarios.ledgerCommitment({
+  turnNum: 6,
+  balances: fiveToApp,
+  proposedBalances: twoThree,
+});
+const ledger7 = testScenarios.ledgerCommitment({ turnNum: 7, balances: twoThree });
+
+// -----------
 const app50 = appCommitment({ turnNum: 50, balances: twoThree, isFinal: false });
 const app51 = appCommitment({ turnNum: 51, balances: twoThree, isFinal: false });
 const app52 = appCommitment({ turnNum: 52, balances: twoThree, isFinal: true });
@@ -95,7 +105,11 @@ const concludeSent = actions.concludeApproved({ processId });
 const defundChosen = actions.defundChosen({ processId });
 const acknowledged = actions.acknowledged({ processId });
 const keepOpenChosen = actions.keepOpenChosen({ processId });
-
+const ledgerUpdate0Received = commitmentReceived({
+  processId,
+  signedCommitment: ledger6,
+  protocolLocator: [],
+});
 // -------
 // Scenarios
 // -------
@@ -141,11 +155,13 @@ export const happyPathAlternative = {
 
   decideDefund: {
     state: decideDefund,
-    sharedData: setFundingStateAlt(
+    sharedData: setFundingState(
       setChannels(EMPTY_SHARED_DATA, [
         channelFromCommitments([app10, app11], bsAddress, bsPrivateKey),
         channelFromCommitments([ledger4, ledger5], bsAddress, bsPrivateKey),
       ]),
+      channelId,
+      { directlyFunded: false, fundingChannel: ledgerId },
     ),
     action: ledgerUpdate0Received,
     reply: ledger7,

--- a/packages/wallet/src/redux/protocols/defunding/__tests__/reducer.test.ts
+++ b/packages/wallet/src/redux/protocols/defunding/__tests__/reducer.test.ts
@@ -84,13 +84,13 @@ describe('indirectly funded happy path', () => {
   });
 });
 
-describe('indirectly funded failure', () => {
-  const scenario = scenarios.indirectlyFundingFailure;
+// describe('indirectly funded failure', () => {
+//   const scenario = scenarios.indirectlyFundingFailure;
 
-  describeScenarioStep(scenario.waitForLedgerDefunding, () => {
-    const { state, action, sharedData } = scenario.waitForLedgerDefunding;
-    const result = defundingReducer(state, sharedData, action);
+//   describeScenarioStep(scenario.waitForLedgerDefunding, () => {
+//     const { state, action, sharedData } = scenario.waitForLedgerDefunding;
+//     const result = defundingReducer(state, sharedData, action);
 
-    itTransitionsToFailure(result, states.failure({ reason: 'Ledger De-funding Failure' }));
-  });
-});
+//     itTransitionsToFailure(result, states.failure({ reason: 'Ledger De-funding Failure' }));
+//   });
+// });

--- a/packages/wallet/src/redux/protocols/defunding/__tests__/reducer.test.ts
+++ b/packages/wallet/src/redux/protocols/defunding/__tests__/reducer.test.ts
@@ -83,14 +83,3 @@ describe('indirectly funded happy path', () => {
     itSendsThisDisplayEventType(result.sharedData, HIDE_WALLET);
   });
 });
-
-// describe('indirectly funded failure', () => {
-//   const scenario = scenarios.indirectlyFundingFailure;
-
-//   describeScenarioStep(scenario.waitForLedgerDefunding, () => {
-//     const { state, action, sharedData } = scenario.waitForLedgerDefunding;
-//     const result = defundingReducer(state, sharedData, action);
-
-//     itTransitionsToFailure(result, states.failure({ reason: 'Ledger De-funding Failure' }));
-//   });
-// });

--- a/packages/wallet/src/redux/protocols/defunding/__tests__/scenarios.ts
+++ b/packages/wallet/src/redux/protocols/defunding/__tests__/scenarios.ts
@@ -70,12 +70,6 @@ const waitForLedgerDefunding = states.waitForLedgerDefunding({
   indirectDefundingState: indirectDefunding.preSuccessState.state,
 });
 
-// const waitForLedgerFailure = states.waitForLedgerDefunding({
-//   processId,
-//   channelId,
-//   indirectDefundingState: indirectDefunding.preFailureState.state,
-// });
-
 const channelNotClosedFailure = states.failure({ reason: 'Channel Not Closed' });
 
 export const directlyFundingChannelHappyPath = {

--- a/packages/wallet/src/redux/protocols/defunding/__tests__/scenarios.ts
+++ b/packages/wallet/src/redux/protocols/defunding/__tests__/scenarios.ts
@@ -75,11 +75,11 @@ const waitForLedgerDefunding = states.waitForLedgerDefunding({
   indirectDefundingState: indirectDefunding.preSuccessState.state,
 });
 
-const waitForLedgerFailure = states.waitForLedgerDefunding({
-  processId,
-  channelId,
-  indirectDefundingState: indirectDefunding.preFailureState.state,
-});
+// const waitForLedgerFailure = states.waitForLedgerDefunding({
+//   processId,
+//   channelId,
+//   indirectDefundingState: indirectDefunding.preFailureState.state,
+// });
 
 const channelNotClosedFailure = states.failure({ reason: 'Channel Not Closed' });
 
@@ -113,7 +113,7 @@ export const indirectlyFundingChannelHappyPath = {
   waitForLedgerDefunding: {
     state: waitForLedgerDefunding,
     action: indirectDefunding.successTrigger,
-    sharedData: indirectDefunding.preSuccessState.store,
+    sharedData: indirectDefunding.preSuccessState.sharedData,
   },
   waitForWithdrawal: {
     state: waitForWithdrawal,
@@ -155,13 +155,13 @@ export const directlyFundingFailure = {
   },
 };
 
-export const indirectlyFundingFailure = {
-  processId,
-  channelId,
-  // States
-  waitForLedgerDefunding: {
-    state: waitForLedgerFailure,
-    action: indirectDefunding.failureTrigger,
-    sharedData: indirectDefunding.preFailureState.store,
-  },
-};
+// export const indirectlyFundingFailure = {
+//   processId,
+//   channelId,
+//   // States
+//   waitForLedgerDefunding: {
+//     state: waitForLedgerFailure,
+//     action: indirectDefunding.failureTrigger,
+//     sharedData: indirectDefunding.preFailureState.store,
+//   },
+// };

--- a/packages/wallet/src/redux/protocols/defunding/__tests__/scenarios.ts
+++ b/packages/wallet/src/redux/protocols/defunding/__tests__/scenarios.ts
@@ -2,38 +2,33 @@ import * as states from '../states';
 import * as withdrawalScenarios from '../../withdrawing/__tests__/scenarios';
 import * as testScenarios from '../../../../domain/commitments/__tests__';
 import { ChannelState, ChannelStore } from '../../../channel-store';
-import { EMPTY_SHARED_DATA, FundingState } from '../../../state';
+import { EMPTY_SHARED_DATA, FundingState, setFundingState, setChannels } from '../../../state';
 import * as indirectDefunding from '../../indirect-defunding/__tests__';
+import { channelFromCommitments } from '../../../channel-store/channel-state/__tests__';
+import { bigNumberify } from 'ethers/utils';
 const processId = 'process-id.123';
 
-const {
-  asAddress: address,
-  asPrivateKey: privateKey,
-  channelId,
-  libraryAddress,
-  participants,
-  channelNonce,
-} = testScenarios;
+const { asAddress, bsAddress, asPrivateKey, channelId } = testScenarios;
+
+const twoThree = [
+  { address: asAddress, wei: bigNumberify(2).toHexString() },
+  { address: bsAddress, wei: bigNumberify(3).toHexString() },
+];
+
 const gameCommitment1 = testScenarios.appCommitment({ turnNum: 19 }).commitment;
 const gameCommitment2 = testScenarios.appCommitment({ turnNum: 20 }).commitment;
-const concludeCommitment1 = testScenarios.appCommitment({ turnNum: 51, isFinal: true }).commitment;
-const concludeCommitment2 = testScenarios.appCommitment({ turnNum: 52, isFinal: true }).commitment;
+const concludeCommitment1 = testScenarios.appCommitment({ turnNum: 51, isFinal: true });
+const concludeCommitment2 = testScenarios.appCommitment({ turnNum: 52, isFinal: true });
+const ledger4 = testScenarios.ledgerCommitment({ turnNum: 4, balances: twoThree });
+const ledger5 = testScenarios.ledgerCommitment({ turnNum: 5, balances: twoThree });
 
-const channelStatus: ChannelState = {
-  address,
-  privateKey,
-  channelId,
-  libraryAddress,
-  ourIndex: 0,
-  participants,
-  channelNonce,
-  turnNum: concludeCommitment2.turnNum,
-  funded: true,
-  commitments: [
-    { commitment: concludeCommitment1, signature: '0x0' },
-    { commitment: concludeCommitment2, signature: '0x0' },
-  ],
-};
+const channelStatus = channelFromCommitments(
+  [concludeCommitment1, concludeCommitment2],
+  asAddress,
+  asPrivateKey,
+);
+
+const ledgerChannelStatus = channelFromCommitments([ledger4, ledger5], asAddress, asPrivateKey);
 
 const channelStore: ChannelStore = {
   [channelId]: channelStatus,
@@ -108,12 +103,28 @@ export const directlyFundingChannelHappyPath = {
 };
 
 export const indirectlyFundingChannelHappyPath = {
-  initialize: { processId, channelId, sharedData: indirectDefunding.initialStore },
+  initialize: {
+    processId,
+    channelId,
+    sharedData: setChannels(
+      setFundingState(indirectDefunding.initialStore, channelId, {
+        directlyFunded: false,
+        fundingChannel: testScenarios.ledgerId,
+      }),
+      [channelStatus],
+    ),
+  },
   // States
   waitForLedgerDefunding: {
     state: waitForLedgerDefunding,
     action: indirectDefunding.successTrigger,
-    sharedData: indirectDefunding.preSuccessState.sharedData,
+    sharedData: setChannels(
+      setFundingState(indirectDefunding.preSuccessState.sharedData, channelId, {
+        directlyFunded: false,
+        fundingChannel: testScenarios.ledgerId,
+      }),
+      [channelStatus, ledgerChannelStatus],
+    ),
   },
   waitForWithdrawal: {
     state: waitForWithdrawal,

--- a/packages/wallet/src/redux/protocols/defunding/__tests__/scenarios.ts
+++ b/packages/wallet/src/redux/protocols/defunding/__tests__/scenarios.ts
@@ -165,14 +165,3 @@ export const directlyFundingFailure = {
     },
   },
 };
-
-// export const indirectlyFundingFailure = {
-//   processId,
-//   channelId,
-//   // States
-//   waitForLedgerDefunding: {
-//     state: waitForLedgerFailure,
-//     action: indirectDefunding.failureTrigger,
-//     sharedData: indirectDefunding.preFailureState.store,
-//   },
-// };

--- a/packages/wallet/src/redux/protocols/defunding/readme.md
+++ b/packages/wallet/src/redux/protocols/defunding/readme.md
@@ -43,4 +43,4 @@ linkStyle default interpolate basis
 2. **Indirect Funded Channel Happy Path** - Start -> Is Channel Closed -> Yes-> Is Direct Channel -> No -> Wait for Indirect de-funding -> Indirect de-funding Protocol Complete -> Wait for Withdrawal->Withdrawal Protocol Complete -> Success
 3. **Channel Not Closed** - Start -> Is Channel Closed -> No -> Failure
 4. **Withdrawal Failure** - Start -> Is Channel Closed -> Yes -> Is Direct Channel -> Yes -> Wait for Withdrawal-> Withdrawal Protocol Failure -> Failure
-5. **Indirect de-funding Failure** - Start -> Is Channel Closed -> Yes-> Is Direct Channel -> No ->Wait for Indirect de-funding->Indirect de-funding Protocol Failure -> Failure
+5. TODO: **Indirect de-funding Failure** - Start -> Is Channel Closed -> Yes-> Is Direct Channel -> No ->Wait for Indirect de-funding->Indirect de-funding Protocol Failure -> Failure

--- a/packages/wallet/src/redux/protocols/defunding/reducer.ts
+++ b/packages/wallet/src/redux/protocols/defunding/reducer.ts
@@ -43,7 +43,7 @@ export const initialize = (
       proposedAllocation,
       proposedDestination,
       sharedData,
-      clearedToSend: true,
+      clearedToProceed: true,
       protocolLocator: makeLocator(EmbeddedProtocol.IndirectDefunding),
     });
 

--- a/packages/wallet/src/redux/protocols/defunding/reducer.ts
+++ b/packages/wallet/src/redux/protocols/defunding/reducer.ts
@@ -1,5 +1,5 @@
 import { SharedData, getChannel } from '../../state';
-import { ProtocolStateWithSharedData } from '..';
+import { ProtocolStateWithSharedData, makeLocator } from '..';
 import * as states from './states';
 import * as helpers from '../reducer-helpers';
 import { withdrawalReducer, initialize as withdrawalInitialize } from './../withdrawing/reducer';
@@ -13,7 +13,7 @@ import {
 } from '../indirect-defunding/reducer';
 import { isIndirectDefundingAction } from '../indirect-defunding/actions';
 import * as indirectDefundingStates from '../indirect-defunding/states';
-import { CommitmentReceived } from '../../../communication';
+import { CommitmentReceived, EmbeddedProtocol } from '../../../communication';
 import { getLastCommitment } from '../../channel-store';
 import { ProtocolAction } from '../../../redux/actions';
 
@@ -43,7 +43,8 @@ export const initialize = (
       proposedAllocation,
       proposedDestination,
       sharedData,
-      action,
+      clearedToSend: true,
+      protocolLocator: makeLocator(EmbeddedProtocol.IndirectDefunding),
     });
 
     const protocolState = states.waitForLedgerDefunding({

--- a/packages/wallet/src/redux/protocols/indirect-defunding/__tests__/index.ts
+++ b/packages/wallet/src/redux/protocols/indirect-defunding/__tests__/index.ts
@@ -1,6 +1,4 @@
 import * as scenarios from './scenarios';
-export const initialStore = scenarios.playerAHappyPath.initialParams.sharedData;
-export const preSuccessState = scenarios.playerAHappyPath.waitForConclude.state;
-export const successTrigger = scenarios.playerAHappyPath.waitForConclude.action;
-export const preFailureState = scenarios.playerAInvalidCommitment.waitForLedgerUpdate.state;
-export const failureTrigger = scenarios.playerAInvalidCommitment.waitForLedgerUpdate.action;
+export const initialStore = scenarios.clearedToSendHappyPath.initialParams.sharedData;
+export const preSuccessState = scenarios.clearedToSendHappyPath.waitForConclude;
+export const successTrigger = scenarios.clearedToSendHappyPath.waitForConclude.action;

--- a/packages/wallet/src/redux/protocols/indirect-defunding/__tests__/reducer.test.ts
+++ b/packages/wallet/src/redux/protocols/indirect-defunding/__tests__/reducer.test.ts
@@ -1,46 +1,10 @@
 import * as scenarios from './scenarios';
 import { IndirectDefundingState, IndirectDefundingStateType } from '../states';
 import { ProtocolStateWithSharedData } from '../..';
-import { getLastMessage } from '../../../state';
-import { SignedCommitment } from '../../../../domain';
 import { initialize, indirectDefundingReducer } from '../reducer';
-import { itRelaysTheseActions } from '../../../__tests__/helpers';
 
-describe('player A happy path', () => {
-  const scenario = scenarios.playerAHappyPath;
-  const { relayActions } = scenario.initialParams;
-
-  describe('when initializing', () => {
-    const result = initialize(scenario.initialParams);
-    itTransitionsTo(result, 'IndirectDefunding.WaitForLedgerUpdate');
-    itRelaysTheseActions(result, relayActions);
-  });
-
-  describe('when in WaitForLedgerUpdate', () => {
-    const { state, action, reply } = scenario.waitForLedgerUpdate;
-    const updatedState = indirectDefundingReducer(state.state, state.store, action);
-    itTransitionsTo(updatedState, 'IndirectDefunding.WaitForConclude');
-    itSendsMessage(updatedState, reply);
-  });
-  describe('when in WaitForConclude', () => {
-    const { state, action } = scenario.waitForConclude;
-    const updatedState = indirectDefundingReducer(state.state, state.store, action);
-    itTransitionsTo(updatedState, 'IndirectDefunding.Success');
-  });
-});
-
-describe('player A invalid commitment', () => {
-  const scenario = scenarios.playerAInvalidCommitment;
-
-  describe('when in WaitForLedgerUpdate', () => {
-    const { state, action } = scenario.waitForLedgerUpdate;
-    const updatedState = indirectDefundingReducer(state.state, state.store, action);
-    itTransitionsTo(updatedState, 'IndirectDefunding.Failure');
-  });
-});
-
-describe('player B happy path', () => {
-  const scenario = scenarios.playerBHappyPath;
+describe('Cleared To Send happy path', () => {
+  const scenario = scenarios.clearedToSendHappyPath;
 
   describe('when initializing', () => {
     const result = initialize(scenario.initialParams);
@@ -48,35 +12,14 @@ describe('player B happy path', () => {
   });
 
   describe('when in WaitForLedgerUpdate', () => {
-    const { state, action, reply } = scenario.waitForLedgerUpdate;
-    const updatedState = indirectDefundingReducer(state.state, state.store, action);
+    const { state, action, sharedData } = scenario.waitForLedgerUpdate;
+    const updatedState = indirectDefundingReducer(state, sharedData, action);
     itTransitionsTo(updatedState, 'IndirectDefunding.WaitForConclude');
-    itSendsMessage(updatedState, reply);
   });
-
   describe('when in WaitForConclude', () => {
-    const { state, action, reply } = scenario.waitForConclude;
-    const updatedState = indirectDefundingReducer(state.state, state.store, action);
+    const { state, action, sharedData } = scenario.waitForConclude;
+    const updatedState = indirectDefundingReducer(state, sharedData, action);
     itTransitionsTo(updatedState, 'IndirectDefunding.Success');
-    itSendsMessage(updatedState, reply);
-  });
-});
-
-describe('player B invalid commitment', () => {
-  const scenario = scenarios.playerBInvalidCommitment;
-
-  describe('when in WaitForLedgerUpdate', () => {
-    const { state, action } = scenario.waitForLedgerUpdate;
-    const updatedState = indirectDefundingReducer(state.state, state.store, action);
-    itTransitionsTo(updatedState, 'IndirectDefunding.Failure');
-  });
-});
-
-describe('not defundable', () => {
-  const scenario = scenarios.notDefundable;
-  describe('when initializing', () => {
-    const result = initialize(scenario.initialParams);
-    itTransitionsTo(result, 'IndirectDefunding.Failure');
   });
 });
 
@@ -84,22 +27,5 @@ type ReturnVal = ProtocolStateWithSharedData<IndirectDefundingState>;
 function itTransitionsTo(state: ReturnVal, type: IndirectDefundingStateType) {
   it(`transitions protocol state to ${type}`, () => {
     expect(state.protocolState.type).toEqual(type);
-  });
-}
-
-function itSendsMessage(state: ReturnVal, message: SignedCommitment) {
-  it('sends a message', () => {
-    const lastMessage = getLastMessage(state.sharedData);
-    if (lastMessage && 'messagePayload' in lastMessage) {
-      const dataPayload = lastMessage.messagePayload;
-      // This is yuk. The data in a message is currently of 'any' type..
-      if (!('signedCommitment' in dataPayload)) {
-        fail('No signedCommitment in the last message.');
-      }
-      const { commitment, signature } = dataPayload.signedCommitment;
-      expect({ commitment, signature }).toEqual(message);
-    } else {
-      fail('No messages in the outbox.');
-    }
   });
 }

--- a/packages/wallet/src/redux/protocols/indirect-defunding/__tests__/scenarios.ts
+++ b/packages/wallet/src/redux/protocols/indirect-defunding/__tests__/scenarios.ts
@@ -35,14 +35,14 @@ export const clearedToSendHappyPath = {
       advanceChannelScenarios.postFund.preSuccess.sharedData,
     ),
     ...props,
-    clearedToSend: true,
+    clearedToProceed: true,
   },
   waitForLedgerUpdate: {
     state: waitForLedgerUpdate({
       ...props,
       ledgerUpdate,
       concluding,
-      ClearedToProceed: true,
+      clearedToProceed: true,
     }),
     action: ledgerUpdateScenarios.twoPlayerPreSuccessA.action,
     sharedData: ledgerUpdateScenarios.twoPlayerPreSuccessA.sharedData,

--- a/packages/wallet/src/redux/protocols/indirect-defunding/__tests__/scenarios.ts
+++ b/packages/wallet/src/redux/protocols/indirect-defunding/__tests__/scenarios.ts
@@ -23,7 +23,6 @@ const props = {
 };
 
 const ledgerUpdate = ledgerUpdateScenarios.twoPlayerPreSuccessA.state;
-// TODO: We should probably add a conclude scenario to advance channel
 const concluding = advanceChannelScenarios.postFund.preSuccess.state;
 
 // -----------

--- a/packages/wallet/src/redux/protocols/indirect-defunding/__tests__/scenarios.ts
+++ b/packages/wallet/src/redux/protocols/indirect-defunding/__tests__/scenarios.ts
@@ -1,20 +1,9 @@
-import {
-  appCommitment,
-  ledgerCommitment,
-  asAddress,
-  bsAddress,
-  asPrivateKey,
-  ledgerId,
-  channelId,
-} from '../../../../domain/commitments/__tests__';
+import { asAddress, bsAddress, channelId } from '../../../../domain/commitments/__tests__';
 import { bigNumberify } from 'ethers/utils/bignumber';
 import { waitForLedgerUpdate, waitForConclude } from '../states';
-import { setChannels, EMPTY_SHARED_DATA, SharedData } from '../../../state';
-import { channelFromCommitments } from '../../../channel-store/channel-state/__tests__';
-import { bsPrivateKey } from '../../../../communication/__tests__/commitments';
-import * as globalActions from '../../../actions';
-import { defundRequested } from '../../actions';
-
+import * as ledgerUpdateScenarios from '../../consensus-update/__tests__';
+import * as advanceChannelScenarios from '../../advance-channel/__tests__';
+import _ from 'lodash';
 const processId = 'processId';
 const protocolLocator = [];
 
@@ -23,179 +12,45 @@ const twoThree = [
   { address: bsAddress, wei: bigNumberify(3).toHexString() },
 ];
 
-const fiveToApp = [{ address: channelId, wei: bigNumberify(5).toHexString() }];
-
 const props = {
-  channelId,
-  ledgerId,
   processId,
+  protocolLocator,
+  channelId,
+  ledgerId: ledgerUpdateScenarios.twoPlayerPreSuccessA.state.channelId,
+
   proposedAllocation: twoThree.map(a => a.wei),
   proposedDestination: twoThree.map(a => a.address),
 };
 
-// -----------
-// Commitments
-// -----------
+const ledgerUpdate = ledgerUpdateScenarios.twoPlayerPreSuccessA.state;
+// TODO: We should probably add a conclude scenario to advance channel
+const concluding = advanceChannelScenarios.postFund.preSuccess.state;
 
-const app9 = appCommitment({ turnNum: 9, balances: twoThree, isFinal: false });
-export const app10 = appCommitment({ turnNum: 10, balances: twoThree, isFinal: true });
-export const app11 = appCommitment({ turnNum: 11, balances: twoThree, isFinal: true });
-
-export const ledger4 = ledgerCommitment({
-  turnNum: 4,
-  balances: twoThree,
-  proposedBalances: fiveToApp,
-});
-export const ledger5 = ledgerCommitment({ turnNum: 5, balances: fiveToApp });
-const ledger6 = ledgerCommitment({ turnNum: 6, balances: fiveToApp, proposedBalances: twoThree });
-export const ledger7 = ledgerCommitment({ turnNum: 7, balances: twoThree });
-const ledger8 = ledgerCommitment({ turnNum: 8, balances: twoThree, isFinal: true });
-const ledger9 = ledgerCommitment({ turnNum: 9, balances: twoThree, isFinal: true });
-
-// -----------
-// States
-// -----------
-
-export const setFundingState = (sharedData: SharedData): SharedData => {
-  return {
-    ...sharedData,
-    fundingState: { [channelId]: { directlyFunded: false, fundingChannel: ledgerId } },
-  };
-};
-const initialStore = setFundingState(
-  setChannels(EMPTY_SHARED_DATA, [
-    channelFromCommitments([app10, app11], asAddress, asPrivateKey),
-    channelFromCommitments([ledger4, ledger5], asAddress, asPrivateKey),
-  ]),
-);
-
-const notDefundableInitialStore = setFundingState(
-  setChannels(EMPTY_SHARED_DATA, [
-    channelFromCommitments([app9, app10], asAddress, asPrivateKey),
-    channelFromCommitments([ledger4, ledger5], asAddress, asPrivateKey),
-  ]),
-);
-
-const playerACommitmentSent = {
-  state: waitForLedgerUpdate(props),
-  store: setFundingState(
-    setChannels(EMPTY_SHARED_DATA, [
-      channelFromCommitments([app10, app11], asAddress, asPrivateKey),
-      channelFromCommitments([ledger5, ledger6], asAddress, asPrivateKey),
-    ]),
-  ),
-};
-
-const playerAWaitForConclude = {
-  state: waitForConclude(props),
-  store: setFundingState(
-    setChannels(EMPTY_SHARED_DATA, [
-      channelFromCommitments([app10, app11], asAddress, asPrivateKey),
-      channelFromCommitments([ledger7, ledger8], asAddress, asPrivateKey),
-    ]),
-  ),
-};
-
-const playerBCommitmentSent = {
-  state: waitForLedgerUpdate(props),
-  store: setFundingState(
-    setChannels(EMPTY_SHARED_DATA, [
-      channelFromCommitments([app10, app11], bsAddress, bsPrivateKey),
-      channelFromCommitments([ledger4, ledger5], bsAddress, bsPrivateKey),
-    ]),
-  ),
-};
-
-const playerBWaitForConclude = {
-  state: waitForConclude(props),
-  store: setFundingState(
-    setChannels(EMPTY_SHARED_DATA, [
-      channelFromCommitments([app10, app11], bsAddress, bsPrivateKey),
-      channelFromCommitments([ledger6, ledger7], bsAddress, bsPrivateKey),
-    ]),
-  ),
-};
-
-// -----------
-// Actions
-// -----------
-export const ledgerUpdate0Received = globalActions.commitmentReceived({
-  processId,
-  signedCommitment: ledger6,
-  protocolLocator,
-});
-const ledgerUpdate1Received = globalActions.commitmentReceived({
-  processId,
-  signedCommitment: ledger7,
-  protocolLocator,
-});
-const conclude0Received = globalActions.commitmentReceived({
-  processId,
-  signedCommitment: ledger8,
-  protocolLocator,
-});
-const conclude1Received = globalActions.commitmentReceived({
-  processId,
-  signedCommitment: ledger9,
-  protocolLocator,
-});
-const invalidLedgerUpdateReceived = globalActions.commitmentReceived({
-  processId,
-  signedCommitment: ledger5,
-  protocolLocator,
-});
 // -----------
 // Scenarios
 // -----------
-export const playerAHappyPath = {
+export const clearedToSendHappyPath = {
   initialParams: {
-    sharedData: initialStore,
+    sharedData: _.merge(
+      ledgerUpdateScenarios.twoPlayerPreSuccessA.sharedData,
+      advanceChannelScenarios.postFund.preSuccess.sharedData,
+    ),
     ...props,
-    relayActions: [
-      defundRequested({
-        channelId,
-      }),
-      globalActions.commitmentReceived({ processId, signedCommitment: ledger6, protocolLocator }),
-    ],
+    clearedToSend: true,
   },
   waitForLedgerUpdate: {
-    state: playerACommitmentSent,
-    action: ledgerUpdate1Received,
-    reply: ledger8,
+    state: waitForLedgerUpdate({
+      ...props,
+      ledgerUpdate,
+      concluding,
+      clearedToSend: true,
+    }),
+    action: ledgerUpdateScenarios.twoPlayerPreSuccessA.action,
+    sharedData: ledgerUpdateScenarios.twoPlayerPreSuccessA.sharedData,
   },
   waitForConclude: {
-    state: playerAWaitForConclude,
-    action: conclude1Received,
-  },
-};
-
-export const playerAInvalidCommitment = {
-  waitForLedgerUpdate: { state: playerACommitmentSent, action: invalidLedgerUpdateReceived },
-};
-export const playerBInvalidCommitment = {
-  waitForLedgerUpdate: { state: playerBCommitmentSent, action: invalidLedgerUpdateReceived },
-};
-
-export const playerBHappyPath = {
-  initialParams: {
-    sharedData: initialStore,
-    ...props,
-  },
-  waitForLedgerUpdate: {
-    state: playerBCommitmentSent,
-    action: ledgerUpdate0Received,
-    reply: ledger7,
-  },
-  waitForConclude: {
-    state: playerBWaitForConclude,
-    action: conclude0Received,
-    reply: ledger9,
-  },
-};
-
-export const notDefundable = {
-  initialParams: {
-    sharedData: notDefundableInitialStore,
-    ...props,
+    state: waitForConclude({ ...props, concluding }),
+    action: advanceChannelScenarios.postFund.preSuccess.trigger,
+    sharedData: advanceChannelScenarios.postFund.preSuccess.sharedData,
   },
 };

--- a/packages/wallet/src/redux/protocols/indirect-defunding/__tests__/scenarios.ts
+++ b/packages/wallet/src/redux/protocols/indirect-defunding/__tests__/scenarios.ts
@@ -42,7 +42,7 @@ export const clearedToSendHappyPath = {
       ...props,
       ledgerUpdate,
       concluding,
-      clearedToSend: true,
+      ClearedToProceed: true,
     }),
     action: ledgerUpdateScenarios.twoPlayerPreSuccessA.action,
     sharedData: ledgerUpdateScenarios.twoPlayerPreSuccessA.sharedData,

--- a/packages/wallet/src/redux/protocols/indirect-defunding/__tests__/stories.tsx
+++ b/packages/wallet/src/redux/protocols/indirect-defunding/__tests__/stories.tsx
@@ -12,7 +12,7 @@ function flattenScenario(scenario) {
 }
 
 addStories(
-  flattenScenario(scenarios.playerAHappyPath),
+  flattenScenario(scenarios.clearedToSendHappyPath),
   'Indirect Defunding / PlayerA / Happy Path',
   IndirectDefunding,
 );

--- a/packages/wallet/src/redux/protocols/indirect-defunding/actions.ts
+++ b/packages/wallet/src/redux/protocols/indirect-defunding/actions.ts
@@ -1,18 +1,45 @@
-import { CommitmentReceived, WalletAction } from '../../actions';
+import { WalletAction } from '../../actions';
+import { ConsensusUpdateAction, isConsensusUpdateAction } from '../consensus-update';
+import { AdvanceChannelAction, isAdvanceChannelAction } from '../advance-channel';
+import {
+  routerFactory,
+  EmbeddedProtocol,
+  BaseProcessAction,
+  ProtocolLocator,
+} from '../../../communication';
+import { ActionConstructor } from '../../utils';
 // -------
 // Actions
 // -------
+export interface ClearedToSend extends BaseProcessAction {
+  type: 'WALLET.INDIRECT_DEFUNDING.CLEARED_TO_SEND';
+  protocolLocator: ProtocolLocator;
+}
 
 // --------
 // Constructors
 // --------
+export const clearedToSend: ActionConstructor<ClearedToSend> = p => {
+  return {
+    ...p,
+    type: 'WALLET.INDIRECT_DEFUNDING.CLEARED_TO_SEND',
+  };
+};
 
 // --------
 // Unions and Guards
 // --------
 
-export type IndirectDefundingAction = CommitmentReceived;
+export type IndirectDefundingAction = ConsensusUpdateAction | AdvanceChannelAction | ClearedToSend;
 
 export function isIndirectDefundingAction(action: WalletAction): action is IndirectDefundingAction {
-  return action.type === 'WALLET.COMMON.COMMITMENT_RECEIVED';
+  return (
+    action.type === 'WALLET.INDIRECT_DEFUNDING.CLEARED_TO_SEND' ||
+    isConsensusUpdateAction(action) ||
+    isAdvanceChannelAction(action)
+  );
 }
+export const routesToIndirectDefunding = routerFactory(
+  isConsensusUpdateAction,
+  EmbeddedProtocol.IndirectDefunding,
+);

--- a/packages/wallet/src/redux/protocols/indirect-defunding/readme.md
+++ b/packages/wallet/src/redux/protocols/indirect-defunding/readme.md
@@ -4,75 +4,34 @@ The purpose of this protocol is handle de-funding a channel that has been indire
 
 The protocol exchanges updates to allocate funds back to the player and conclude commitments to close the channel.
 
+The protocol assumes the application channel is closed and a new ledger consensus does need to be reached.
+
 It covers:
 
-- Checking that a channel is closed (either finalized on chain or a conclusion proof exists)
-- Crafting a ledger update that allocates the funds to the players.
-- Waiting for a ledger response from the opponent.
+- Updating consensus (using ConsensusUpdate sub-protocol) on the ledger channel to reflect the app channel balance.
+- Concluding the ledger channel (using AdvanceChannel sub-protocol)
 - Crafting a conclude commitment to close the ledger channel.
 
 ## State machine
 
-### Player A State machine
-
 ```mermaid
 graph TD
 linkStyle default interpolate basis
-  St((start))-->DF{Defundable?}
-  DF --> |No| F((Failure))
-  DF -->|Yes|SC0[SendLedgerUpdate0]
-  SC0-->WFU(WaitForLedgerUpdate)
-  WFU --> |"CommitmentReceived(Accept)"|SCo0[SendConclude0]
-  WFU --> |"CommitmentReceived(Reject)"| F
-  SCo0 -->WFC(WaitForConclude)
-  WFC --> |"CommitmentReceived(Accept)"|Su((success))
-  WFC --> |"CommitmentReceived(Reject)"| F
+  St((start))-->WFU(WaitForLedgerUpdate)
+  WFU-->|ConsensusUpdateAction|WFU
+  WFU-->|ConsensusUpdateSuccess|WFC(WaitForConclude)
+  WFC-->|AdvanceChannelAction|WFC
+  WFC-->|AdvanceChannelComplete|Su((success))
 
   classDef logic fill:#efdd20;
   classDef Success fill:#58ef21;
   classDef Failure fill:#f45941;
   classDef NotAState stroke:#333,stroke-width:4px,color:#ffff,fill:#aaaaaa;
+  classDef WaitForChildProtocol stroke:#333,stroke-width:4px,color:#ffff,fill:#333;
+
   class St,DF logic;
   class Su Success;
   class F Failure;
-  class SC0,SCo0 NotAState
+  class SC0,SCo0 NotAState;
+  class WFU,WFC WaitForChildProtocol;
 ```
-
-### Player B State machine
-
-```mermaid
-graph TD
-linkStyle default interpolate basis
-  St((start))-->DF{Defundable?}
-  DF --> |No| F((Failure))
-  DF --> |Yes| WFU(WaitForLedgerUpdate)
-  WFU-->|"CommitmentReceived(Accept)"|SC1[SendLedgerUpdate1]
-  WFU --> |"CommitmentReceived(Reject)"| F
-  SC1-->WFC(WaitForConclude)
-  WFC --> |"CommitmentReceived(Accept)"|SCo1[SendConclude1]
-  SCo1-->Su((success))
-  WFC --> |"CommitmentReceived(Reject)"| F
-
-  classDef logic fill:#efdd20;
-  classDef Success fill:#58ef21;
-  classDef Failure fill:#f45941;
-  classDef NotAState stroke:#333,stroke-width:4px,color:#ffff,fill:#aaaaaa;
-  class St,DF logic;
-  class Su Success;
-  class F Failure;
-  class SC1,SCo1 NotAState
-
-```
-
-Notes:
-
-- SendLedgerUpdate is not a state but indicate when the ledger update is sent.
-- A single reducer implements both the player A and B state machine.
-
-## Scenarios
-
-1. **Happy Path - Player A** Start->SendLedgerUpdate->WaitForLedgerUpdate->Success
-2. **Happy Path - Player B** Start->WaitForLedgerUpdate->SendLedgerUpdate->Success
-3. **Not De-fundable** Start->Failure
-4. **Commitment Rejected - Player A** Start->SendLedgerUpdate->WaitForLedgerUpdate->Failure
-5. **Commitment Rejected - Player B** Start->WaitForLedgerUpdate->Failure

--- a/packages/wallet/src/redux/protocols/indirect-defunding/reducer.ts
+++ b/packages/wallet/src/redux/protocols/indirect-defunding/reducer.ts
@@ -1,21 +1,25 @@
-import { ProtocolStateWithSharedData } from '..';
-import { SharedData, signAndStore, queueMessage, checkAndStore } from '../../state';
+import { ProtocolStateWithSharedData, makeLocator } from '..';
+import { SharedData } from '../../state';
 import * as states from './states';
 import { IndirectDefundingAction } from './actions';
 import * as helpers from '../reducer-helpers';
 import { unreachable } from '../../../utils/reducer-utils';
-import * as selectors from '../../selectors';
-import { proposeNewConsensus, acceptConsensus } from '../../../domain/consensus-app';
+import { ProtocolLocator, EmbeddedProtocol } from '../../../communication';
 import {
-  sendCommitmentReceived,
-  multipleRelayableActions,
-  commitmentReceived,
-} from '../../../communication';
-import { theirAddress, getLastCommitment } from '../../channel-store';
-import { composeConcludeCommitment } from '../../../utils/commitment-utils';
-import { CommitmentReceived } from '../../actions';
-import { messageRelayRequested } from 'magmo-wallet-client';
-import { defundRequested } from '../actions';
+  ConsensusUpdateState,
+  initializeConsensusUpdate,
+  consensusUpdateReducer,
+} from '../consensus-update';
+import { routesToAdvanceChannel } from '../advance-channel/actions';
+import { routesToConsensusUpdate } from '../consensus-update/actions';
+import * as consensusUpdateActions from '../consensus-update/actions';
+import * as advanceChannelActions from '../advance-channel/actions';
+import {
+  AdvanceChannelState,
+  initializeAdvanceChannel,
+  advanceChannelReducer,
+} from '../advance-channel';
+import { CommitmentType } from '../../../domain';
 
 export const initialize = ({
   processId,
@@ -24,7 +28,8 @@ export const initialize = ({
   proposedAllocation,
   proposedDestination,
   sharedData,
-  action,
+  clearedToSend,
+  protocolLocator,
 }: {
   processId: string;
   channelId: string;
@@ -32,70 +37,42 @@ export const initialize = ({
   proposedAllocation: string[];
   proposedDestination: string[];
   sharedData: SharedData;
-  action?: CommitmentReceived;
+  clearedToSend: boolean;
+  protocolLocator: ProtocolLocator;
 }): ProtocolStateWithSharedData<states.IndirectDefundingState> => {
-  if (!helpers.channelIsClosed(channelId, sharedData)) {
-    return {
-      protocolState: states.failure({ reason: 'Channel Not Closed' }),
-      sharedData,
-    };
-  }
-  let newSharedData = { ...sharedData };
-  if (helpers.isFirstPlayer(ledgerId, sharedData)) {
-    const ledgerChannel = selectors.getChannelState(sharedData, ledgerId);
-
-    const theirCommitment = getLastCommitment(ledgerChannel);
-    const ourCommitment = proposeNewConsensus(
-      theirCommitment,
-      proposedAllocation,
-      proposedDestination,
-    );
-    const signResult = signAndStore(sharedData, ourCommitment);
-    if (!signResult.isSuccess) {
-      return {
-        protocolState: states.failure({ reason: 'Received Invalid Commitment' }),
-        sharedData,
-      };
-    }
-    newSharedData = signResult.store;
-
-    const actionToRelay = multipleRelayableActions({
-      actions: [
-        // send a request for opponent to start new defunding process first, because they may not yet have done so
-        defundRequested({
-          channelId,
-        }),
-        commitmentReceived({
-          processId,
-          signedCommitment: {
-            commitment: signResult.signedCommitment.commitment,
-            signature: signResult.signedCommitment.signature,
-          },
-          protocolLocator: [],
-        }),
-      ],
-    });
-
-    const messageRelay = messageRelayRequested(theirAddress(ledgerChannel), actionToRelay);
-
-    newSharedData = queueMessage(newSharedData, messageRelay);
-  }
-
-  const protocolState = states.waitForLedgerUpdate({
+  let ledgerUpdate: ConsensusUpdateState;
+  ({ protocolState: ledgerUpdate, sharedData } = initializeConsensusUpdate({
     processId,
-    ledgerId,
-    channelId,
     proposedAllocation,
     proposedDestination,
-  });
+    channelId: ledgerId,
+    clearedToSend,
+    protocolLocator,
+    sharedData,
+  }));
 
-  if (!helpers.isFirstPlayer && action) {
-    // are we second player?
-    return waitForLedgerUpdateReducer(protocolState, sharedData, action);
-  }
+  let concluding: AdvanceChannelState;
+  const ourIndex = helpers.getTwoPlayerIndex(ledgerId, sharedData);
+  ({ protocolState: concluding, sharedData } = initializeAdvanceChannel(sharedData, {
+    ourIndex,
+    commitmentType: CommitmentType.Conclude,
+    channelId: ledgerId,
+    processId,
+    clearedToSend: false, // We only want to clear this to send after the ledger updating is done
+    protocolLocator: makeLocator(protocolLocator, EmbeddedProtocol.AdvanceChannel),
+  }));
+
   return {
-    protocolState,
-    sharedData: newSharedData,
+    protocolState: states.waitForLedgerUpdate({
+      processId,
+      ledgerId,
+      channelId,
+      clearedToSend,
+      ledgerUpdate,
+      concluding,
+      protocolLocator,
+    }),
+    sharedData,
   };
 };
 
@@ -104,6 +81,9 @@ export const indirectDefundingReducer = (
   sharedData: SharedData,
   action: IndirectDefundingAction,
 ): ProtocolStateWithSharedData<states.IndirectDefundingState> => {
+  if (action.type === 'WALLET.INDIRECT_DEFUNDING.CLEARED_TO_SEND') {
+    return handleClearedToSend(protocolState, sharedData);
+  }
   switch (protocolState.type) {
     case 'IndirectDefunding.WaitForLedgerUpdate':
       return waitForLedgerUpdateReducer(protocolState, sharedData, action);
@@ -117,35 +97,59 @@ export const indirectDefundingReducer = (
   }
 };
 
+const handleClearedToSend = (
+  protocolState: states.IndirectDefundingState,
+  sharedData: SharedData,
+): ProtocolStateWithSharedData<states.IndirectDefundingState> => {
+  // We only need to send clear to send to the consensus update reducer
+  // as the advance channel only gets cleared to send after this state
+  if (protocolState.type !== 'IndirectDefunding.WaitForLedgerUpdate') {
+    console.warn(`Received ClearedToSend in state ${protocolState.type}`);
+    return {
+      protocolState,
+      sharedData,
+    };
+  }
+  const { processId, protocolLocator } = protocolState;
+  return handleConsensusUpdateAction(
+    protocolState,
+    sharedData,
+    consensusUpdateActions.clearedToSend({
+      processId,
+      protocolLocator: makeLocator(protocolLocator, EmbeddedProtocol.ConsensusUpdate),
+    }),
+  );
+};
+
 const waitForConcludeReducer = (
   protocolState: states.WaitForConclude,
   sharedData: SharedData,
   action: IndirectDefundingAction,
 ): ProtocolStateWithSharedData<states.IndirectDefundingState> => {
-  if (action.type !== 'WALLET.COMMON.COMMITMENT_RECEIVED') {
-    throw new Error(`Invalid action ${action.type}`);
+  if (!routesToAdvanceChannel(action, protocolState.protocolLocator)) {
+    console.warn(`Received non-AdvanceChannel action in state ${protocolState.type}`);
+    return { protocolState, sharedData };
   }
-
-  let newSharedData = { ...sharedData };
-
-  const checkResult = checkAndStore(newSharedData, action.signedCommitment);
-  if (!checkResult.isSuccess) {
-    return { protocolState: states.failure({ reason: 'Received Invalid Commitment' }), sharedData };
+  let concluding: AdvanceChannelState;
+  ({ protocolState: concluding, sharedData } = advanceChannelReducer(
+    protocolState.concluding,
+    sharedData,
+    action,
+  ));
+  switch (concluding.type) {
+    case 'AdvanceChannel.Failure':
+      return { protocolState: states.failure({ reason: 'AdvanceChannel Failure' }), sharedData };
+    case 'AdvanceChannel.Success':
+      return {
+        protocolState: states.success({}),
+        sharedData,
+      };
+    default:
+      return {
+        protocolState: states.waitForConclude({ ...protocolState, concluding }),
+        sharedData,
+      };
   }
-  newSharedData = checkResult.store;
-
-  if (!helpers.isFirstPlayer(protocolState.ledgerId, sharedData)) {
-    newSharedData = createAndSendConcludeCommitment(
-      newSharedData,
-      protocolState.processId,
-      protocolState.ledgerId,
-    );
-  }
-
-  return {
-    protocolState: states.success({}),
-    sharedData: newSharedData,
-  };
 };
 
 const waitForLedgerUpdateReducer = (
@@ -153,70 +157,49 @@ const waitForLedgerUpdateReducer = (
   sharedData: SharedData,
   action: IndirectDefundingAction,
 ): ProtocolStateWithSharedData<states.IndirectDefundingState> => {
-  if (action.type !== 'WALLET.COMMON.COMMITMENT_RECEIVED') {
-    throw new Error(`Invalid action ${action.type}`);
+  if (!routesToConsensusUpdate(action, protocolState.protocolLocator)) {
+    console.warn(`Received non-ConsensusUpdate action in state ${protocolState.type}`);
+    return { protocolState, sharedData };
   }
-
-  let newSharedData = { ...sharedData };
-
-  const checkResult = checkAndStore(newSharedData, action.signedCommitment);
-  if (!checkResult.isSuccess) {
-    return { protocolState: states.failure({ reason: 'Received Invalid Commitment' }), sharedData };
-  }
-  newSharedData = checkResult.store;
-
-  if (!helpers.isFirstPlayer(protocolState.channelId, sharedData)) {
-    const theirCommitment = action.signedCommitment.commitment;
-    const ourCommitment = acceptConsensus(theirCommitment);
-    const signResult = signAndStore(newSharedData, ourCommitment);
-    if (!signResult.isSuccess) {
-      return {
-        protocolState: states.failure({ reason: 'Received Invalid Commitment' }),
-        sharedData: newSharedData,
-      };
-    }
-    newSharedData = signResult.store;
-    const { ledgerId, processId } = protocolState;
-    const ledgerChannel = selectors.getChannelState(newSharedData, ledgerId);
-
-    const messageRelay = sendCommitmentReceived(
-      theirAddress(ledgerChannel),
-      processId,
-      signResult.signedCommitment.commitment,
-      signResult.signedCommitment.signature,
-    );
-    newSharedData = queueMessage(newSharedData, messageRelay);
-  } else {
-    newSharedData = createAndSendConcludeCommitment(
-      newSharedData,
-      protocolState.processId,
-      protocolState.ledgerId,
-    );
-  }
-  return { protocolState: states.waitForConclude(protocolState), sharedData: newSharedData };
+  return handleConsensusUpdateAction(protocolState, sharedData, action);
 };
 
-// Helpers
-
-const createAndSendConcludeCommitment = (
+function handleConsensusUpdateAction(
+  protocolState: states.WaitForLedgerUpdate,
   sharedData: SharedData,
-  processId: string,
-  channelId: string,
-): SharedData => {
-  const channelState = selectors.getOpenedChannelState(sharedData, channelId);
-
-  const commitment = composeConcludeCommitment(channelState);
-
-  const signResult = signAndStore(sharedData, commitment);
-  if (!signResult.isSuccess) {
-    throw new Error(`Could not sign commitment due to  ${signResult.reason}`);
+  action: consensusUpdateActions.ConsensusUpdateAction,
+) {
+  const { processId, protocolLocator } = protocolState;
+  let ledgerUpdate: ConsensusUpdateState;
+  ({ protocolState: ledgerUpdate, sharedData } = consensusUpdateReducer(
+    protocolState.ledgerUpdate,
+    sharedData,
+    action,
+  ));
+  switch (ledgerUpdate.type) {
+    case 'ConsensusUpdate.Failure':
+      return {
+        protocolState: states.failure({ reason: 'Consensus Update Failure' }),
+        sharedData,
+      };
+    case 'ConsensusUpdate.Success':
+      let concluding: AdvanceChannelState;
+      ({ protocolState: concluding, sharedData } = advanceChannelReducer(
+        protocolState.concluding,
+        sharedData,
+        advanceChannelActions.clearedToSend({
+          processId,
+          protocolLocator: makeLocator(protocolLocator, EmbeddedProtocol.AdvanceChannel),
+        }),
+      ));
+      return {
+        protocolState: states.waitForConclude({ ...protocolState, concluding }),
+        sharedData,
+      };
+    default:
+      return {
+        protocolState: { ...protocolState, ledgerUpdate },
+        sharedData,
+      };
   }
-
-  const messageRelay = sendCommitmentReceived(
-    theirAddress(channelState),
-    processId,
-    signResult.signedCommitment.commitment,
-    signResult.signedCommitment.signature,
-  );
-  return queueMessage(signResult.store, messageRelay);
-};
+}

--- a/packages/wallet/src/redux/protocols/indirect-defunding/reducer.ts
+++ b/packages/wallet/src/redux/protocols/indirect-defunding/reducer.ts
@@ -67,7 +67,7 @@ export const initialize = ({
       processId,
       ledgerId,
       channelId,
-      ClearedToProceed: clearedToProceed,
+      clearedToProceed,
       ledgerUpdate,
       concluding,
       protocolLocator,

--- a/packages/wallet/src/redux/protocols/indirect-defunding/reducer.ts
+++ b/packages/wallet/src/redux/protocols/indirect-defunding/reducer.ts
@@ -28,7 +28,7 @@ export const initialize = ({
   proposedAllocation,
   proposedDestination,
   sharedData,
-  clearedToSend,
+  clearedToProceed,
   protocolLocator,
 }: {
   processId: string;
@@ -37,7 +37,7 @@ export const initialize = ({
   proposedAllocation: string[];
   proposedDestination: string[];
   sharedData: SharedData;
-  clearedToSend: boolean;
+  clearedToProceed: boolean;
   protocolLocator: ProtocolLocator;
 }): ProtocolStateWithSharedData<states.IndirectDefundingState> => {
   let ledgerUpdate: ConsensusUpdateState;
@@ -46,7 +46,7 @@ export const initialize = ({
     proposedAllocation,
     proposedDestination,
     channelId: ledgerId,
-    clearedToSend,
+    clearedToSend: clearedToProceed,
     protocolLocator,
     sharedData,
   }));
@@ -67,7 +67,7 @@ export const initialize = ({
       processId,
       ledgerId,
       channelId,
-      clearedToSend,
+      ClearedToProceed: clearedToProceed,
       ledgerUpdate,
       concluding,
       protocolLocator,

--- a/packages/wallet/src/redux/protocols/indirect-defunding/states.ts
+++ b/packages/wallet/src/redux/protocols/indirect-defunding/states.ts
@@ -1,5 +1,8 @@
 import { StateConstructor } from '../../utils';
 import { ProtocolState } from '..';
+import { ConsensusUpdateState } from '../consensus-update/states';
+import { ProtocolLocator } from '../../../communication';
+import { AdvanceChannelState } from '../advance-channel';
 // -------
 // States
 // -------
@@ -9,6 +12,8 @@ export interface WaitForConclude {
   processId: string;
   ledgerId: string;
   channelId: string;
+  concluding: AdvanceChannelState;
+  protocolLocator: ProtocolLocator;
 }
 
 export interface WaitForLedgerUpdate {
@@ -16,11 +21,12 @@ export interface WaitForLedgerUpdate {
   processId: string;
   ledgerId: string;
   channelId: string;
-  proposedAllocation: string[];
-  proposedDestination: string[];
+  clearedToSend: boolean;
+  ledgerUpdate: ConsensusUpdateState;
+  concluding: AdvanceChannelState;
+  protocolLocator: ProtocolLocator;
 }
 
-export type FailureReason = 'Received Invalid Commitment' | 'Channel Not Closed';
 export interface Failure {
   type: 'IndirectDefunding.Failure';
   reason: string;

--- a/packages/wallet/src/redux/protocols/indirect-defunding/states.ts
+++ b/packages/wallet/src/redux/protocols/indirect-defunding/states.ts
@@ -21,7 +21,7 @@ export interface WaitForLedgerUpdate {
   processId: string;
   ledgerId: string;
   channelId: string;
-  ClearedToProceed: boolean;
+  clearedToProceed: boolean;
   ledgerUpdate: ConsensusUpdateState;
   concluding: AdvanceChannelState;
   protocolLocator: ProtocolLocator;

--- a/packages/wallet/src/redux/protocols/indirect-defunding/states.ts
+++ b/packages/wallet/src/redux/protocols/indirect-defunding/states.ts
@@ -21,7 +21,7 @@ export interface WaitForLedgerUpdate {
   processId: string;
   ledgerId: string;
   channelId: string;
-  clearedToSend: boolean;
+  ClearedToProceed: boolean;
   ledgerUpdate: ConsensusUpdateState;
   concluding: AdvanceChannelState;
   protocolLocator: ProtocolLocator;


### PR DESCRIPTION
This PR does two things:
- Refactors the Indirect De-funding to use AdvanceChannel/ConsensusUpdate to handle sending/receiving commitments
- Add a `ClearedToSend` to allow indirectDefunding to be started early.

This was needed for work on #658 